### PR TITLE
Mirror new version directxman12/k8s-prometheus-adapter-amd64:v0.7.0

### DIFF
--- a/images-list
+++ b/images-list
@@ -13,6 +13,7 @@ coredns/coredns rancher/coredns-coredns 1.7.0
 curlimages/curl rancher/curlimages-curl 7.70.0
 curlimages/curl rancher/curlimages-curl 7.73.0
 directxman12/k8s-prometheus-adapter-amd64 rancher/directxman12-k8s-prometheus-adapter-amd64 v0.6.0
+directxman12/k8s-prometheus-adapter-amd64 rancher/directxman12-k8s-prometheus-adapter-amd64 v0.7.0
 fluent/fluent-bit rancher/fluent-fluent-bit 1.5.4
 fluent/fluent-bit rancher/fluent-fluent-bit 1.5.4-debug
 fluent/fluent-bit rancher/fluent-fluent-bit 1.6.1


### PR DESCRIPTION
Mirror new version directxman12/k8s-prometheus-adapter-amd64:v0.7.0

#### Pull Request Checklist ####

- [x] Change does not remove any existing Images or Tags
- [x] New entries are in format `SOURCE DESTINATION TAG`
- [x] New entries are added to the correct section of the list (sorted lexographically) 
- [x] Changes to scripting or CI config have been tested to the best of your ability

#### Types of Change ####
Version bump

#### Linked Issues ####

https://github.com/rancher/charts/pull/844