### PR TITLE
Fix repos for Monitoring V1 upgrade to v0.39.0

### DIFF
--- a/images-list
+++ b/images-list
@@ -57,8 +57,8 @@ prom/prometheus rancher/prom-prometheus v2.18.2
 quay.io/kiali/kiali rancher/kiali-kiali v1.22.1
 quay.io/kiali/kiali rancher/kiali-kiali v1.23.0
 quay.io/kiali/kiali rancher/kiali-kiali v1.24.0
-quay.io/prometheus-operator/prometheus-config-reloader rancher/coreos-prometheus-config-reloader v0.39.0
-quay.io/prometheus-operator/prometheus-operator rancher/coreos-prometheus-operator v0.39.0
+quay.io/coreos/prometheus-config-reloader rancher/coreos-prometheus-config-reloader v0.39.0
+quay.io/coreos/prometheus-operator rancher/coreos-prometheus-operator v0.39.0
 quay.io/prometheus-operator/prometheus-config-reloader rancher/coreos-prometheus-config-reloader v0.43.0
 quay.io/prometheus-operator/prometheus-operator rancher/coreos-prometheus-operator v0.43.0
 quay.io/prometheus/prometheus rancher/prom-prometheus v2.22.0


### PR DESCRIPTION
Both repositories `quay.io/prometheus-operator/prometheus-config-reloader` and `quay.io/prometheus-operator/prometheus-operator` do not have a tag for `v0.39.0` since Prometheus Operator never migrated to using `quay.io/prometheus-operator/*` until release `v0.38.3` based on the [release notes](https://github.com/prometheus-operator/prometheus-operator/releases/tag/v0.38.3). `v0.38.3` was released after `v0.39.0`.

We should be pulling images from the old repository at `quay.io/coreos/*` instead, which has both image tags:
- [`quay.io/coreos/prometheus-config-reloader:v0.39.0`](https://quay.io/repository/coreos/prometheus-config-reloader?tag=v0.39.0&tab=tags)
- [`quay.io/coreos/prometheus-operator:v0.39.0`](https://quay.io/repository/coreos/prometheus-operator?tag=v0.39.0&tab=tags)

#### Pull Request Checklist ####

- [x] Change does not remove any existing Images or Tags
  - Note: image was never pushed in the first place due to the [failed Drone build](https://drone-publish.rancher.io/rancher/image-mirror/50/1/2)
- [x] New entries are in format `SOURCE DESTINATION TAG`
- [x] New entries are added to the correct section of the list (sorted lexographically) 
- [x] Changes to scripting or CI config have been tested to the best of your ability

#### Types of Change ####

<!-- New image, version bump. script update, etc etc -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request.  -->

Original PR whose images failed to be pushed: https://github.com/rancher/image-mirror/pull/48

Related Issue: https://github.com/rancher/rancher/issues/30067

#### Additional Notes ####

<!-- Any additional details / test results / etc -->