### PR TITLE
Add multi-arch support

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -26,6 +26,25 @@ steps:
     event:
     - push
 
+- name: make-manifests
+  image: rancher/dapper:v0.5.2
+  volumes:
+  - name: docker
+    path: /var/run/docker.sock
+  environment:
+    PASSWORD:
+      from_secret: docker_password
+    USERNAME:
+      from_secret: docker_username
+  commands:
+  - dapper sleep 1 && ./make-manifest.sh manifest-images-list rancher
+  privileged: true
+  settings:
+    custom_dns: 1.1.1.1
+  when:
+    event:
+    - push
+
 volumes:
 - name: docker
   host:

--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,0 +1,16 @@
+FROM docker:19.03.8-dind
+
+RUN apk add --no-cache bash jq tar curl git
+
+RUN curl -L -o /bin/manifest-tool https://github.com/estesp/manifest-tool/releases/download/v1.0.2/manifest-tool-linux-amd64
+RUN chmod a+x /bin/manifest-tool
+
+ENV DOCKER_CLI_EXPERMENTAL enabled
+
+ENV DAPPER_RUN_ARGS --privileged
+ENV DAPPER_SOURCE /go/src/github.com/rancher/image-mirror
+ENV DAPPER_ENV USERNAME PASSWORD DOCKER_CLI_EXPERMENTAL
+
+WORKDIR ${DAPPER_SOURCE}
+
+CMD ["--experimental"]

--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@ There are 2 types of images that are mirrored.
 
 * Single Arch Images - This list is maintained in the `images-list` file. The file is structured as `Name of Original Image`, `Name of Rancher Image`, `Image Tag`. 
 
-* Multi-Arch Images - Coming Soon!
+* Multi-Arch Images - To clone multi arch images, add the image to manifest-images-list file.
+  	     	      Repo path:version-tag comma separated list of architectures
+  
 
 ## New Images
 

--- a/make-manifest.sh
+++ b/make-manifest.sh
@@ -1,0 +1,271 @@
+#!/bin/bash
+
+# Usage: ./make-manifest.sh manifest-images-list destination-repo
+# manifest-images-list file should be of the format
+# source-repo:version comma-sep-os/arch
+
+set -e
+
+PARALLEL=${PARALLEL:-'false'}
+
+info() {
+  echo "$@" >&2
+}
+
+if [ "$#" -ne 2 ]; then
+    info "... Need two arguments: image-mirror file and destination repo: $# $@"
+    exit 1
+fi
+
+mirror_file=$1
+dest_repo=$2
+
+if ! command -v manifest-tool &>/dev/null; then
+    info "Script requires github.com/estesp/manifest-tool for inspecting from gcr."
+    exit 1
+fi
+
+lock() {
+  local waiting=0
+  while ! (set -o noclobber; >$1 ) 2>/dev/null; do
+    [ ${waiting} = 0 ] && info "... Waiting for lock $1"; waiting=1
+    sleep 1
+  done
+  info "... Obtained lock $1"
+}
+global_lock="${HOME}/.docker/mirror.lock"
+#lock "${global_lock}"
+
+workspace=$(mktemp -d)
+cp ${mirror_file} ${workspace} 
+cd "${workspace}"
+
+cleanup() {
+  local code=$?
+  set +e
+  trap - INT TERM EXIT
+  info "... Cleanup code ${code}"
+  rm -rf "${workspace}" "${global_lock}"
+  [ $code -ne 0 ] && kill 0
+  exit ${code}
+}
+trap cleanup INT TERM EXIT
+
+cleanup-mirror() {
+  local code=$?
+  local mirror=$1
+  local mirror_lock=$2
+  set +e
+  [ $code -ne 0 ] && info "!!! Failed mirror ${mirror}"
+  rm -f "${mirror_lock}"
+  exit ${code}
+}
+
+tr_repo() {
+  (tr '/' '-' | tr ':' '-') <<<$1
+}
+
+check_if_img_with_tag_already_exists() {
+    docker manifest inspect $1 > /dev/null 2>&1 ; echo $?
+}
+
+image_host_from_src() {
+    arr=($(tr '/' ' '<<<$1))
+    if [ "${#arr[@]}" -ge 3 ]; then
+	echo "${arr[0]}"
+    fi
+}
+
+image_from_src() {
+    (rev | cut -d / -f1,2 | rev) <<<$1
+}
+
+create-mirror() {
+  local image_host=$(image_host_from_src $1)
+  local image=$(image_from_src $1)
+  local repo=${image%:*}
+  local version=${image#$repo:}
+  local mirror="${ORG}/$(tr_repo ${repo}):${version}"
+  local mirror_repo="${ORG}/$(tr_repo ${repo})"
+  local mirror_lock="${workspace}/$(tr_repo ${mirror_repo}).lock"
+  local manifest_amend
+
+  # For each image/os/arch tuple, process the image, add necessary metadata
+  # push the image to the destination and add it to the manifest.
+  # Finally push the manifest to the destination
+  process-manifest() {
+    while read -r arch_img os arch variant; do
+      local tag="${mirror_repo}:${version}-${arch}"
+      local annotate_args="--os ${os} --arch ${arch}"
+      local platform="${os}/${arch}"
+      if [ -n "${variant}" ]; then
+        tag+="-${variant}"
+        annotate_args+=" --variant ${variant}"
+        platform+="/${variant}"
+      fi
+
+      local img_name=""
+      if [ -n "${image_host}" ]; then
+	  img_name="${image_host}/"
+      fi
+      img_name+="${arch_img}"
+
+      # Pull the image from the source if it is not already present in the destination repo
+      # Otherwise get it from destination repo for addition to the manifest 
+      tag-arch-img() {
+	if [ $(check_if_img_with_tag_already_exists ${tag}) -ne 0 ]; then
+	    info "... Pulling image from source repo: ${img_name}"
+            docker pull -q ${img_name} >/dev/null
+	    info "... Tagging original source repo image: ${tag}"
+            docker tag ${img_name} ${tag} >/dev/null
+	else
+	    info "... Pulling preexisting image from destination repo with tags: ${tag}"
+	    docker pull -q ${tag} >/dev/null
+	fi
+      }
+
+      # If platform specific info is missing from the image, then manipulate JSON to add it
+      set-image-platform() {
+        info "... Set platform ${platform} for image ${tag}"
+        mkdir -p ${tag}
+        docker image save ${tag} -o ${tag}.tar >/dev/null
+        for f in $(tar --list -f ${tag}.tar | grep -e '[./]json$'); do
+          tar -C ${tag} -xf ${tag}.tar ${f}
+          if jq '
+              if has("os") then .os = "'${os}'" else . end |
+              if has("architecture") then .architecture = "'${arch}'" else . end |
+              if has("variant") then .variant = "'${variant}'" else . end
+            ' <${tag}/${f} >${tag}/${f}.tmp 2>/dev/null; then
+            mv -f ${tag}/${f}.tmp ${tag}/${f}
+            tar -C ${tag} -uf ${tag}.tar ${f}
+          fi
+        done
+        docker image load -q -i ${tag}.tar >/dev/null
+        rm -rf ${tag}*
+      }
+
+      # If image is not present in the mirror, add it to the mirror
+      # Create or amend existing manifest with the new image and add image specific tags to the manifest file
+      annotate-manifest() {
+	if [ $(check_if_img_with_tag_already_exists ${tag}) -ne 0 ]; then
+	    info "... Pushing new image to destination repo with tags: ${tag}"      
+	    docker push ${tag} >/dev/null	
+	fi
+        local digest=$(docker image inspect ${tag} | jq -r '.[] | .RepoDigests[0]')
+	info "... Creating manifest: amend-option:${manifest_amend} manifest-name:${mirror} image:${digest}"
+        docker manifest create ${manifest_amend} ${mirror} ${digest} >/dev/null
+        docker manifest annotate ${mirror} ${digest} ${annotate_args} >/dev/null
+        docker image rm -f ${tag} >/dev/null
+        manifest_amend='--amend'
+      }
+
+      {
+        tag-arch-img
+        set-image-platform
+        annotate-manifest
+      }
+
+    done < <(manifest-list ${image})
+    info "--- Push mirror ${mirror}"
+    docker manifest push ${mirror} >/dev/null
+  }
+
+  lock "${mirror_lock}"
+  (
+    trap 'cleanup-mirror ${mirror} ${mirror_lock}' EXIT
+    info "+++ Create mirror ${mirror}"
+    process-manifest    
+  )
+}
+
+manifest-inspect() {
+  # docker manifest inspect $1 | \
+  #     jq -r '.manifests[] | "'$1'@\(.digest) \(.platform.os) \(.platform.architecture) \(.platform.variant // "")"'
+  manifest-tool inspect --raw $1 2>/dev/null | \
+      jq -r '.[] | 
+        select((.Platform.architecture // "") != "") |
+        "'$1'@\(.Digest) \(.Platform.os) \(.Platform.architecture) \(.Platform.variant // "")"
+      '
+}
+
+manifest-template() {
+  local image=$(image_from_src $1)
+  local repo=${image%:*}
+  local version=${image#$repo:}
+  info "??? Generating manifest template for ${image}"
+  for platform in $(tr ',' ' ' <<<${PLATFORMS}); do
+    read -r os arch variant <<<$(tr '/' ' ' <<<${platform})
+    local img=$(sed -e "
+      s|REPO|${repo}|g;
+      s|VERSION|${version}|g;
+      s|OS|${os}|g;
+      s|ARCH|${arch}|g;
+      s|VARIANT|${variant}|g;
+    " <<<${TEMPLATE})
+    echo "${img} ${os} ${arch} ${variant}"
+  done
+}
+
+manifest-list() {
+  manifest=$(manifest-inspect $1)
+  manifest=${manifest:-$(manifest-template $1)}
+  echo "${manifest}"
+}
+
+create-mirrors() {
+  info "+++ Create mirrors"
+  local pids=()
+  local code=0
+  wait-pid() {
+    wait $1 || code=$((code+1))
+  }
+
+  for mirror in $@; do
+    [ -z "${mirror}" ] &&  continue
+    create-mirror ${mirror} &
+    local pid=$!
+    if [[ "${PARALLEL}" = 'true' ]]; then
+      pids+=(${pid})
+    else
+      wait-pid ${pid}
+    fi
+  done
+  for pid in ${pids[@]}; do
+    wait-pid ${pid}
+  done
+
+  info "--- Done create mirrors"
+  if [ $code -ne 0 ]; then
+    info "!!! Failed $code mirrors"
+  fi
+  return ${code}
+}
+
+clear-cache() {
+  info "... Clear cache"
+  rm -rf "${HOME}/.docker/manifests/"
+  docker image prune -a -f >/dev/null
+}
+
+parse_file() {
+  ORG=$dest_repo
+  while IFS= read -r line;
+  do
+      params=( $line )
+      repo_image_version=${params[0]}
+      PLATFORMS=${params[1]}
+      TEMPLATE='REPO-ARCH:VERSION'
+      if [ "${#PLATFORMS[@]}" -eq 1 ]; then
+	  TEMPLATE='REPO:VERSION'
+      fi
+
+      info "... Creating mirror for ${repo_image_version} at ${dest_repo} for platforms: ${PLATFORMS}"
+      create-mirrors ${repo_image_version}
+  done < $mirror_file
+}
+
+
+{
+  clear-cache
+  parse_file $@
+}

--- a/manifest-images-list
+++ b/manifest-images-list
@@ -1,0 +1,2 @@
+coredns/coredns:1.6.9 linux/ppc64le,linux/amd64,linux/s390x,linux/arm,linux/arm64
+quay.io/coreos/flannel:v0.12.0 linux/amd64,linux/arm64


### PR DESCRIPTION
Add script to generate multi-arch images automatically. The following script generate these images for os=linux when triggered from command line. Subsequent diffs will contain a Dockerfile and drone modifications so that manual execution is not needed. Then the last diff would take care of adding windows images to the manifest.

Format of the manifest-list:
source-repo:version comma-sep-os/arch

Example:

> coredns/coredns:1.6.9 linux/ppc64le,linux/amd64,linux/s390x,linux/arm,linux/arm64
> quay.io/coreos/flannel:v0.10.0 linux/amd64,linux/arm64

Invoke by passing manifest-image-mirror and destination org repo:

> yogesh@Yogeshs-MacBook-Pro:~/go/src/rancher/image-mirror$ time ./make-manifest.sh manifest-images-list yogeshmundadarancher
> ... Obtained lock /Users/yogesh/.docker/mirror.lock
> ... Clear cache
> ... Creating mirror for coredns/coredns:1.6.9 at yogeshmundadarancher for platforms: linux/ppc64le,linux/amd64,linux/s390x,linux/arm,linux/arm64
> +++ Create mirrors
> ... Obtained lock /var/folders/my/q57fwzdj75bdjn38t4b_w1mw0000gn/T/tmp.f2tTrTHx/yogeshmundadarancher-coredns-coredns.lock
> +++ Create mirror yogeshmundadarancher/coredns-coredns:1.6.9
> ... Pulling preexisting image from destination repo with tags: yogeshmundadarancher/coredns-coredns:1.6.9-amd64
> ... Set platform linux/amd64 for image yogeshmundadarancher/coredns-coredns:1.6.9-amd64
> ... Creating manifest: amend-option: manifest-name:yogeshmundadarancher/coredns-coredns:1.6.9 image:yogeshmundadarancher/coredns-coredns@sha256:6dbdd57f6b7b991d75a677f8b011106a065e3b309217611ed58e68ce4b0e792a
> ... Pulling preexisting image from destination repo with tags: yogeshmundadarancher/coredns-coredns:1.6.9-arm
> ... Set platform linux/arm for image yogeshmundadarancher/coredns-coredns:1.6.9-arm
> ... Creating manifest: amend-option:--amend manifest-name:yogeshmundadarancher/coredns-coredns:1.6.9 image:yogeshmundadarancher/coredns-coredns@sha256:901fc4f66f3cbf76cd45fe86a44c79870ca353feb2a0297fcb91e26ab7d65434
> ... Pulling preexisting image from destination repo with tags: yogeshmundadarancher/coredns-coredns:1.6.9-arm64
> ... Set platform linux/arm64 for image yogeshmundadarancher/coredns-coredns:1.6.9-arm64
> ... Creating manifest: amend-option:--amend manifest-name:yogeshmundadarancher/coredns-coredns:1.6.9 image:yogeshmundadarancher/coredns-coredns@sha256:9c1c0922d4be8e28810553d23b63effc0d5417b4bc51fe147d2994ffeabe30eb
> ... Pulling preexisting image from destination repo with tags: yogeshmundadarancher/coredns-coredns:1.6.9-ppc64le
> ... Set platform linux/ppc64le for image yogeshmundadarancher/coredns-coredns:1.6.9-ppc64le
> ... Creating manifest: amend-option:--amend manifest-name:yogeshmundadarancher/coredns-coredns:1.6.9 image:yogeshmundadarancher/coredns-coredns@sha256:4376e3fc2c06e7dd24f17f5a077911a7ff82c0819788ed0cf0d6c492d60154e9
> ... Pulling preexisting image from destination repo with tags: yogeshmundadarancher/coredns-coredns:1.6.9-s390x
> ... Set platform linux/s390x for image yogeshmundadarancher/coredns-coredns:1.6.9-s390x
> ... Creating manifest: amend-option:--amend manifest-name:yogeshmundadarancher/coredns-coredns:1.6.9 image:yogeshmundadarancher/coredns-coredns@sha256:80f7a7cdf07c030169ee82f7cb3ca7dc02ddcfad28562e5fdb3b525da6455556
> --- Push mirror yogeshmundadarancher/coredns-coredns:1.6.9
> --- Done create mirrors
> ... Creating mirror for quay.io/coreos/flannel:v0.10.0 at yogeshmundadarancher for platforms: linux/amd64,linux/arm64
> +++ Create mirrors
> ... Obtained lock /var/folders/my/q57fwzdj75bdjn38t4b_w1mw0000gn/T/tmp.f2tTrTHx/yogeshmundadarancher-coreos-flannel.lock
> +++ Create mirror yogeshmundadarancher/coreos-flannel:v0.10.0
> ??? Generating manifest template for coreos/flannel:v0.10.0
> ... Pulling preexisting image from destination repo with tags: yogeshmundadarancher/coreos-flannel:v0.10.0-amd64
> ... Set platform linux/amd64 for image yogeshmundadarancher/coreos-flannel:v0.10.0-amd64
> ... Creating manifest: amend-option: manifest-name:yogeshmundadarancher/coreos-flannel:v0.10.0 image:yogeshmundadarancher/coreos-flannel@sha256:a0e5c4d10347578eee70d57e0a5ffc31e3b85cc9620781ed3ee4319d8ecd477d
> ... Pulling preexisting image from destination repo with tags: yogeshmundadarancher/coreos-flannel:v0.10.0-arm64
> ... Set platform linux/arm64 for image yogeshmundadarancher/coreos-flannel:v0.10.0-arm64
> ... Creating manifest: amend-option:--amend manifest-name:yogeshmundadarancher/coreos-flannel:v0.10.0 image:yogeshmundadarancher/coreos-flannel@sha256:2504c20bc002f6c94b220675e2a5efab0e2d851e79f9f639142dd26d3ffa11da
> --- Push mirror yogeshmundadarancher/coreos-flannel:v0.10.0
> --- Done create mirrors
> ... Cleanup code 0
> 
> real	1m11.290s
> user	0m6.283s
> sys	0m3.820s
> yogesh@Yogeshs-MacBook-Pro:~/go/src/rancher/image-mirror$

Coredns and flannel manifest images are uploaded to private docker hub repo:

<img width="1295" alt="Screen Shot 2020-06-24 at 12 25 23 PM" src="https://user-images.githubusercontent.com/2420413/85618641-ea518180-b615-11ea-8116-08f8a7c6a2ab.png">
<img width="1311" alt="Screen Shot 2020-06-24 at 12 25 41 PM" src="https://user-images.githubusercontent.com/2420413/85618649-ee7d9f00-b615-11ea-97a6-bac4fb6332e3.png">
