### PR TITLE
Add kube-dns node-cache 1.18.0

### DIFF
--- a/images-list
+++ b/images-list
@@ -172,6 +172,7 @@ k8s.gcr.io/dns/k8s-dns-kube-dns rancher/mirrored-k8s-dns-kube-dns 1.17.3
 k8s.gcr.io/dns/k8s-dns-kube-dns rancher/mirrored-k8s-dns-kube-dns 1.17.4
 k8s.gcr.io/dns/k8s-dns-node-cache rancher/mirrored-k8s-dns-node-cache 1.17.3
 k8s.gcr.io/dns/k8s-dns-node-cache rancher/mirrored-k8s-dns-node-cache 1.17.4
+k8s.gcr.io/dns/k8s-dns-node-cache rancher/mirrored-k8s-dns-node-cache 1.18.0
 k8s.gcr.io/dns/k8s-dns-sidecar rancher/mirrored-k8s-dns-sidecar 1.17.3
 k8s.gcr.io/dns/k8s-dns-sidecar rancher/mirrored-k8s-dns-sidecar 1.17.4
 k8s.gcr.io/kube-state-metrics/kube-state-metrics rancher/mirrored-kube-state-metrics-kube-state-metrics v1.9.8


### PR DESCRIPTION
#### Pull Request Checklist ####

- [X] Change does not remove any existing Images or Tags in the images-list file
- [X] Change does not remove / overwrite exiting Images or Tags in Rancher DockerHub
- [X] New entries are in format `SOURCE DESTINATION TAG`
- [X] New entries are added to the correct section of the list (sorted lexicographically)
- [X] New entries have a repo created in Rancher Dockerhub (where the image will be mirrored to)
- [X] Changes to scripting or CI config have been tested to the best of your ability

#### Types of Change ####

New image

#### Linked Issues ####

https://github.com/rancher/rancher/issues/31567

#### Additional Notes ####

According to https://github.com/kubernetes/k8s.io/pull/2118, only the node-cache image was bumped and released.