### PR TITLE
epinio 1.6.2 images

### DIFF
--- a/images-list
+++ b/images-list
@@ -199,12 +199,14 @@ ghcr.io/epinio/epinio-server rancher/mirrored-epinio-epinio-server v1.2.0
 ghcr.io/epinio/epinio-server rancher/mirrored-epinio-epinio-server v1.4.0
 ghcr.io/epinio/epinio-server rancher/mirrored-epinio-epinio-server v1.5.1
 ghcr.io/epinio/epinio-server rancher/mirrored-epinio-epinio-server v1.6.1
+ghcr.io/epinio/epinio-server rancher/mirrored-epinio-epinio-server v1.6.2
 ghcr.io/epinio/epinio-ui rancher/mirrored-epinio-epinio-ui v0.6.2-0.0.1
 ghcr.io/epinio/epinio-ui rancher/mirrored-epinio-epinio-ui v1.0.0-0.0.4
 ghcr.io/epinio/epinio-ui rancher/mirrored-epinio-epinio-ui v1.2.0-0.0.1
 ghcr.io/epinio/epinio-ui rancher/mirrored-epinio-epinio-ui v1.5.1-0.0.3
 ghcr.io/epinio/epinio-unpacker rancher/mirrored-epinio-epinio-unpacker 1.0
 ghcr.io/epinio/epinio-unpacker rancher/mirrored-epinio-epinio-unpacker v1.6.1
+ghcr.io/epinio/epinio-unpacker rancher/mirrored-epinio-epinio-unpacker v1.6.2
 grafana/grafana rancher/grafana-grafana 7.1.5
 grafana/grafana rancher/grafana-grafana 7.2.1
 grafana/grafana rancher/mirrored-grafana-grafana 6.7.4


### PR DESCRIPTION
#### Pull Request Checklist ####

- [x] Change does not remove any existing Images or Tags in the images-list file
- [x] Change does not remove / overwrite exiting Images or Tags in Rancher DockerHub
- [x] If updating an existing entry, verify the `SOURCE` is still accurate and upstream hasn't been migrated to a new regitry or repo (if they've migrated, a new repo request to EIO is needed to comply with the `SOURCE DESTINATION TAG` pattern)
- [x] New entries are in format `SOURCE DESTINATION TAG`
- [x] New entries are added to the correct section of the list (sorted lexicographically)
- [x] New entries have a repo created in Rancher Dockerhub (where the image will be mirrored to)
- [x] New entries are licensed with Rancher favored licenses - Apache 2 and MIT - or approved licenses - as according to [CNCF approved licenses](https://github.com/cncf/foundation/blob/main/allowed-third-party-license-policy.md).
- [x] Changes to scripting or CI config have been tested to the best of your ability

#### Types of Change ####

New epinio release 1.6.2. No changes to dependencies.

#### Linked Issues ####

- Release: https://github.com/epinio/epinio/releases/tag/v1.6.2
- Chart use: https://github.com/rancher/charts/pull/2401
 
#### Additional Notes ####

#### Final Checks after the PR is merged ####
- [ ] Confirm that you can pull the new images and tags from DockerHub