### PR TITLE
Add etcd v3.5.0

### DIFF
--- a/images-list
+++ b/images-list
@@ -316,6 +316,7 @@ quay.io/cilium/operator-generic rancher/mirrored-cilium-operator-generic v1.9.4
 quay.io/cilium/operator-generic rancher/mirrored-cilium-operator-generic v1.9.6
 quay.io/cilium/operator-generic rancher/mirrored-cilium-operator-generic v1.9.8
 quay.io/cilium/startup-script rancher/mirrored-cilium-startup-script 62bfbe88c17778aad7bef9fa57ff9e2d4a9ba0d8
+quay.io/coreos/etcd rancher/mirrored-coreos-etcd v3.5.0
 quay.io/coreos/kube-state-metrics rancher/mirrored-coreos-kube-state-metrics v1.9.7
 quay.io/coreos/prometheus-config-reloader rancher/coreos-prometheus-config-reloader v0.39.0
 quay.io/coreos/prometheus-config-reloader rancher/mirrored-coreos-prometheus-config-reloader v0.38.1


### PR DESCRIPTION
#### Pull Request Checklist ####

- [X] Change does not remove any existing Images or Tags in the images-list file
- [X] Change does not remove / overwrite exiting Images or Tags in Rancher DockerHub
- [X] New entries are in format `SOURCE DESTINATION TAG`
- [X] New entries are added to the correct section of the list (sorted lexicographically)
- [X] New entries have a repo created in Rancher Dockerhub (where the image will be mirrored to)
- [X] Changes to scripting or CI config have been tested to the best of your ability

#### Types of Change ####

New image, needed for k8s 1.22 and to test if we can now mirror 1:1 because of manifest support.

#### Linked Issues ####

https://github.com/rancher/rancher/issues/33114

#### Final Checks after the PR is merged ####
- [ ] Confirm that you can pull the new images and tags from DockerHub