### PR TITLE
Add newer cilium images

### DIFF
--- a/images-list
+++ b/images-list
@@ -874,11 +874,16 @@ quay.io/cilium/cilium rancher/mirrored-cilium-cilium v1.12.0
 quay.io/cilium/cilium rancher/mirrored-cilium-cilium v1.12.1
 quay.io/cilium/cilium rancher/mirrored-cilium-cilium v1.12.3
 quay.io/cilium/cilium rancher/mirrored-cilium-cilium v1.12.4
+quay.io/cilium/cilium rancher/mirrored-cilium-cilium v1.12.5
 quay.io/cilium/cilium-etcd-operator rancher/mirrored-cilium-cilium-etcd-operator v2.0.7
 quay.io/cilium/clustermesh-apiserver rancher/mirrored-cilium-clustermesh-apiserver v1.12.4
+quay.io/cilium/clustermesh-apiserver rancher/mirrored-cilium-clustermesh-apiserver v1.12.5
 quay.io/cilium/hubble-relay rancher/mirrored-cilium-hubble-relay v1.12.4
+quay.io/cilium/hubble-relay rancher/mirrored-cilium-hubble-relay v1.12.5
 quay.io/cilium/hubble-ui rancher/mirrored-cilium-hubble-ui v0.9.2
+quay.io/cilium/hubble-ui rancher/mirrored-cilium-hubble-ui v0.10.0
 quay.io/cilium/hubble-ui-backend rancher/mirrored-cilium-hubble-ui-backend v0.9.2
+quay.io/cilium/hubble-ui-backend rancher/mirrored-cilium-hubble-ui-backend v0.10.0
 quay.io/cilium/operator-aws rancher/mirrored-cilium-operator-aws v1.9.4
 quay.io/cilium/operator-aws rancher/mirrored-cilium-operator-aws v1.9.6
 quay.io/cilium/operator-aws rancher/mirrored-cilium-operator-aws v1.9.8
@@ -894,6 +899,7 @@ quay.io/cilium/operator-aws rancher/mirrored-cilium-operator-aws v1.12.0
 quay.io/cilium/operator-aws rancher/mirrored-cilium-operator-aws v1.12.1
 quay.io/cilium/operator-aws rancher/mirrored-cilium-operator-aws v1.12.3
 quay.io/cilium/operator-aws rancher/mirrored-cilium-operator-aws v1.12.4
+quay.io/cilium/operator-aws rancher/mirrored-cilium-operator-aws v1.12.5
 quay.io/cilium/operator-azure rancher/mirrored-cilium-operator-azure v1.9.4
 quay.io/cilium/operator-azure rancher/mirrored-cilium-operator-azure v1.9.6
 quay.io/cilium/operator-azure rancher/mirrored-cilium-operator-azure v1.9.8
@@ -909,6 +915,7 @@ quay.io/cilium/operator-azure rancher/mirrored-cilium-operator-azure v1.12.0
 quay.io/cilium/operator-azure rancher/mirrored-cilium-operator-azure v1.12.1
 quay.io/cilium/operator-azure rancher/mirrored-cilium-operator-azure v1.12.3
 quay.io/cilium/operator-azure rancher/mirrored-cilium-operator-azure v1.12.4
+quay.io/cilium/operator-azure rancher/mirrored-cilium-operator-azure v1.12.5
 quay.io/cilium/operator-generic rancher/mirrored-cilium-operator-generic v1.9.4
 quay.io/cilium/operator-generic rancher/mirrored-cilium-operator-generic v1.9.6
 quay.io/cilium/operator-generic rancher/mirrored-cilium-operator-generic v1.9.8
@@ -924,6 +931,8 @@ quay.io/cilium/operator-generic rancher/mirrored-cilium-operator-generic v1.12.0
 quay.io/cilium/operator-generic rancher/mirrored-cilium-operator-generic v1.12.1
 quay.io/cilium/operator-generic rancher/mirrored-cilium-operator-generic v1.12.3
 quay.io/cilium/operator-generic rancher/mirrored-cilium-operator-generic v1.12.4
+quay.io/cilium/operator-generic rancher/mirrored-cilium-operator-generic v1.12.5
+quay.io/cilium/startup-script rancher/mirrored-cilium-startup-script 5e928f628f9fc644a1d2651d6cd6aecbde0e7acd
 quay.io/cilium/startup-script rancher/mirrored-cilium-startup-script 62bfbe88c17778aad7bef9fa57ff9e2d4a9ba0d8
 quay.io/cilium/startup-script rancher/mirrored-cilium-startup-script d69851597ea019af980891a4628fb36b7880ec26
 quay.io/coreos/etcd rancher/mirrored-coreos-etcd v3.5.0


### PR DESCRIPTION
#### Pull Request Checklist ####

- [x] Change does not remove any existing Images or Tags in the images-list file
- [x] Change does not remove / overwrite exiting Images or Tags in Rancher DockerHub
- [x] If updating an existing entry, verify the `SOURCE` is still accurate and upstream hasn't been migrated to a new regitry or repo (if they've migrated, a new repo request to EIO is needed to comply with the `SOURCE DESTINATION TAG` pattern)
- [x] New entries are in format `SOURCE DESTINATION TAG`
- [x] New entries are added to the correct section of the list (sorted lexicographically)
- [x] New entries have a repo created in Rancher Dockerhub (where the image will be mirrored to)
- [x] New entries are licensed with Rancher favored licenses - Apache 2 and MIT - or approved licenses - as according to [CNCF approved licenses](https://github.com/cncf/foundation/blob/main/allowed-third-party-license-policy.md).
- [x] Changes to scripting or CI config have been tested to the best of your ability

#### Types of Change ####

Version bump for images:
```
quay.io/cilium/clustermesh-apiserver:v1.12.5
quay.io/cilium/hubble-relay:v1.12.5
quay.io/cilium/hubble-ui:v0.10.0
quay.io/cilium/hubble-ui-backend:v0.10.0
quay.io/cilium/operator-aws:v1.12.5
quay.io/cilium/operator-azure:v1.12.5
quay.io/cilium/operator-generic:v1.12.5
quay.io/cilium/startup-script:5e928f628f9fc644a1d2651d6cd6aecbde0e7acd
```

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request.  -->

#### Additional Notes ####

<!-- Any additional details / test results / etc -->

#### Final Checks after the PR is merged ####
- [ ] Confirm that you can pull the new images and tags from DockerHub