### PR TITLE
Add mirrored image for gatekeeper 3.7.0 and gatekeeper-crds 3.7.0

### DIFF
--- a/images-list
+++ b/images-list
@@ -393,11 +393,13 @@ openpolicyagent/gatekeeper rancher/mirrored-openpolicyagent-gatekeeper v3.4.0
 openpolicyagent/gatekeeper rancher/mirrored-openpolicyagent-gatekeeper v3.5.1
 openpolicyagent/gatekeeper rancher/mirrored-openpolicyagent-gatekeeper v3.5.2
 openpolicyagent/gatekeeper rancher/mirrored-openpolicyagent-gatekeeper v3.6.0
+openpolicyagent/gatekeeper rancher/mirrored-openpolicyagent-gatekeeper v3.7.0
 openpolicyagent/gatekeeper rancher/openpolicyagent-gatekeeper v3.1.0
 openpolicyagent/gatekeeper rancher/openpolicyagent-gatekeeper v3.1.1
 openpolicyagent/gatekeeper rancher/openpolicyagent-gatekeeper v3.2.1
 openpolicyagent/gatekeeper rancher/openpolicyagent-gatekeeper v3.3.0
 openpolicyagent/gatekeeper-crds rancher/mirrored-openpolicyagent-gatekeeper-crds v3.6.0
+openpolicyagent/gatekeeper-crds rancher/mirrored-openpolicyagent-gatekeeper-crds v3.7.0
 openzipkin/zipkin rancher/mirrored-openzipkin-zipkin 2.14.2
 plugins/docker rancher/mirrored-plugins-docker 18.09
 plugins/docker rancher/mirrored-plugins-docker 19.03.8


### PR DESCRIPTION
#### Pull Request Checklist ####

- [x] Change does not remove any existing Images or Tags in the images-list file
- [x] Change does not remove / overwrite exiting Images or Tags in Rancher DockerHub
- [x] If updating an existing entry, verify the `SOURCE` is still accurate and upstream hasn't been migrated to a new regitry or repo (if they've migrated, a new repo request to EIO is needed to comply with the `SOURCE DESTINATION TAG` pattern)
- [x] New entries are in format `SOURCE DESTINATION TAG`
- [x] New entries are added to the correct section of the list (sorted lexicographically)
- [x] New entries have a repo created in Rancher Dockerhub (where the image will be mirrored to)
- [ ] Changes to scripting or CI config have been tested to the best of your ability

#### Types of Change ####

<!-- New image, version bump. script update, etc etc -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request.  -->

#### Additional Notes ####

<!-- Any additional details / test results / etc -->

#### Final Checks after the PR is merged ####
- [ ] Confirm that you can pull the new images and tags from DockerHub