### PR TITLE
Add mirrored image for rancher-external-dns system-chart

### DIFF
--- a/images-list
+++ b/images-list
@@ -343,3 +343,4 @@ squareup/ghostunnel rancher/squareup-ghostunnel v1.5.2
 thanosio/thanos rancher/mirrored-thanosio-thanos v0.15.0
 thanosio/thanos rancher/thanosio-thanos v0.15.0
 us.gcr.io/k8s-artifacts-prod/external-dns/external-dns rancher/kubernetes-external-dns v0.7.3
+us.gcr.io/k8s-artifacts-prod/external-dns/external-dns rancher/mirrored-kubernetes-external-dns v0.7.3


### PR DESCRIPTION
#### Pull Request Checklist ####

- [x] Change does not remove any existing Images or Tags in the images-list file
- [x] Change does not remove / overwrite exiting Images or Tags in Rancher DockerHub
- [x] New entries are in format `SOURCE DESTINATION TAG`
- [x] New entries are added to the correct section of the list (sorted lexicographically)
- [x] New entries have a repo created in Rancher Dockerhub (where the image will be mirrored to)
- [ ] Changes to scripting or CI config have been tested to the best of your ability

#### Types of Change ####

 New mirrored image

#### Linked Issues ####

https://github.com/rancher/rancher/issues/31873
https://github.com/rancher/rancher/issues/31598

EIO ticket: https://github.com/rancherlabs/eio/issues/454
System-Charts PR: https://github.com/rancher/system-charts/pull/461

#### Additional Notes ####
The following dockerHub repo is to be created to support this PR:

`rancher/mirrored-kubernetes-external-dns`


#### Final Checks after the PR is merged ####
- [ ] Confirm that you can pull the new images and tags from DockerHub