### PR TITLE
adding flannel cni plugin

### DIFF
--- a/images-list
+++ b/images-list
@@ -46,6 +46,7 @@ directxman12/k8s-prometheus-adapter-amd64 rancher/directxman12-k8s-prometheus-ad
 directxman12/k8s-prometheus-adapter-amd64 rancher/directxman12-k8s-prometheus-adapter-amd64 v0.7.0
 directxman12/k8s-prometheus-adapter-amd64 rancher/mirrored-directxman12-k8s-prometheus-adapter-amd64 v0.7.0
 directxman12/k8s-prometheus-adapter-amd64 rancher/mirrored-directxman12-k8s-prometheus-adapter-amd64 v0.8.3
+flannelcni/flannel-cni-plugin rancher/flannel-cni-plugin v1.2
 fluent/fluent-bit rancher/fluent-fluent-bit 1.5.4
 fluent/fluent-bit rancher/fluent-fluent-bit 1.5.4-debug
 fluent/fluent-bit rancher/fluent-fluent-bit 1.6.1


### PR DESCRIPTION
CNI plugins have been pulled from the containernetworking group and the CNI themselves have to maintain the code/images. This adds a mirror from the flannelcni dockerhub to get the image mirrored to a rancher repo.

#### Pull Request Checklist ####

- [ x] Change does not remove any existing Images or Tags in the images-list file
- [x ] Change does not remove / overwrite exiting Images or Tags in Rancher DockerHub
- [ x] If updating an existing entry, verify the `SOURCE` is still accurate and upstream hasn't been migrated to a new regitry or repo (if they've migrated, a new repo request to EIO is needed to comply with the `SOURCE DESTINATION TAG` pattern)
- [ x] New entries are in format `SOURCE DESTINATION TAG`
- [x ] New entries are added to the correct section of the list (sorted lexicographically)
- [x ] New entries have a repo created in Rancher Dockerhub (where the image will be mirrored to)
- [x ] Changes to scripting or CI config have been tested to the best of your ability

#### Types of Change ####

<!-- New image, version bump. script update, etc etc -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request.  -->

#### Additional Notes ####

<!-- Any additional details / test results / etc -->

#### Final Checks after the PR is merged ####
- [ ] Confirm that you can pull the new images and tags from DockerHub