### PR TITLE
Add correct image for Prometheus Adapter

### DIFF
--- a/images-list
+++ b/images-list
@@ -36,6 +36,7 @@ directxman12/k8s-prometheus-adapter-amd64 rancher/directxman12-k8s-prometheus-ad
 directxman12/k8s-prometheus-adapter-amd64 rancher/directxman12-k8s-prometheus-adapter-amd64 v0.7.0
 directxman12/k8s-prometheus-adapter-amd64 rancher/mirrored-directxman12-k8s-prometheus-adapter-amd64 v0.7.0
 directxman12/k8s-prometheus-adapter-amd64 rancher/mirrored-directxman12-k8s-prometheus-adapter-amd64 v0.8.3
+directxman12/k8s-prometheus-adapter rancher/mirrored-directxman12-k8s-prometheus-adapter v0.8.3
 fluent/fluent-bit rancher/fluent-fluent-bit 1.5.4
 fluent/fluent-bit rancher/fluent-fluent-bit 1.5.4-debug
 fluent/fluent-bit rancher/fluent-fluent-bit 1.6.1


### PR DESCRIPTION
#### Pull Request Checklist ####

- [x] Change does not remove any existing Images or Tags in index-list.txt
- [x] Change does not remove / overwrite exiting Images or Tags in Rancher DockerHub
- [x] New entries are in format `SOURCE DESTINATION TAG`
- [x] New entries are added to the correct section of the list (sorted lexographically)
- [ ] New entries have a repo created in Rancher Dockerhub (where the image will be mirrored to)
- [x] Changes to scripting or CI config have been tested to the best of your ability

#### Types of Change ####

<!-- New image, version bump. script update, etc etc -->

Adding a new repository to support prometheus adapter ARM. Need to create repository first.

#### Linked Issues ####

Related Issue: https://github.com/rancher/rancher/issues/29871

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request.  -->

#### Additional Notes ####

<!-- Any additional details / test results / etc -->