### PR TITLE
Added images required for Epinio 1.5.1 and dependencies

### DIFF
--- a/images-list
+++ b/images-list
@@ -191,9 +191,11 @@ ghcr.io/epinio/epinio-server rancher/mirrored-epinio-epinio-server 0.7.1
 ghcr.io/epinio/epinio-server rancher/mirrored-epinio-epinio-server v1.0.0
 ghcr.io/epinio/epinio-server rancher/mirrored-epinio-epinio-server v1.2.0
 ghcr.io/epinio/epinio-server rancher/mirrored-epinio-epinio-server v1.4.0
+ghcr.io/epinio/epinio-server rancher/mirrored-epinio-epinio-server v1.5.1
 ghcr.io/epinio/epinio-ui rancher/mirrored-epinio-epinio-ui v0.6.2-0.0.1
 ghcr.io/epinio/epinio-ui rancher/mirrored-epinio-epinio-ui v1.0.0-0.0.4
 ghcr.io/epinio/epinio-ui rancher/mirrored-epinio-epinio-ui v1.2.0-0.0.1
+ghcr.io/epinio/epinio-ui rancher/mirrored-epinio-epinio-ui v1.5.1-0.0.3
 ghcr.io/epinio/epinio-unpacker rancher/mirrored-epinio-epinio-unpacker 1.0
 grafana/grafana rancher/grafana-grafana 7.1.5
 grafana/grafana rancher/grafana-grafana 7.2.1
@@ -984,6 +986,7 @@ quay.io/prometheus/prometheus rancher/mirrored-prometheus-prometheus v2.38.0
 quay.io/prometheus/prometheus rancher/mirrored-prom-prometheus v2.18.2
 quay.io/prometheus/prometheus rancher/prom-prometheus v2.19.2
 quay.io/prometheus/prometheus rancher/prom-prometheus v2.22.0
+quay.io/skopeo/stable rancher/mirrored-skopeo-skopeo v1.10
 quay.io/thanos/thanos rancher/mirrored-thanos-thanos v0.17.2
 quay.io/thanos/thanos rancher/mirrored-thanos-thanos v0.28.0
 quay.io/tigera/operator rancher/mirrored-calico-operator v1.15.1

--- a/images-list
+++ b/images-list
@@ -986,7 +986,7 @@ quay.io/prometheus/prometheus rancher/mirrored-prometheus-prometheus v2.38.0
 quay.io/prometheus/prometheus rancher/mirrored-prom-prometheus v2.18.2
 quay.io/prometheus/prometheus rancher/prom-prometheus v2.19.2
 quay.io/prometheus/prometheus rancher/prom-prometheus v2.22.0
-quay.io/skopeo/stable rancher/mirrored-skopeo-skopeo v1.10
+quay.io/skopeo/stable rancher/mirrored-skopeo-skopeo v1.10.0
 quay.io/thanos/thanos rancher/mirrored-thanos-thanos v0.17.2
 quay.io/thanos/thanos rancher/mirrored-thanos-thanos v0.28.0
 quay.io/tigera/operator rancher/mirrored-calico-operator v1.15.1


### PR DESCRIPTION
#### Pull Request Checklist ####

- [x] Change does not remove any existing Images or Tags in the images-list file
- [x] Change does not remove / overwrite exiting Images or Tags in Rancher DockerHub
- [x] If updating an existing entry, verify the `SOURCE` is still accurate and upstream hasn't been migrated to a new regitry or repo (if they've migrated, a new repo request to EIO is needed to comply with the `SOURCE DESTINATION TAG` pattern)
- [x] New entries are in format `SOURCE DESTINATION TAG`
- [x] New entries are added to the correct section of the list (sorted lexicographically)
- [x] New entries have a repo created in Rancher Dockerhub (where the image will be mirrored to)
- [x] New entries are licensed with Rancher favored licenses - Apache 2 and MIT - or approved licenses - as according to [CNCF approved licenses](https://github.com/cncf/foundation/blob/main/allowed-third-party-license-policy.md).
- [x] Changes to scripting or CI config have been tested to the best of your ability

#### Types of Change ####

New images for Epinio 1.5.1

  - `epinio-server`, new tag
  - `epinio-ui`, new tag
  - `skopeo/stable`, new image

#### Linked Issues ####

See https://github.com/rancher/charts/pull/2247

#### Additional Notes ####

Requisites for merging this PR

  - [x] EIO request is made for new images - https://github.com/rancherlabs/eio/issues/1405
  - [x] EIO request is processed
  - [x] EIO New repository is available

#### Final Checks after the PR is merged ####
- [ ] Confirm that you can pull the new images and tags from DockerHub