### PR TITLE
Adding mirror for sigwindowstools GMSA Webhook image.

### DIFF
--- a/images-list
+++ b/images-list
@@ -609,6 +609,7 @@ rancher/metrics-server rancher/mirrored-metrics-server v0.3.4
 rancher/metrics-server rancher/mirrored-metrics-server v0.3.6
 rancher/nginx-ingress-controller-defaultbackend rancher/mirrored-nginx-ingress-controller-defaultbackend 1.5-rancher1
 rpardini/docker-registry-proxy rancher/rpardini-docker-registry-proxy 0.6.1
+sigwindowstools/k8s-gmsa-webhook rancher/mirrored-sigwindowstools-k8s-gmsa-webhook v0.3.0
 sonobuoy/sonobuoy rancher/mirrored-sonobuoy-sonobuoy v0.16.3
 sonobuoy/sonobuoy rancher/mirrored-sonobuoy-sonobuoy v0.19.0
 sonobuoy/sonobuoy rancher/mirrored-sonobuoy-sonobuoy v0.52.0


### PR DESCRIPTION
#### Pull Request Checklist ####

- [x] Change does not remove any existing Images or Tags in the images-list file
- [x] Change does not remove / overwrite exiting Images or Tags in Rancher DockerHub
- [x] If updating an existing entry, verify the `SOURCE` is still accurate and upstream hasn't been migrated to a new regitry or repo (if they've migrated, a new repo request to EIO is needed to comply with the `SOURCE DESTINATION TAG` pattern)
- [x] New entries are in format `SOURCE DESTINATION TAG`
- [x] New entries are added to the correct section of the list (sorted lexicographically)
- [x] New entries have a repo created in Rancher Dockerhub (where the image will be mirrored to)
- [x] Changes to scripting or CI config have been tested to the best of your ability

#### Types of Change ####

This request is adding a new image to mirror for the sigwindowstools GMSA webhook.

#### Linked Issues ####

* https://github.com/rancher/windows/issues/22

#### Additional Notes ####

<!-- Any additional details / test results / etc -->

#### Final Checks after the PR is merged ####
- [ ] Confirm that you can pull the new images and tags from DockerHub

Signed-off-by: Jamie Phillips <jamie.phillips@suse.com>