### PR TITLE
Bump various epinio images (aws, nginx, paketo, and minio) to reduce amount of CVEs

### DIFF
--- a/images-list
+++ b/images-list
@@ -6,6 +6,7 @@
 amazon/aws-cli rancher/mirrored-amazon-aws-cli 2.0.52
 amazon/aws-cli rancher/mirrored-amazon-aws-cli 2.8.5
 amazon/aws-cli rancher/mirrored-amazon-aws-cli 2.8.9
+amazon/aws-cli rancher/mirrored-amazon-aws-cli 2.9.0
 appscode/kubed rancher/mirrored-appscode-kubed v0.13.2
 banzaicloud/fluentd rancher/banzaicloud-fluentd v1.11.2-alpine-2
 banzaicloud/fluentd rancher/banzaicloud-fluentd v1.11.4-alpine-1
@@ -424,6 +425,7 @@ library/nginx rancher/mirrored-library-nginx 1.21.0-alpine
 library/nginx rancher/mirrored-library-nginx 1.21.1-alpine
 library/nginx rancher/mirrored-library-nginx 1.21.6-alpine
 library/nginx rancher/mirrored-library-nginx 1.23.0-alpine
+library/nginx rancher/mirrored-library-nginx 1.23.2-alpine
 library/registry rancher/mirrored-library-registry 2.7.1
 library/registry rancher/mirrored-library-registry 2.8.1
 library/traefik rancher/library-traefik 2.4.2
@@ -613,9 +615,11 @@ messagebird/sachet rancher/mirrored-messagebird-sachet 0.2.6
 minio/mc rancher/mirrored-minio-mc RELEASE.2020-07-13T18-09-56Z
 minio/mc rancher/mirrored-minio-mc RELEASE.2022-05-09T04-08-26Z
 minio/mc rancher/mirrored-minio-mc RELEASE.2022-09-16T09-16-47Z
+minio/mc rancher/mirrored-minio-mc RELEASE.2022-11-07T23-47-39Z
 minio/minio rancher/mirrored-minio-minio RELEASE.2020-07-13T18-09-56Z
 minio/minio rancher/mirrored-minio-minio RELEASE.2022-05-08T23-50-31Z
 minio/minio rancher/mirrored-minio-minio RELEASE.2022-09-17T00-09-45Z
+minio/minio rancher/mirrored-minio-minio RELEASE.2022-11-11T03-44-20Z
 neuvector/controller rancher/mirrored-neuvector-controller 5.0.0
 neuvector/controller rancher/mirrored-neuvector-controller 5.0.0-b1
 neuvector/controller rancher/mirrored-neuvector-controller 5.0.0-b2
@@ -660,6 +664,7 @@ openpolicyagent/gatekeeper-crds rancher/mirrored-openpolicyagent-gatekeeper-crds
 openzipkin/zipkin rancher/mirrored-openzipkin-zipkin 2.14.2
 paketobuildpacks/builder rancher/mirrored-paketobuildpacks-builder 0.2.95-full
 paketobuildpacks/builder rancher/mirrored-paketobuildpacks-builder 0.2.220-full
+paketobuildpacks/builder rancher/mirrored-paketobuildpacks-builder 0.2.234-full
 plugins/docker rancher/mirrored-plugins-docker 18.09
 plugins/docker rancher/mirrored-plugins-docker 19.03.8
 prom/alertmanager rancher/mirrored-prom-alertmanager v0.21.0


### PR DESCRIPTION
#### Pull Request Checklist ####

- [x] Change does not remove any existing Images or Tags in the images-list file
- [x] Change does not remove / overwrite exiting Images or Tags in Rancher DockerHub
- [x] If updating an existing entry, verify the `SOURCE` is still accurate and upstream hasn't been migrated to a new regitry or repo (if they've migrated, a new repo request to EIO is needed to comply with the `SOURCE DESTINATION TAG` pattern)
- [x] New entries are in format `SOURCE DESTINATION TAG`
- [x] New entries are added to the correct section of the list (sorted lexicographically)
- [x] New entries have a repo created in Rancher Dockerhub (where the image will be mirrored to)
- [x] New entries are licensed with Rancher favored licenses - Apache 2 and MIT - or approved licenses - as according to [CNCF approved licenses](https://github.com/cncf/foundation/blob/main/allowed-third-party-license-policy.md).
- [ ] Changes to scripting or CI config have been tested to the best of your ability

#### Types of Change ####

Updated image tags for enhanced security

#### Linked Issues ####

- https://github.com/rancherlabs/image-scanning/issues/1458
- https://github.com/rancherlabs/image-scanning/issues/1459
- https://github.com/rancherlabs/image-scanning/issues/1460
- https://github.com/rancherlabs/image-scanning/issues/1461
- https://github.com/rancherlabs/image-scanning/issues/1666

#### Additional Notes ####

#### Final Checks after the PR is merged ####
- [ ] Confirm that you can pull the new images and tags from DockerHub