### PR TITLE
Bump kiali version

### DIFF
--- a/images-list
+++ b/images-list
@@ -98,6 +98,7 @@ quay.io/kiali/kiali rancher/kiali-kiali v1.22.1
 quay.io/kiali/kiali rancher/kiali-kiali v1.23.0
 quay.io/kiali/kiali rancher/kiali-kiali v1.24.0
 quay.io/kiali/kiali rancher/kiali-kiali v1.28.0
+quay.io/kiali/kiali rancher/kiali-kiali v1.29.0
 quay.io/prometheus-operator/prometheus-config-reloader rancher/coreos-prometheus-config-reloader v0.43.0
 quay.io/prometheus-operator/prometheus-operator rancher/coreos-prometheus-operator v0.43.0
 quay.io/prometheus/prometheus rancher/prom-prometheus v2.19.2


### PR DESCRIPTION
#### Pull Request Checklist ####

- [x] Change does not remove any existing Images or Tags in index-list.txt
- [x] Change does not remove / overwrite exiting Images or Tags in Rancher DockerHub
- [x] New entries are in format `SOURCE DESTINATION TAG`
- [x] New entries are added to the correct section of the list (sorted lexographically)
- [x] New entries have a repo created in Rancher Dockerhub (where the image will be mirrored to)
- [ ] Changes to scripting or CI config have been tested to the best of your ability

#### Types of Change ####

Verison Bump

Kiali version from v1.28.0 to v1.29.0

#### Linked Issues ####
https://github.com/rancher/rancher/issues/30470

#### Additional Notes ####

Kiali v1.28.0 was already mirrored, but will not be used in upcoming releases. 
