### PR TITLE
Update traefik to 2.6.0

### DIFF
--- a/images-list
+++ b/images-list
@@ -280,6 +280,7 @@ library/traefik rancher/library-traefik 2.4.9
 library/traefik rancher/mirrored-library-traefik 2.4.8
 library/traefik rancher/mirrored-library-traefik 2.5.0
 library/traefik rancher/mirrored-library-traefik 2.5.6
+library/traefik rancher/mirrored-library-traefik 2.6.0
 longhornio/backing-image-manager rancher/longhornio-backing-image-manager v1_20210422
 longhornio/backing-image-manager rancher/longhornio-backing-image-manager v1_20210422_patch1
 longhornio/backing-image-manager rancher/longhornio-backing-image-manager v2_20210820


### PR DESCRIPTION
#### Pull Request Checklist ####

- [x] Change does not remove any existing Images or Tags in the images-list file
- [x] Change does not remove / overwrite exiting Images or Tags in Rancher DockerHub
- [x] If updating an existing entry, verify the `SOURCE` is still accurate and upstream hasn't been migrated to a new regitry or repo (if they've migrated, a new repo request to EIO is needed to comply with the `SOURCE DESTINATION TAG` pattern)
- [x] New entries are in format `SOURCE DESTINATION TAG`
- [x] New entries are added to the correct section of the list (sorted lexicographically)
- [x] New entries have a repo created in Rancher Dockerhub (where the image will be mirrored to)
- [x] Changes to scripting or CI config have been tested to the best of your ability

#### Types of Change ####

Version bump for library/traefik:2.5.6 -> 2.6.0

#### Linked Issues ####

Related to https://github.com/k3s-io/k3s/pull/5069


#### Final Checks after the PR is merged ####
- [ ] Confirm that you can pull the new images and tags from DockerHub