### PR TITLE
Add istio v1.8.6 & v1.9.5

### DIFF
--- a/images-list
+++ b/images-list
@@ -91,9 +91,11 @@ istio/install-cni rancher/mirrored-istio-install-cni 1.7.8
 istio/install-cni rancher/mirrored-istio-install-cni 1.8.3
 istio/install-cni rancher/mirrored-istio-install-cni 1.8.4
 istio/install-cni rancher/mirrored-istio-install-cni 1.8.5
+istio/install-cni rancher/mirrored-istio-install-cni 1.8.6
 istio/install-cni rancher/mirrored-istio-install-cni 1.9.1
 istio/install-cni rancher/mirrored-istio-install-cni 1.9.2
 istio/install-cni rancher/mirrored-istio-install-cni 1.9.3
+istio/install-cni rancher/mirrored-istio-install-cni 1.9.5
 istio/kubectl rancher/istio-kubectl 1.5.10
 istio/kubectl rancher/mirrored-istio-kubectl 1.5.9
 istio/mixer rancher/istio-mixer 1.7.0
@@ -114,9 +116,11 @@ istio/pilot rancher/mirrored-istio-pilot 1.7.8
 istio/pilot rancher/mirrored-istio-pilot 1.8.3
 istio/pilot rancher/mirrored-istio-pilot 1.8.4
 istio/pilot rancher/mirrored-istio-pilot 1.8.5
+istio/pilot rancher/mirrored-istio-pilot 1.8.6
 istio/pilot rancher/mirrored-istio-pilot 1.9.1
 istio/pilot rancher/mirrored-istio-pilot 1.9.2
 istio/pilot rancher/mirrored-istio-pilot 1.9.3
+istio/pilot rancher/mirrored-istio-pilot 1.9.5
 istio/proxyv2 rancher/istio-proxyv2 1.7.0
 istio/proxyv2 rancher/istio-proxyv2 1.7.1
 istio/proxyv2 rancher/istio-proxyv2 1.7.3
@@ -128,9 +132,11 @@ istio/proxyv2 rancher/mirrored-istio-proxyv2 1.7.8
 istio/proxyv2 rancher/mirrored-istio-proxyv2 1.8.3
 istio/proxyv2 rancher/mirrored-istio-proxyv2 1.8.4
 istio/proxyv2 rancher/mirrored-istio-proxyv2 1.8.5
+istio/proxyv2 rancher/mirrored-istio-proxyv2 1.8.6
 istio/proxyv2 rancher/mirrored-istio-proxyv2 1.9.1
 istio/proxyv2 rancher/mirrored-istio-proxyv2 1.9.2
 istio/proxyv2 rancher/mirrored-istio-proxyv2 1.9.3
+istio/proxyv2 rancher/mirrored-istio-proxyv2 1.9.5
 istio/sidecar_injector rancher/mirrored-istio-sidecar_injector 1.5.9
 jaegertracing/all-in-one rancher/jaegertracing-all-in-one 1.20.0
 jaegertracing/all-in-one rancher/mirrored-jaegertracing-all-in-one 1.14


### PR DESCRIPTION
#### Pull Request Checklist ####

- [x] Change does not remove any existing Images or Tags in the images-list file
- [x] Change does not remove / overwrite exiting Images or Tags in Rancher DockerHub
- [x] New entries are in format `SOURCE DESTINATION TAG`
- [x] New entries are added to the correct section of the list (sorted lexicographically)
- [x] New entries have a repo created in Rancher Dockerhub (where the image will be mirrored to)
- [x] Changes to scripting or CI config have been tested to the best of your ability

#### Types of Change ####

Version Bump

#### Additional Notes ####
https://istio.io/latest/news/security/istio-security-2021-006/
https://istio.io/latest/news/security/istio-security-2021-005/

#### Final Checks after the PR is merged ####
- [ ] Confirm that you can pull the new images and tags from DockerHub