### PR TITLE
images for epinio 1.4.0 - mostly just new tags, one new image

### DIFF
--- a/images-list
+++ b/images-list
@@ -184,9 +184,11 @@ ghcr.io/banzaicloud/logging-operator rancher/mirrored-banzaicloud-logging-operat
 ghcr.io/banzaicloud/logging-operator rancher/mirrored-banzaicloud-logging-operator 3.17.7
 ghcr.io/banzaicloud/logging-operator rancher/mirrored-banzaicloud-logging-operator 3.17.8
 ghcr.io/banzaicloud/logging-operator rancher/mirrored-banzaicloud-logging-operator 3.17.9
+ghcr.io/dexidp/dex rancher/mirrored-dexidp-dex v2.35.3
 ghcr.io/epinio/epinio-server rancher/mirrored-epinio-epinio-server 0.7.1
 ghcr.io/epinio/epinio-server rancher/mirrored-epinio-epinio-server v1.0.0
 ghcr.io/epinio/epinio-server rancher/mirrored-epinio-epinio-server v1.2.0
+ghcr.io/epinio/epinio-server rancher/mirrored-epinio-epinio-server v1.4.0
 ghcr.io/epinio/epinio-ui rancher/mirrored-epinio-epinio-ui v0.6.2-0.0.1
 ghcr.io/epinio/epinio-ui rancher/mirrored-epinio-epinio-ui v1.0.0-0.0.4
 ghcr.io/epinio/epinio-ui rancher/mirrored-epinio-epinio-ui v1.2.0-0.0.1
@@ -603,8 +605,10 @@ messagebird/sachet rancher/mirrored-messagebird-sachet 0.2.3
 messagebird/sachet rancher/mirrored-messagebird-sachet 0.2.6
 minio/mc rancher/mirrored-minio-mc RELEASE.2020-07-13T18-09-56Z
 minio/mc rancher/mirrored-minio-mc RELEASE.2022-05-09T04-08-26Z
+minio/mc rancher/mirrored-minio-mc RELEASE.2022-09-16T09-16-47Z
 minio/minio rancher/mirrored-minio-minio RELEASE.2020-07-13T18-09-56Z
 minio/minio rancher/mirrored-minio-minio RELEASE.2022-05-08T23-50-31Z
+minio/minio rancher/mirrored-minio-minio RELEASE.2022-09-17T00-09-45Z
 neuvector/controller rancher/mirrored-neuvector-controller 5.0.0
 neuvector/controller rancher/mirrored-neuvector-controller 5.0.0-b1
 neuvector/controller rancher/mirrored-neuvector-controller 5.0.0-b2
@@ -648,6 +652,7 @@ openpolicyagent/gatekeeper-crds rancher/mirrored-openpolicyagent-gatekeeper-crds
 openpolicyagent/gatekeeper-crds rancher/mirrored-openpolicyagent-gatekeeper-crds v3.10.0
 openzipkin/zipkin rancher/mirrored-openzipkin-zipkin 2.14.2
 paketobuildpacks/builder rancher/mirrored-paketobuildpacks-builder 0.2.95-full
+paketobuildpacks/builder rancher/mirrored-paketobuildpacks-builder 0.2.220-full
 plugins/docker rancher/mirrored-plugins-docker 18.09
 plugins/docker rancher/mirrored-plugins-docker 19.03.8
 prom/alertmanager rancher/mirrored-prom-alertmanager v0.21.0


### PR DESCRIPTION
#### Pull Request Checklist ####

- [x] Change does not remove any existing Images or Tags in the images-list file
- [x] Change does not remove / overwrite exiting Images or Tags in Rancher DockerHub
- [x] If updating an existing entry, verify the `SOURCE` is still accurate and upstream hasn't been migrated to a new regitry or repo (if they've migrated, a new repo request to EIO is needed to comply with the `SOURCE DESTINATION TAG` pattern)
- [x] New entries are in format `SOURCE DESTINATION TAG`
- [x] New entries are added to the correct section of the list (sorted lexicographically)
- [ ] New entries have a repo created in Rancher Dockerhub (where the image will be mirrored to)
- [x] New entries are licensed with Rancher favored licenses - Apache 2 and MIT - or approved licenses - as according to [CNCF approved licenses](https://github.com/cncf/foundation/blob/main/allowed-third-party-license-policy.md).
- [ ] Changes to scripting or CI config have been tested to the best of your ability

#### Types of Change ####

New tags for various images used by epinio.
One new image (dex) ... Depending on EIO PR to come. :construction: :warning: 

|origin|mirror|tag|notes|
|:---|:---|:---|:---|
| ghcr.io/dexidp/dex| rancher/mirrored-dexidp-dex| v2.35.3| :new: EIO to come :construction: |
| ghcr.io/epinio/epinio-server| rancher/mirrored-epinio-epinio-server| v1.4.0||
| minio/mc |rancher/mirrored-minio-mc| RELEASE.2022-09-16T09-16-47Z||
| minio/minio |rancher/mirrored-minio-minio| RELEASE.2022-09-17T00-09-45Z||
| paketobuildpacks/builder| rancher/mirrored-paketobuildpacks-builder| 0.2.220-full||


#### Linked Issues ####

The bump to 1.4.0 is done in the context of https://github.com/rancher/charts/pull/2191
Starting out as a security bump of a used image it is now used to bump epinio to version 1.4.0.

#### Additional Notes ####

#### Final Checks after the PR is merged ####
- [ ] Confirm that you can pull the new images and tags from DockerHub
