### PR TITLE
Add images for kubernetes-csi/external-snapshotter

### DIFF
--- a/images-list
+++ b/images-list
@@ -972,6 +972,8 @@ rancher/coreos-flannel rancher/mirrored-coreos-flannel v0.12.0
 rancher/metrics-server rancher/mirrored-metrics-server v0.3.4
 rancher/metrics-server rancher/mirrored-metrics-server v0.3.6
 rancher/nginx-ingress-controller-defaultbackend rancher/mirrored-nginx-ingress-controller-defaultbackend 1.5-rancher1
+registry.k8s.io/sig-storage/snapshot-controller rancher/mirrored-sig-storage-snapshot-controller v6.1.0
+registry.k8s.io/sig-storage/snapshot-validation-webhook rancher/mirrored-sig-storage-snapshot-validation-webhook v6.1.0
 registry.suse.com/bci/bci-busybox rancher/mirrored-bci-busybox 15.4.11.2
 registry.suse.com/bci/bci-micro rancher/mirrored-bci-micro 15.4.14.3
 rpardini/docker-registry-proxy rancher/rpardini-docker-registry-proxy 0.6.1


### PR DESCRIPTION
Signed-off-by: Brad Davidson <brad.davidson@rancher.com>

#### Pull Request Checklist ####

- [x] Change does not remove any existing Images or Tags in the images-list file
- [x] Change does not remove / overwrite exiting Images or Tags in Rancher DockerHub
- [x] New entries are in format `SOURCE DESTINATION TAG`
- [x] New entries are added to the correct section of the list (sorted lexicographically)
- [x] New entries have a repo created in Rancher Dockerhub (where the image will be mirrored to)
- [x] New entries are licensed with Rancher favored licenses - Apache 2 and MIT - or approved licenses - as according to [CNCF approved licenses](https://github.com/cncf/foundation/blob/main/allowed-third-party-license-policy.md).

#### Types of Change ####

new image

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/2865

#### Additional Notes ####

EIO repo creation request:
* https://github.com/rancherlabs/eio/issues/1377

#### Final Checks after the PR is merged ####
- [ ] Confirm that you can pull the new images and tags from DockerHub