### PR TITLE
Add mirror for etcd v3.5.3

### DIFF
--- a/images-list
+++ b/images-list
@@ -632,6 +632,7 @@ quay.io/cilium/operator-generic rancher/mirrored-cilium-operator-generic v1.11.2
 quay.io/cilium/startup-script rancher/mirrored-cilium-startup-script 62bfbe88c17778aad7bef9fa57ff9e2d4a9ba0d8
 quay.io/coreos/etcd rancher/mirrored-coreos-etcd v3.5.0
 quay.io/coreos/etcd rancher/mirrored-coreos-etcd v3.5.2
+quay.io/coreos/etcd rancher/mirrored-coreos-etcd v3.5.3
 quay.io/coreos/flannel rancher/mirrored-coreos-flannel v0.13.0
 quay.io/coreos/flannel rancher/mirrored-coreos-flannel v0.14.0
 quay.io/coreos/flannel rancher/mirrored-coreos-flannel v0.15.0


### PR DESCRIPTION
#### Pull Request Checklist ####

- [x] Change does not remove any existing Images or Tags in the images-list file
- [x] Change does not remove / overwrite exiting Images or Tags in Rancher DockerHub
- [x] If updating an existing entry, verify the `SOURCE` is still accurate and upstream hasn't been migrated to a new regitry or repo (if they've migrated, a new repo request to EIO is needed to comply with the `SOURCE DESTINATION TAG` pattern)
- [x] New entries are in format `SOURCE DESTINATION TAG`
- [x] New entries are added to the correct section of the list (sorted lexicographically)
- [x] New entries have a repo created in Rancher Dockerhub (where the image will be mirrored to)
- [x] Changes to scripting or CI config have been tested to the best of your ability

#### Types of Change ####
Version bump
<!-- New image, version bump. script update, etc etc -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request.  -->
https://github.com/rancher/rancher/issues/37388#issuecomment-1102949363
#### Additional Notes ####

<!-- Any additional details / test results / etc -->
Image can be found here: https://quay.io/repository/coreos/etcd?tab=tags

#### Final Checks after the PR is merged ####
- [ ] Confirm that you can pull the new images and tags from DockerHub