### PR TITLE
Run max 1 pipeline at a time

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -2,6 +2,9 @@
 kind: pipeline
 name: default-image-push-pull
 
+concurrency:
+  limit: 1
+
 platform:
   os: linux
   arch: amd64


### PR DESCRIPTION
Only allow Drone to run the pipeline once at the same time, to avoid conflicting tasks. Also avoids the "wait to merge til the previous pipeline run completes" which I doubt even everyone knows.