### PR TITLE
Add logging operator 3.8.2 image

### DIFF
--- a/images-list
+++ b/images-list
@@ -10,6 +10,7 @@ banzaicloud/logging-operator rancher/banzaicloud-logging-operator 3.6.0
 banzaicloud/logging-operator rancher/banzaicloud-logging-operator 3.7.0
 banzaicloud/logging-operator rancher/banzaicloud-logging-operator 3.7.3
 banzaicloud/logging-operator rancher/banzaicloud-logging-operator 3.8.0
+banzaicloud/logging-operator rancher/banzaicloud-logging-operator 3.8.2
 bats/bats rancher/bats-bats v1.1.0
 coredns/coredns rancher/coredns-coredns 1.7.0
 coredns/coredns rancher/coredns-coredns 1.7.1


### PR DESCRIPTION
#### Pull Request Checklist ####

- [x] Change does not remove any existing Images or Tags
- [x] New entries are in format `SOURCE DESTINATION TAG`
- [x] New entries are added to the correct section of the list (sorted lexographically) 
- [x] Changes to scripting or CI config have been tested to the best of your ability

#### Types of Change ####

<!-- New image, version bump. script update, etc etc -->

Version bump

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request.  -->

Relevant issue: https://github.com/rancher/rancher/issues/29892

#### Additional Notes ####

```bash
[nickgerace at rancherbook in ~/Developer/rancher-charts] (130) (dev-v2.5-source-logging-382)
% docker pull banzaicloud/logging-operator:3.8.2 
3.8.2: Pulling from banzaicloud/logging-operator
# digest info
Status: Image is up to date for banzaicloud/logging-operator:3.8.2
docker.io/banzaicloud/logging-operator:3.8.2
```