### PR TITLE
Flannel/CoreDNS/metrics-server update for v1.21

### DIFF
--- a/images-list
+++ b/images-list
@@ -33,6 +33,7 @@ coredns/coredns rancher/mirrored-coredns-coredns 1.6.9
 coredns/coredns rancher/mirrored-coredns-coredns 1.7.0
 coredns/coredns rancher/mirrored-coredns-coredns 1.8.0
 coredns/coredns rancher/mirrored-coredns-coredns 1.8.3
+coredns/coredns rancher/mirrored-coredns-coredns 1.8.4
 curlimages/curl rancher/curlimages-curl 7.70.0
 curlimages/curl rancher/curlimages-curl 7.73.0
 curlimages/curl rancher/mirrored-curlimages-curl 7.70.0
@@ -178,6 +179,7 @@ k8s.gcr.io/kube-state-metrics/kube-state-metrics rancher/mirrored-kube-state-met
 k8s.gcr.io/metrics-server/metrics-server rancher/metrics-server v0.4.1
 k8s.gcr.io/metrics-server/metrics-server rancher/mirrored-metrics-server v0.4.1
 k8s.gcr.io/metrics-server/metrics-server rancher/mirrored-metrics-server v0.4.4
+k8s.gcr.io/metrics-server/metrics-server rancher/mirrored-metrics-server v0.5.0
 k8s.gcr.io/pause rancher/mirrored-pause 3.4.1
 k8s.gcr.io/pause rancher/mirrored-pause 3.5
 kiwigrid/k8s-sidecar rancher/kiwigrid-k8s-sidecar 0.1.151
@@ -319,6 +321,7 @@ quay.io/cilium/operator-generic rancher/mirrored-cilium-operator-generic v1.9.6
 quay.io/cilium/operator-generic rancher/mirrored-cilium-operator-generic v1.9.8
 quay.io/cilium/startup-script rancher/mirrored-cilium-startup-script 62bfbe88c17778aad7bef9fa57ff9e2d4a9ba0d8
 quay.io/coreos/etcd rancher/mirrored-coreos-etcd v3.5.0
+quay.io/coreos/flannel rancher/mirrored-coreos-flannel v0.14.0
 quay.io/coreos/kube-state-metrics rancher/mirrored-coreos-kube-state-metrics v1.9.7
 quay.io/coreos/prometheus-config-reloader rancher/coreos-prometheus-config-reloader v0.39.0
 quay.io/coreos/prometheus-config-reloader rancher/mirrored-coreos-prometheus-config-reloader v0.38.1


### PR DESCRIPTION
#### Pull Request Checklist ####

- [X] Change does not remove any existing Images or Tags in the images-list file
- [X] Change does not remove / overwrite exiting Images or Tags in Rancher DockerHub
- [X] New entries are in format `SOURCE DESTINATION TAG`
- [X] New entries are added to the correct section of the list (sorted lexicographically)
- [X] New entries have a repo created in Rancher Dockerhub (where the image will be mirrored to)
- [X] Changes to scripting or CI config have been tested to the best of your ability

#### Types of Change ####

New images for k8s v1.21 addons updates

#### Linked Issues ####

https://github.com/rancher/rancher/issues/31567#issuecomment-858754265

#### Additional Notes ####

* Missing kube-dns because images for 1.18.0 are missing upstream.
* Calico was already added for 3.19.1

#### Final Checks after the PR is merged ####
- [ ] Confirm that you can pull the new images and tags from DockerHub