### PR TITLE
Adding Pause 3.6

### DIFF
--- a/images-list
+++ b/images-list
@@ -237,6 +237,7 @@ k8s.gcr.io/metrics-server/metrics-server rancher/mirrored-metrics-server v0.4.4
 k8s.gcr.io/metrics-server/metrics-server rancher/mirrored-metrics-server v0.5.0
 k8s.gcr.io/pause rancher/mirrored-pause 3.4.1
 k8s.gcr.io/pause rancher/mirrored-pause 3.5
+k8s.gcr.io/pause rancher/mirrored-pause 3.6
 k8s.gcr.io/prometheus-adapter/prometheus-adapter rancher/mirrored-prometheus-adapter-prometheus-adapter v0.9.0
 k8s.gcr.io/sig-storage/csi-attacher rancher/longhornio-csi-attacher v3.2.1
 k8s.gcr.io/sig-storage/csi-attacher rancher/mirrored-longhornio-csi-attacher v3.2.1


### PR DESCRIPTION
Required as 3.6 is the first version to add support for Windows Server 2022.

Signed-off-by: Jamie Phillips <jamie.phillips@suse.com>

#### Pull Request Checklist ####

- [x] Change does not remove any existing Images or Tags in the images-list file
- [x] Change does not remove / overwrite exiting Images or Tags in Rancher DockerHub
- [x] If updating an existing entry, verify the `SOURCE` is still accurate and upstream hasn't been migrated to a new regitry or repo (if they've migrated, a new repo request to EIO is needed to comply with the `SOURCE DESTINATION TAG` pattern)
- [x] New entries are in format `SOURCE DESTINATION TAG`
- [x] New entries are added to the correct section of the list (sorted lexicographically)
- [x] New entries have a repo created in Rancher Dockerhub (where the image will be mirrored to)
- [x] Changes to scripting or CI config have been tested to the best of your ability

#### Types of Change ####

Version pump to the Pause image since 3.6 is the first version to add Windows support.

#### Linked Issues ####

* https://github.com/rancher/windows/issues/104

#### Additional Notes ####

<!-- Any additional details / test results / etc -->

#### Final Checks after the PR is merged ####
- [ ] Confirm that you can pull the new images and tags from DockerHub