### PR TITLE
Adds section to PR template to link dockerhub repos

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,7 @@
 #### Pull Request Checklist ####
 
 - [ ] Change does not remove any existing Images or Tags
+- [ ] Added links to changed repo's in section below
 - [ ] New entries are in format `SOURCE DESTINATION TAG`
 - [ ] New entries are added to the correct section of the list (sorted lexographically) 
 - [ ] Changes to scripting or CI config have been tested to the best of your ability
@@ -12,6 +13,11 @@
 #### Linked Issues ####
 
 <!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request.  -->
+
+#### Links of all changed repositories ####
+
+* https://hub.docker.com/r/rancher/THE_REPO/tags
+* ...
 
 #### Additional Notes ####
 


### PR DESCRIPTION
We should always be checking that the existing image does not exist first or we could overwrite it.
I do a lot of PR reviews on my phone, and without links that is very hard. This way the dev will do by hand first anyway.
