### PR TITLE
Bump skopeo/docker/buildx versions

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,13 +1,12 @@
-FROM quay.io/skopeo/stable:v1.1.1
+FROM quay.io/skopeo/stable:v1.7.0
 
 # Add jq
 RUN yum -y update && yum -y install jq && yum -y clean all && rm -rf /var/cache/dnf/* /var/log/dnf* /var/log/yum*
 
 # Add docker cli
-COPY --from=docker.io/library/docker:19.03.12 /usr/local/bin/docker /usr/local/bin/
-
-# Add buildx plugin from github
-RUN mkdir -p /root/.docker/cli-plugins/ && curl -sLo /root/.docker/cli-plugins/docker-buildx https://github.com/docker/buildx/releases/download/v0.4.2/buildx-v0.4.2.linux-amd64 && chmod a+x /root/.docker/cli-plugins/*
+COPY --from=docker.io/library/docker:20.10.14 /usr/local/bin/docker /usr/local/bin/
+# Add buildx plugin
+COPY --from=docker.io/docker/buildx-bin:0.8.1 /buildx /usr/libexec/docker/cli-plugins/docker-buildx
 
 # Add scripts
 COPY image-mirror.sh entrypoint.sh /


### PR DESCRIPTION
@cbron Who owns and maintains this repository? Do we have a test environment for it or should I test this change on my own account?

This bump should boost performance but I have other changes in queue (like seeing how we can reduce the 30 minutes build time further and/or move up processing the added images first)