### PR TITLE
Added images required for Epinio 1.6.1 and dependencies

### DIFF
--- a/images-list
+++ b/images-list
@@ -641,10 +641,13 @@ minio/mc rancher/mirrored-minio-mc RELEASE.2020-07-13T18-09-56Z
 minio/mc rancher/mirrored-minio-mc RELEASE.2022-05-09T04-08-26Z
 minio/mc rancher/mirrored-minio-mc RELEASE.2022-09-16T09-16-47Z
 minio/mc rancher/mirrored-minio-mc RELEASE.2022-11-07T23-47-39Z
+minio/mc rancher/mirrored-minio-mc RELEASE.2022-12-13T00-23-28Z
 minio/minio rancher/mirrored-minio-minio RELEASE.2020-07-13T18-09-56Z
+minio/minio rancher/mirrored-minio-minio RELEASE.2022-03-24T00-43-44Z
 minio/minio rancher/mirrored-minio-minio RELEASE.2022-05-08T23-50-31Z
 minio/minio rancher/mirrored-minio-minio RELEASE.2022-09-17T00-09-45Z
 minio/minio rancher/mirrored-minio-minio RELEASE.2022-11-11T03-44-20Z
+minio/minio rancher/mirrored-minio-minio RELEASE.2022-12-12T19-27-27Z
 neuvector/controller rancher/mirrored-neuvector-controller 5.0.0
 neuvector/controller rancher/mirrored-neuvector-controller 5.0.0-b1
 neuvector/controller rancher/mirrored-neuvector-controller 5.0.0-b2
@@ -1002,9 +1005,6 @@ quay.io/kiwigrid/k8s-sidecar rancher/mirrored-kiwigrid-k8s-sidecar 1.12.3
 quay.io/kiwigrid/k8s-sidecar rancher/mirrored-kiwigrid-k8s-sidecar 1.15.6
 quay.io/kiwigrid/k8s-sidecar rancher/mirrored-kiwigrid-k8s-sidecar 1.15.9
 quay.io/kiwigrid/k8s-sidecar rancher/mirrored-kiwigrid-k8s-sidecar 1.19.2
-quay.io/minio/mc rancher/mirrored-minio-mc RELEASE.2022-12-13T00-23-28Z
-quay.io/minio/minio rancher/mirrored-minio-minio RELEASE.2022-03-24T00-43-44Z
-quay.io/minio/minio rancher/mirrored-minio-minio RELEASE.2022-12-12T19-27-27Z
 quay.io/prometheus-operator/prometheus-config-reloader rancher/coreos-prometheus-config-reloader v0.43.0
 quay.io/prometheus-operator/prometheus-config-reloader rancher/mirrored-prometheus-operator-prometheus-config-reloader v0.46.0
 quay.io/prometheus-operator/prometheus-config-reloader rancher/mirrored-prometheus-operator-prometheus-config-reloader v0.48.0

--- a/images-list
+++ b/images-list
@@ -643,7 +643,6 @@ minio/mc rancher/mirrored-minio-mc RELEASE.2022-09-16T09-16-47Z
 minio/mc rancher/mirrored-minio-mc RELEASE.2022-11-07T23-47-39Z
 minio/mc rancher/mirrored-minio-mc RELEASE.2022-12-13T00-23-28Z
 minio/minio rancher/mirrored-minio-minio RELEASE.2020-07-13T18-09-56Z
-minio/minio rancher/mirrored-minio-minio RELEASE.2022-03-24T00-43-44Z
 minio/minio rancher/mirrored-minio-minio RELEASE.2022-05-08T23-50-31Z
 minio/minio rancher/mirrored-minio-minio RELEASE.2022-09-17T00-09-45Z
 minio/minio rancher/mirrored-minio-minio RELEASE.2022-11-11T03-44-20Z
@@ -1005,6 +1004,7 @@ quay.io/kiwigrid/k8s-sidecar rancher/mirrored-kiwigrid-k8s-sidecar 1.12.3
 quay.io/kiwigrid/k8s-sidecar rancher/mirrored-kiwigrid-k8s-sidecar 1.15.6
 quay.io/kiwigrid/k8s-sidecar rancher/mirrored-kiwigrid-k8s-sidecar 1.15.9
 quay.io/kiwigrid/k8s-sidecar rancher/mirrored-kiwigrid-k8s-sidecar 1.19.2
+quay.io/minio/minio rancher/mirrored-minio-minio RELEASE.2022-03-24T00-43-44Z
 quay.io/prometheus-operator/prometheus-config-reloader rancher/coreos-prometheus-config-reloader v0.43.0
 quay.io/prometheus-operator/prometheus-config-reloader rancher/mirrored-prometheus-operator-prometheus-config-reloader v0.46.0
 quay.io/prometheus-operator/prometheus-config-reloader rancher/mirrored-prometheus-operator-prometheus-config-reloader v0.48.0

--- a/images-list
+++ b/images-list
@@ -7,6 +7,7 @@ amazon/aws-cli rancher/mirrored-amazon-aws-cli 2.0.52
 amazon/aws-cli rancher/mirrored-amazon-aws-cli 2.8.5
 amazon/aws-cli rancher/mirrored-amazon-aws-cli 2.8.9
 amazon/aws-cli rancher/mirrored-amazon-aws-cli 2.9.0
+amazon/aws-cli rancher/mirrored-amazon-aws-cli 2.9.14
 appscode/kubed rancher/mirrored-appscode-kubed v0.13.2
 banzaicloud/fluentd rancher/banzaicloud-fluentd v1.11.2-alpine-2
 banzaicloud/fluentd rancher/banzaicloud-fluentd v1.11.4-alpine-1
@@ -197,11 +198,13 @@ ghcr.io/epinio/epinio-server rancher/mirrored-epinio-epinio-server v1.0.0
 ghcr.io/epinio/epinio-server rancher/mirrored-epinio-epinio-server v1.2.0
 ghcr.io/epinio/epinio-server rancher/mirrored-epinio-epinio-server v1.4.0
 ghcr.io/epinio/epinio-server rancher/mirrored-epinio-epinio-server v1.5.1
+ghcr.io/epinio/epinio-server rancher/mirrored-epinio-epinio-server v1.6.1
 ghcr.io/epinio/epinio-ui rancher/mirrored-epinio-epinio-ui v0.6.2-0.0.1
 ghcr.io/epinio/epinio-ui rancher/mirrored-epinio-epinio-ui v1.0.0-0.0.4
 ghcr.io/epinio/epinio-ui rancher/mirrored-epinio-epinio-ui v1.2.0-0.0.1
 ghcr.io/epinio/epinio-ui rancher/mirrored-epinio-epinio-ui v1.5.1-0.0.3
 ghcr.io/epinio/epinio-unpacker rancher/mirrored-epinio-epinio-unpacker 1.0
+ghcr.io/epinio/epinio-unpacker rancher/mirrored-epinio-epinio-unpacker 1.6.1
 grafana/grafana rancher/grafana-grafana 7.1.5
 grafana/grafana rancher/grafana-grafana 7.2.1
 grafana/grafana rancher/mirrored-grafana-grafana 6.7.4
@@ -690,6 +693,7 @@ openzipkin/zipkin rancher/mirrored-openzipkin-zipkin 2.14.2
 paketobuildpacks/builder rancher/mirrored-paketobuildpacks-builder 0.2.95-full
 paketobuildpacks/builder rancher/mirrored-paketobuildpacks-builder 0.2.220-full
 paketobuildpacks/builder rancher/mirrored-paketobuildpacks-builder 0.2.234-full
+paketobuildpacks/builder rancher/mirrored-paketobuildpacks-builder 0.2.289-full
 plugins/docker rancher/mirrored-plugins-docker 18.09
 plugins/docker rancher/mirrored-plugins-docker 19.03.8
 prom/alertmanager rancher/mirrored-prom-alertmanager v0.21.0
@@ -998,7 +1002,9 @@ quay.io/kiwigrid/k8s-sidecar rancher/mirrored-kiwigrid-k8s-sidecar 1.12.3
 quay.io/kiwigrid/k8s-sidecar rancher/mirrored-kiwigrid-k8s-sidecar 1.15.6
 quay.io/kiwigrid/k8s-sidecar rancher/mirrored-kiwigrid-k8s-sidecar 1.15.9
 quay.io/kiwigrid/k8s-sidecar rancher/mirrored-kiwigrid-k8s-sidecar 1.19.2
+quay.io/minio/mc rancher/mirrored-minio-mc RELEASE.2022-12-13T00-23-28Z
 quay.io/minio/minio rancher/mirrored-minio-minio RELEASE.2022-03-24T00-43-44Z
+quay.io/minio/minio rancher/mirrored-minio-minio RELEASE.2022-12-12T19-27-27Z
 quay.io/prometheus-operator/prometheus-config-reloader rancher/coreos-prometheus-config-reloader v0.43.0
 quay.io/prometheus-operator/prometheus-config-reloader rancher/mirrored-prometheus-operator-prometheus-config-reloader v0.46.0
 quay.io/prometheus-operator/prometheus-config-reloader rancher/mirrored-prometheus-operator-prometheus-config-reloader v0.48.0


### PR DESCRIPTION
#### Pull Request Checklist ####

- [x] Change does not remove any existing Images or Tags in the images-list file
- [x] Change does not remove / overwrite exiting Images or Tags in Rancher DockerHub
- [x] If updating an existing entry, verify the `SOURCE` is still accurate and upstream hasn't been migrated to a new registry or repo (if they've migrated, a new repo request to EIO is needed to comply with the `SOURCE DESTINATION TAG` pattern)
- [x] New entries are in format `SOURCE DESTINATION TAG`
- [x] New entries are added to the correct section of the list (sorted lexicographically)
- [x] New entries have a repo created in Rancher Dockerhub (where the image will be mirrored to)
- [x] New entries are licensed with Rancher favored licenses - Apache 2 and MIT - or approved licenses - as according to [CNCF approved licenses](https://github.com/cncf/foundation/blob/main/allowed-third-party-license-policy.md).
- [x] Changes to scripting or CI config have been tested to the best of your ability

#### Types of Change ####

Images for Epinio 1.6.1

|Name|Version|
|---|---|
|aws-cli|2.9.14|
|epinio-server|1.6.1|
|epinio-unpacker|1.6.1|
|paketobuildpacks|0.2.298-full|
|minio,mc|5.0.4 (chart version)|

#### Linked Issues ####

https://github.com/epinio/epinio/issues/2036

#### Additional Notes ####

<!-- Any additional details / test results / etc -->

#### Final Checks after the PR is merged ####
- [ ] Confirm that you can pull the new images and tags from DockerHub