### PR TITLE
Add rancher dockerhub and not changing mirrored images check to list

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,8 +1,10 @@
 #### Pull Request Checklist ####
 
-- [ ] Change does not remove any existing Images or Tags
+- [ ] Change does not remove any existing Images or Tags in index-list.txt
+- [ ] Change does not remove / overwrite exiting Images or Tags in Rancher DockerHub
 - [ ] New entries are in format `SOURCE DESTINATION TAG`
-- [ ] New entries are added to the correct section of the list (sorted lexographically) 
+- [ ] New entries are added to the correct section of the list (sorted lexographically)
+- [ ] New entries have a repo created in Rancher Dockerhub (where the image will be mirrored to)
 - [ ] Changes to scripting or CI config have been tested to the best of your ability
 
 #### Types of Change ####


### PR DESCRIPTION
#### Pull Request Checklist ####

- [ ] Change does not remove any existing Images or Tags
- [ ] New entries are in format `SOURCE DESTINATION TAG`
- [ ] New entries are added to the correct section of the list (sorted lexographically) 
- [ ] Changes to scripting or CI config have been tested to the best of your ability

#### Types of Change ####

PR Template Update

#### Additional Notes ####

Additional manual checks need to be added to attempt a manual intervention for missing Rancher Dockerhub repos on new entires and overwriting existing Rancher Dockerhub images. 
