### PR TITLE
Include istio 1.9.6 & istio 1.10.2

### DIFF
--- a/images-list
+++ b/images-list
@@ -104,8 +104,10 @@ istio/install-cni rancher/mirrored-istio-install-cni 1.9.1
 istio/install-cni rancher/mirrored-istio-install-cni 1.9.2
 istio/install-cni rancher/mirrored-istio-install-cni 1.9.3
 istio/install-cni rancher/mirrored-istio-install-cni 1.9.5
+istio/install-cni rancher/mirrored-istio-install-cni 1.9.6
 istio/install-cni rancher/mirrored-istio-install-cni 1.10.0
 istio/install-cni rancher/mirrored-istio-install-cni 1.10.1
+istio/install-cni rancher/mirrored-istio-install-cni 1.10.2
 istio/kubectl rancher/istio-kubectl 1.5.10
 istio/kubectl rancher/mirrored-istio-kubectl 1.5.9
 istio/mixer rancher/istio-mixer 1.7.0
@@ -131,8 +133,10 @@ istio/pilot rancher/mirrored-istio-pilot 1.9.1
 istio/pilot rancher/mirrored-istio-pilot 1.9.2
 istio/pilot rancher/mirrored-istio-pilot 1.9.3
 istio/pilot rancher/mirrored-istio-pilot 1.9.5
+istio/pilot rancher/mirrored-istio-pilot 1.9.6
 istio/pilot rancher/mirrored-istio-pilot 1.10.0
 istio/pilot rancher/mirrored-istio-pilot 1.10.1
+istio/pilot rancher/mirrored-istio-pilot 1.10.2
 istio/proxyv2 rancher/istio-proxyv2 1.7.0
 istio/proxyv2 rancher/istio-proxyv2 1.7.1
 istio/proxyv2 rancher/istio-proxyv2 1.7.3
@@ -149,8 +153,10 @@ istio/proxyv2 rancher/mirrored-istio-proxyv2 1.9.1
 istio/proxyv2 rancher/mirrored-istio-proxyv2 1.9.2
 istio/proxyv2 rancher/mirrored-istio-proxyv2 1.9.3
 istio/proxyv2 rancher/mirrored-istio-proxyv2 1.9.5
+istio/proxyv2 rancher/mirrored-istio-proxyv2 1.9.6
 istio/proxyv2 rancher/mirrored-istio-proxyv2 1.10.0
 istio/proxyv2 rancher/mirrored-istio-proxyv2 1.10.1
+istio/proxyv2 rancher/mirrored-istio-proxyv2 1.10.2
 istio/sidecar_injector rancher/mirrored-istio-sidecar_injector 1.5.9
 jaegertracing/all-in-one rancher/jaegertracing-all-in-one 1.20.0
 jaegertracing/all-in-one rancher/mirrored-jaegertracing-all-in-one 1.14


### PR DESCRIPTION
#### Pull Request Checklist ####

- [x] Change does not remove any existing Images or Tags in the images-list file
- [x] Change does not remove / overwrite exiting Images or Tags in Rancher DockerHub
- [x] New entries are in format `SOURCE DESTINATION TAG`
- [x] New entries are added to the correct section of the list (sorted lexicographically)
- [x] New entries have a repo created in Rancher Dockerhub (where the image will be mirrored to)
- [x] Changes to scripting or CI config have been tested to the best of your ability

#### Types of Change ####

Version Bump

#### Linked Issues ####
https://hub.docker.com/r/istio/istioctl/tags?page=1&ordering=last_updated&name=1.10.2
https://hub.docker.com/r/istio/istioctl/tags?page=1&ordering=last_updated&name=1.9.6

#### Additional Notes ####

Need to include versions for most recent Istio releases

#### Final Checks after the PR is merged ####
- [ ] Confirm that you can pull the new images and tags from DockerHub