### PR TITLE
Update logging images to match 3.7.0 upstream

### DIFF
--- a/images-list
+++ b/images-list
@@ -4,13 +4,17 @@
 #
 # LIST FORMAT: <SOURCE> <DESTINATION> <TAG>
 banzaicloud/fluentd rancher/banzaicloud-fluentd v1.11.2-alpine-2
+banzaicloud/fluentd rancher/banzaicloud-fluentd v1.11.4-alpine-1
 banzaicloud/logging-operator rancher/banzaicloud-logging-operator 3.6.0
+banzaicloud/logging-operator rancher/banzaicloud-logging-operator 3.7.0
 bats/bats rancher/bats-bats v1.1.0
 coredns/coredns rancher/coredns-coredns 1.7.0
 curlimages/curl rancher/curlimages-curl 7.70.0
 directxman12/k8s-prometheus-adapter-amd64 rancher/directxman12-k8s-prometheus-adapter-amd64 v0.6.0
-fluent/fluent-bit rancher/fluent-fluent-bit 1.5.4-debug
 fluent/fluent-bit rancher/fluent-fluent-bit 1.5.4
+fluent/fluent-bit rancher/fluent-fluent-bit 1.5.4-debug
+fluent/fluent-bit rancher/fluent-fluent-bit 1.6.1
+fluent/fluent-bit rancher/fluent-fluent-bit 1.6.1-debug
 grafana/grafana rancher/grafana-grafana 7.1.5
 istio/coredns-plugin rancher/istio-coredns-plugin 0.2-istio-1.1
 istio/install-cni rancher/istio-install-cni 1.7.0


### PR DESCRIPTION
Update logging images to match Banzai Logging Operator 3.7.0 helm chart
images. This includes four images: logging-operator, fluentd, fluentbit,
and fluentbit-debug.

#### Pull Request Checklist ####

- [x] Change does not remove any existing Images or Tags
- [x] New entries are in format `SOURCE DESTINATION TAG`
- [x] New entries are added to the correct section of the list (sorted lexographically) 
- [x] Changes to scripting or CI config have been tested to the best of your ability

#### Types of Change ####
<!-- New image, version bump. script update, etc etc -->
version bump

#### Linked Issues ####
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request.  -->
Issue: [#29642](https://github.com/rancher/rancher/issues/29642)

#### Additional Notes ####
<!-- Any additional details / test results / etc -->
n/a