### PR TITLE
New image and a few version bumps

### DIFF
--- a/images-list
+++ b/images-list
@@ -342,6 +342,7 @@ prom/node-exporter rancher/prom-node-exporter v1.0.1
 prom/prometheus rancher/mirrored-prom-prometheus v2.12.0
 prom/prometheus rancher/prom-prometheus v2.18.2
 pstauffer/curl rancher/mirrored-pstauffer-curl v1.0.3
+quay.io/calico/apiserver rancher/mirrored-calico-apiserver v3.20.1
 quay.io/calico/cni rancher/calico-cni v3.16.5
 quay.io/calico/cni rancher/calico-cni v3.16.6
 quay.io/calico/cni rancher/calico-cni v3.17.1
@@ -354,6 +355,7 @@ quay.io/calico/cni rancher/mirrored-calico-cni v3.18.1
 quay.io/calico/cni rancher/mirrored-calico-cni v3.19.0
 quay.io/calico/cni rancher/mirrored-calico-cni v3.19.1
 quay.io/calico/cni rancher/mirrored-calico-cni v3.19.2
+quay.io/calico/cni rancher/mirrored-calico-cni v3.20.1
 quay.io/calico/ctl rancher/calico-ctl v3.16.5
 quay.io/calico/ctl rancher/calico-ctl v3.16.6
 quay.io/calico/ctl rancher/calico-ctl v3.17.1
@@ -368,6 +370,7 @@ quay.io/calico/ctl rancher/mirrored-calico-ctl v3.18.1
 quay.io/calico/ctl rancher/mirrored-calico-ctl v3.19.0
 quay.io/calico/ctl rancher/mirrored-calico-ctl v3.19.1
 quay.io/calico/ctl rancher/mirrored-calico-ctl v3.19.2
+quay.io/calico/ctl rancher/mirrored-calico-ctl v3.20.1
 quay.io/calico/kube-controllers rancher/calico-kube-controllers v3.16.5
 quay.io/calico/kube-controllers rancher/calico-kube-controllers v3.16.6
 quay.io/calico/kube-controllers rancher/calico-kube-controllers v3.17.1
@@ -380,6 +383,7 @@ quay.io/calico/kube-controllers rancher/mirrored-calico-kube-controllers v3.18.1
 quay.io/calico/kube-controllers rancher/mirrored-calico-kube-controllers v3.19.0
 quay.io/calico/kube-controllers rancher/mirrored-calico-kube-controllers v3.19.1
 quay.io/calico/kube-controllers rancher/mirrored-calico-kube-controllers v3.19.2
+quay.io/calico/kube-controllers rancher/mirrored-calico-kube-controllers v3.20.1
 quay.io/calico/node rancher/calico-node v3.16.5
 quay.io/calico/node rancher/calico-node v3.16.6
 quay.io/calico/node rancher/calico-node v3.17.1
@@ -392,6 +396,7 @@ quay.io/calico/node rancher/mirrored-calico-node v3.18.1
 quay.io/calico/node rancher/mirrored-calico-node v3.19.0
 quay.io/calico/node rancher/mirrored-calico-node v3.19.1
 quay.io/calico/node rancher/mirrored-calico-node v3.19.2
+quay.io/calico/node rancher/mirrored-calico-node v3.20.1
 quay.io/calico/pod2daemon-flexvol rancher/calico-pod2daemon-flexvol v3.16.5
 quay.io/calico/pod2daemon-flexvol rancher/calico-pod2daemon-flexvol v3.16.6
 quay.io/calico/pod2daemon-flexvol rancher/calico-pod2daemon-flexvol v3.17.1
@@ -404,9 +409,11 @@ quay.io/calico/pod2daemon-flexvol rancher/mirrored-calico-pod2daemon-flexvol v3.
 quay.io/calico/pod2daemon-flexvol rancher/mirrored-calico-pod2daemon-flexvol v3.19.0
 quay.io/calico/pod2daemon-flexvol rancher/mirrored-calico-pod2daemon-flexvol v3.19.1
 quay.io/calico/pod2daemon-flexvol rancher/mirrored-calico-pod2daemon-flexvol v3.19.2
+quay.io/calico/pod2daemon-flexvol rancher/mirrored-calico-pod2daemon-flexvol v3.20.1
 quay.io/calico/typha rancher/mirrored-calico-typha v3.18.1
 quay.io/calico/typha rancher/mirrored-calico-typha v3.19.1
 quay.io/calico/typha rancher/mirrored-calico-typha v3.19.2
+quay.io/calico/typha rancher/mirrored-calico-typha v3.20.1
 quay.io/cilium/cilium rancher/mirrored-cilium-cilium v1.9.4
 quay.io/cilium/cilium rancher/mirrored-cilium-cilium v1.9.6
 quay.io/cilium/cilium rancher/mirrored-cilium-cilium v1.9.8
@@ -479,6 +486,7 @@ quay.io/tigera/operator rancher/mirrored-calico-operator v1.15.1
 quay.io/tigera/operator rancher/mirrored-calico-operator v1.17.2
 quay.io/tigera/operator rancher/mirrored-calico-operator v1.17.4
 quay.io/tigera/operator rancher/mirrored-calico-operator v1.17.6
+quay.io/tigera/operator rancher/mirrored-calico-operator v1.20.3
 rancher/cluster-proportional-autoscaler rancher/mirrored-cluster-proportional-autoscaler 1.7.1
 rancher/cluster-proportional-autoscaler rancher/mirrored-cluster-proportional-autoscaler 1.8.1
 rancher/coreos-etcd rancher/mirrored-coreos-etcd v3.3.15-rancher1


### PR DESCRIPTION
Signed-off-by: Manuel Buil <mbuil@suse.com>

#### Pull Request Checklist ####

- [X] Change does not remove any existing Images or Tags in the images-list file
- [X] Change does not remove / overwrite exiting Images or Tags in Rancher DockerHub
- [X] If updating an existing entry, verify the `SOURCE` is still accurate and upstream hasn't been migrated to a new regitry or repo (if they've migrated, a new repo request to EIO is needed to comply with the `SOURCE DESTINATION TAG` pattern)
- [X] New entries are in format `SOURCE DESTINATION TAG`
- [X] New entries are added to the correct section of the list (sorted lexicographically)
- [x] New entries have a repo created in Rancher Dockerhub (where the image will be mirrored to): https://github.com/rancherlabs/eio/issues/597
- [X] Changes to scripting or CI config have been tested to the best of your ability

#### Types of Change ####

<!-- New image, version bump. script update, etc etc -->
* New image:  quay.io/calico/apiserver rancher/mirrored-calico-apiserver v3.20.1
* Few Version bumps to v3.20.1 and operator to v3.20.3

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request.  -->
https://github.com/rancher/rke2/issues/1892

#### Additional Notes ####

<!-- Any additional details / test results / etc -->

#### Final Checks after the PR is merged ####
- [ ] Confirm that you can pull the new images and tags from DockerHub