### PR TITLE
Add a daily image-mirror pipeline

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -10,7 +10,9 @@ steps:
   - name: validate-list
     image: library/ubuntu:21.04
     commands:
-      - grep -vE '^\s*(#|//)' images-list | sort -Vc
+    - grep -vE '^\s*(#|//)' images-list | sort -Vc
+    - grep -vE '^\s*(#|//)' images-list-daily | sort -Vc
+  # this step will run on every push
   - name: mirror-images
     image: rancher/dapper:v0.5.7
     volumes:
@@ -28,6 +30,25 @@ steps:
     when:
       event:
         - push
+  # this step will run on every push, and also via cron every day
+  - name: mirror-images-daily
+    image: rancher/dapper:v0.5.7
+    volumes:
+      - name: docker
+        path: /var/run/docker.sock
+    environment:
+      DOCKER_PASSWORD:
+        from_secret: docker_password
+      DOCKER_USERNAME:
+        from_secret: docker_username
+    commands:
+      - cat images-list-daily | dapper
+    settings:
+      custom_dns: 1.1.1.1
+    when:
+      event:
+      - push
+      - cron
 
 volumes:
   - name: docker

--- a/images-list
+++ b/images-list
@@ -447,8 +447,6 @@ minio/minio rancher/mirrored-minio-minio RELEASE.2020-07-13T18-09-56Z
 neuvector/controller rancher/mirrored-neuvector-controller 5.0.0-b1
 neuvector/enforcer rancher/mirrored-neuvector-enforcer 5.0.0-b1
 neuvector/manager rancher/mirrored-neuvector-manager 5.0.0-b1
-neuvector/scanner rancher/mirrored-neuvector-scanner latest
-neuvector/updater rancher/mirrored-neuvector-updater latest
 openpolicyagent/gatekeeper rancher/mirrored-openpolicyagent-gatekeeper v3.3.0
 openpolicyagent/gatekeeper rancher/mirrored-openpolicyagent-gatekeeper v3.4.0
 openpolicyagent/gatekeeper rancher/mirrored-openpolicyagent-gatekeeper v3.5.1

--- a/images-list-daily
+++ b/images-list-daily
@@ -1,0 +1,6 @@
+# This list should be sorted in lexicographical (alphabetical) order. Do not change existing entries. Comments lines may be started with # or //.
+# See images-list for more information
+#
+# LIST FORMAT: <SOURCE> <DESTINATION> <TAG>
+neuvector/scanner rancher/mirrored-neuvector-scanner latest
+neuvector/updater rancher/mirrored-neuvector-updater latest


### PR DESCRIPTION
Solution for: https://github.com/rancherlabs/eio/issues/921

The goal of this PR is to add a pipeline step which will sync "latest" style images every day. They are in a separated list, and will run on push and [cron triggers](https://docs.drone.io/pipeline/docker/syntax/trigger/).

I ran the validator and daily steps locally, but I can't test for real without the credentials.


#### Pull Request Checklist ####

- [x] Change does not remove any existing Images or Tags in the images-list file
- [x] Change does not remove / overwrite exiting Images or Tags in Rancher DockerHub
- [x] If updating an existing entry, verify the `SOURCE` is still accurate and upstream hasn't been migrated to a new regitry or repo (if they've migrated, a new repo request to EIO is needed to comply with the `SOURCE DESTINATION TAG` pattern)
- [x] New entries are in format `SOURCE DESTINATION TAG`
- [x] New entries are added to the correct section of the list (sorted lexicographically)
- [x] New entries have a repo created in Rancher Dockerhub (where the image will be mirrored to)
- [x] Changes to scripting or CI config have been tested to the best of your ability

#### Types of Change ####

<!-- New image, version bump. script update, etc etc -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request.  -->

#### Additional Notes ####

<!-- Any additional details / test results / etc -->

#### Final Checks after the PR is merged ####
- [ ] Confirm that you can pull the new images and tags from DockerHub