### PR TITLE
correct source repo for autoscaler and pause

### DIFF
--- a/images-list
+++ b/images-list
@@ -71,7 +71,6 @@ gcr.io/google_containers/k8s-dns-sidecar rancher/mirrored-k8s-dns-sidecar 1.15.1
 gcr.io/google_containers/k8s-dns-sidecar rancher/mirrored-k8s-dns-sidecar 1.17.3
 gcr.io/google_containers/pause rancher/mirrored-pause 3.1
 gcr.io/google_containers/pause rancher/mirrored-pause 3.2
-gcr.io/google_containers/pause rancher/mirrored-pause 3.4.1
 gcr.io/kubebuilder/kube-rbac-proxy rancher/kube-rbac-proxy v0.5.0
 gcr.io/kubebuilder/kube-rbac-proxy rancher/mirrored-kube-rbac-proxy v0.5.0
 grafana/grafana rancher/grafana-grafana 7.1.5
@@ -149,10 +148,12 @@ jimmidyson/configmap-reload rancher/jimmidyson-configmap-reload v0.3.0
 jimmidyson/configmap-reload rancher/jimmidyson-configmap-reload v0.4.0
 jimmidyson/configmap-reload rancher/mirrored-jimmidyson-configmap-reload v0.3.0
 jimmidyson/configmap-reload rancher/mirrored-jimmidyson-configmap-reload v0.4.0
+k8s.gcr.io/cpa/cluster-proportional-autoscaler rancher/mirrored-cluster-proportional-autoscaler 1.8.3
 k8s.gcr.io/kube-state-metrics/kube-state-metrics rancher/mirrored-kube-state-metrics-kube-state-metrics v1.9.8
 k8s.gcr.io/metrics-server/metrics-server rancher/metrics-server v0.4.1
 k8s.gcr.io/metrics-server/metrics-server rancher/mirrored-metrics-server v0.4.1
 k8s.gcr.io/metrics-server/metrics-server rancher/mirrored-metrics-server v0.4.4
+k8s.gcr.io/pause rancher/mirrored-pause 3.4.1
 kiwigrid/k8s-sidecar rancher/kiwigrid-k8s-sidecar 0.1.151
 kiwigrid/k8s-sidecar rancher/kiwigrid-k8s-sidecar 1.1.0
 kiwigrid/k8s-sidecar rancher/mirrored-kiwigrid-k8s-sidecar 0.1.151
@@ -316,7 +317,6 @@ quay.io/prometheus/prometheus rancher/prom-prometheus v2.22.0
 quay.io/tigera/operator rancher/mirrored-calico-operator v1.15.1
 rancher/cluster-proportional-autoscaler rancher/mirrored-cluster-proportional-autoscaler 1.7.1
 rancher/cluster-proportional-autoscaler rancher/mirrored-cluster-proportional-autoscaler 1.8.1
-rancher/cluster-proportional-autoscaler rancher/mirrored-cluster-proportional-autoscaler 1.8.3
 rancher/coreos-etcd rancher/mirrored-coreos-etcd v3.3.15-rancher1
 rancher/coreos-etcd rancher/mirrored-coreos-etcd v3.4.3-rancher1
 rancher/coreos-etcd rancher/mirrored-coreos-etcd v3.4.13-rancher1


### PR DESCRIPTION
#### Pull Request Checklist ####

- [x] Change does not remove any existing Images or Tags in the images-list file
- [x] Change does not remove / overwrite exiting Images or Tags in Rancher DockerHub
- [x] New entries are in format `SOURCE DESTINATION TAG`
- [x] New entries are added to the correct section of the list (sorted lexicographically)
- [x] New entries have a repo created in Rancher Dockerhub (where the image will be mirrored to)
- [x] Changes to scripting or CI config have been tested to the best of your ability

#### Types of Change ####

<!-- New image, version bump. script update, etc etc -->

#### Linked Issues ####

https://drone-publish.rancher.io/rancher/image-mirror/106/1/3 
Images weren't tagged and failed, sample msg: 
```
Line: gcr.io/google_containers/pause rancher/mirrored-pause 3.4.1
--
1630 | gcr.io/google_containers/pause rancher/mirrored-pause 3.4.1
1631 | time="2021-05-10T19:03:24Z" level=fatal msg="Error parsing image name \"docker://gcr.io/google_containers/pause:3.4.1\": Error reading manifest 3.4.1 in gcr.io/google_containers/pause: manifest unknown: Failed to fetch \"3.4.1\" from request \"/v2/google_containers/pause/manifests/3.4.1\"."
1632 | ===
1633 | Failed copying image for rancher/mirrored-pause
1634 | ===
1635 | gcr.io/google_containers/pause:3.4.1 has unknown schemaVersion
1636 | ===
1637 | Failed copying image for rancher/mirrored-pause
1638 | ===
```

#### Additional Notes ####

<!-- Any additional details / test results / etc -->
