### PR TITLE
bump images for epinio v1

### DIFF
--- a/images-list
+++ b/images-list
@@ -141,7 +141,9 @@ ghcr.io/banzaicloud/logging-operator rancher/mirrored-banzaicloud-logging-operat
 ghcr.io/banzaicloud/logging-operator rancher/mirrored-banzaicloud-logging-operator 3.17.3
 ghcr.io/banzaicloud/logging-operator rancher/mirrored-banzaicloud-logging-operator 3.17.4
 ghcr.io/epinio/epinio-server rancher/mirrored-epinio-epinio-server 0.7.1
+ghcr.io/epinio/epinio-server rancher/mirrored-epinio-epinio-server v1.0.0
 ghcr.io/epinio/epinio-ui rancher/mirrored-epinio-epinio-ui v0.6.2-0.0.1
+ghcr.io/epinio/epinio-ui rancher/mirrored-epinio-epinio-ui v1.0.0-0.0.4
 grafana/grafana rancher/grafana-grafana 7.1.5
 grafana/grafana rancher/grafana-grafana 7.2.1
 grafana/grafana rancher/mirrored-grafana-grafana 6.7.4
@@ -462,7 +464,9 @@ longhornio/longhorn-ui rancher/mirrored-longhornio-longhorn-ui v1.2.4
 messagebird/sachet rancher/mirrored-messagebird-sachet 0.2.3
 messagebird/sachet rancher/mirrored-messagebird-sachet 0.2.6
 minio/mc rancher/mirrored-minio-mc RELEASE.2020-07-13T18-09-56Z
+minio/mc rancher/mirrored-minio-mc RELEASE.2022-05-09T04-08-26Z
 minio/minio rancher/mirrored-minio-minio RELEASE.2020-07-13T18-09-56Z
+minio/minio rancher/mirrored-minio-minio RELEASE.2022-05-08T23-50-31Z
 neuvector/controller rancher/mirrored-neuvector-controller 5.0.0
 neuvector/controller rancher/mirrored-neuvector-controller 5.0.0-b1
 neuvector/controller rancher/mirrored-neuvector-controller 5.0.0-b2


### PR DESCRIPTION
#### Pull Request Checklist ####

Followup on https://github.com/rancher/image-mirror/pull/239

- [x] Change does not remove any existing Images or Tags in the images-list file
- [x] Change does not remove / overwrite exiting Images or Tags in Rancher DockerHub
- [ ] If updating an existing entry, verify the `SOURCE` is still accurate and upstream hasn't been migrated to a new registry or repo (if they've migrated, a new repo request to EIO is needed to comply with the `SOURCE DESTINATION TAG` pattern)
- [x] New entries are in format `SOURCE DESTINATION TAG`
- [x] New entries are added to the correct section of the list (sorted lexicographically)
- [x] New entries have a repo created in Rancher Dockerhub (where the image will be mirrored to)
- [ ] Changes to scripting or CI config have been tested to the best of your ability

#### Types of Change ####

New images for the bump of epinio to v1.0.0.

#### Linked Issues ####

See https://github.com/rancher/charts/pull/1814 

#### Final Checks after the PR is merged ####
- [ ] Confirm that you can pull the new images and tags from DockerHub
