### PR TITLE
bump aws-cli image used by epinio

### DIFF
--- a/images-list
+++ b/images-list
@@ -4,6 +4,7 @@
 #
 # LIST FORMAT: <SOURCE> <DESTINATION> <TAG>
 amazon/aws-cli rancher/mirrored-amazon-aws-cli 2.0.52
+amazon/aws-cli rancher/mirrored-amazon-aws-cli 2.8.5
 appscode/kubed rancher/mirrored-appscode-kubed v0.13.2
 banzaicloud/fluentd rancher/banzaicloud-fluentd v1.11.2-alpine-2
 banzaicloud/fluentd rancher/banzaicloud-fluentd v1.11.4-alpine-1


### PR DESCRIPTION
#### Pull Request Checklist ####

- [x] Change does not remove any existing Images or Tags in the images-list file
- [x] Change does not remove / overwrite exiting Images or Tags in Rancher DockerHub
- [x] If updating an existing entry, verify the `SOURCE` is still accurate and upstream hasn't been migrated to a new registry or repo (if they've migrated, a new repo request to EIO is needed to comply with the `SOURCE DESTINATION TAG` pattern)
- [x] New entries are in format `SOURCE DESTINATION TAG`
- [x] New entries are added to the correct section of the list (sorted lexicographically)
- [x] New entries have a repo created in Rancher Dockerhub (where the image will be mirrored to)
- [ ] Changes to scripting or CI config have been tested to the best of your ability

#### Types of Change ####

Additional/New version for existing image

#### Linked Issues ####

See https://github.com/rancherlabs/image-scanning/issues/1454 for origin

#### Final Checks after the PR is merged ####
- [ ] Confirm that you can pull the new images and tags from DockerHub