### PR TITLE
Add images for CSI 2.3.0 and CPI v1.21.0

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,6 +2,7 @@
 
 - [ ] Change does not remove any existing Images or Tags in the images-list file
 - [ ] Change does not remove / overwrite exiting Images or Tags in Rancher DockerHub
+- [ ] If updating an existing entry, verify the `SOURCE` is still accurate and upstream hasn't been migrated to a new regitry or repo (if they've migrated, a new repo request to EIO is needed to comply with the `SOURCE DESTINATION TAG` pattern)
 - [ ] New entries are in format `SOURCE DESTINATION TAG`
 - [ ] New entries are added to the correct section of the list (sorted lexicographically)
 - [ ] New entries have a repo created in Rancher Dockerhub (where the image will be mirrored to)

--- a/images-list
+++ b/images-list
@@ -66,6 +66,10 @@ fluent/fluent-bit rancher/mirrored-fluent-fluent-bit 1.8.5-debug
 fluent/fluent-bit rancher/mirrored-fluent-fluent-bit 1.8.7
 fluent/fluent-bit rancher/mirrored-fluent-fluent-bit 1.8.7-debug
 gcr.io/cloud-provider-vsphere/cpi/release/manager rancher/mirrored-cloud-provider-vsphere-cpi-release-manager v1.2.1
+gcr.io/cloud-provider-vsphere/cpi/release/manager rancher/mirrored-cloud-provider-vsphere-cpi-release-manager v1.18.0
+gcr.io/cloud-provider-vsphere/cpi/release/manager rancher/mirrored-cloud-provider-vsphere-cpi-release-manager v1.19.0
+gcr.io/cloud-provider-vsphere/cpi/release/manager rancher/mirrored-cloud-provider-vsphere-cpi-release-manager v1.20.0
+gcr.io/cloud-provider-vsphere/cpi/release/manager rancher/mirrored-cloud-provider-vsphere-cpi-release-manager v1.21.0
 gcr.io/cloud-provider-vsphere/csi/release/driver rancher/mirrored-cloud-provider-vsphere-csi-release-driver v2.1.0
 gcr.io/cloud-provider-vsphere/csi/release/driver rancher/mirrored-cloud-provider-vsphere-csi-release-driver v2.2.0
 gcr.io/cloud-provider-vsphere/csi/release/driver rancher/mirrored-cloud-provider-vsphere-csi-release-driver v2.2.1

--- a/images-list
+++ b/images-list
@@ -69,9 +69,11 @@ gcr.io/cloud-provider-vsphere/cpi/release/manager rancher/mirrored-cloud-provide
 gcr.io/cloud-provider-vsphere/csi/release/driver rancher/mirrored-cloud-provider-vsphere-csi-release-driver v2.1.0
 gcr.io/cloud-provider-vsphere/csi/release/driver rancher/mirrored-cloud-provider-vsphere-csi-release-driver v2.2.0
 gcr.io/cloud-provider-vsphere/csi/release/driver rancher/mirrored-cloud-provider-vsphere-csi-release-driver v2.2.1
+gcr.io/cloud-provider-vsphere/csi/release/driver rancher/mirrored-cloud-provider-vsphere-csi-release-driver v2.3.0
 gcr.io/cloud-provider-vsphere/csi/release/syncer rancher/mirrored-cloud-provider-vsphere-csi-release-syncer v2.1.0
 gcr.io/cloud-provider-vsphere/csi/release/syncer rancher/mirrored-cloud-provider-vsphere-csi-release-syncer v2.2.0
 gcr.io/cloud-provider-vsphere/csi/release/syncer rancher/mirrored-cloud-provider-vsphere-csi-release-syncer v2.2.1
+gcr.io/cloud-provider-vsphere/csi/release/syncer rancher/mirrored-cloud-provider-vsphere-csi-release-syncer v2.3.0
 gcr.io/google-containers/k8s-dns-node-cache rancher/mirrored-k8s-dns-node-cache 1.15.7
 gcr.io/google-containers/k8s-dns-node-cache rancher/mirrored-k8s-dns-node-cache 1.15.13
 gcr.io/google_containers/k8s-dns-dnsmasq-nanny rancher/mirrored-k8s-dns-dnsmasq-nanny 1.15.0
@@ -220,10 +222,12 @@ k8s.gcr.io/pause rancher/mirrored-pause 3.4.1
 k8s.gcr.io/pause rancher/mirrored-pause 3.5
 k8s.gcr.io/sig-storage/csi-attacher rancher/longhornio-csi-attacher v3.2.1
 k8s.gcr.io/sig-storage/csi-attacher rancher/mirrored-longhornio-csi-attacher v3.2.1
+k8s.gcr.io/sig-storage/csi-attacher rancher/mirrored-sig-storage-csi-attacher v3.2.0
 k8s.gcr.io/sig-storage/csi-node-driver-registrar rancher/longhornio-csi-node-driver-registrar v2.3.0
 k8s.gcr.io/sig-storage/csi-node-driver-registrar rancher/mirrored-longhornio-csi-node-driver-registrar v2.3.0
 k8s.gcr.io/sig-storage/csi-provisioner rancher/longhornio-csi-provisioner v2.1.2
 k8s.gcr.io/sig-storage/csi-provisioner rancher/mirrored-longhornio-csi-provisioner v2.1.2
+k8s.gcr.io/sig-storage/csi-provisioner rancher/mirrored-sig-storage-csi-provisioner v2.2.0
 k8s.gcr.io/sig-storage/csi-resizer rancher/longhornio-csi-resizer v1.2.0
 k8s.gcr.io/sig-storage/csi-resizer rancher/mirrored-longhornio-csi-resizer v1.2.0
 k8s.gcr.io/sig-storage/csi-snapshotter rancher/longhornio-csi-snapshotter v3.0.3


### PR DESCRIPTION
#### Pull Request Checklist ####

- [x] Change does not remove any existing Images or Tags in the images-list file
- [x] Change does not remove / overwrite exiting Images or Tags in Rancher DockerHub
- [x] New entries are in format `SOURCE DESTINATION TAG`
- [x] New entries are added to the correct section of the list (sorted lexicographically)
- [x] New entries have a repo created in Rancher Dockerhub (where the image will be mirrored to)
- [ ] Changes to scripting or CI config have been tested to the best of your ability

#### Types of Change ####
New images for the vSphere CSI 2.3.0 update and vSphere CPI v1.21.0

<!-- New image, version bump. script update, etc etc -->

#### Linked Issues ####
https://github.com/rancher/rancher/issues/34630
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request.  -->

#### Final Checks after the PR is merged ####
- [ ] Confirm that you can pull the new images and tags from DockerHub