### PR TITLE
Update logging images to match 3.7.3 upstream

### DIFF
--- a/images-list
+++ b/images-list
@@ -7,6 +7,7 @@ banzaicloud/fluentd rancher/banzaicloud-fluentd v1.11.2-alpine-2
 banzaicloud/fluentd rancher/banzaicloud-fluentd v1.11.4-alpine-1
 banzaicloud/logging-operator rancher/banzaicloud-logging-operator 3.6.0
 banzaicloud/logging-operator rancher/banzaicloud-logging-operator 3.7.0
+banzaicloud/logging-operator rancher/banzaicloud-logging-operator 3.7.3
 bats/bats rancher/bats-bats v1.1.0
 coredns/coredns rancher/coredns-coredns 1.7.0
 curlimages/curl rancher/curlimages-curl 7.70.0


### PR DESCRIPTION
Update logging images to match 3.7.3 upstream. Fluentd and fluentbit
are the same versions as 3.7.0.

#### Pull Request Checklist ####

- [x] Change does not remove any existing Images or Tags
- [x] New entries are in format `SOURCE DESTINATION TAG`
- [x] New entries are added to the correct section of the list (sorted lexographically) 
- [x] Changes to scripting or CI config have been tested to the best of your ability

#### Types of Change ####

version bump

#### Linked Issues ####

Relevant issue: https://github.com/rancher/rancher/issues/29642

#### Additional Notes ####

n/a
