### PR TITLE
Do not proceed if image/manifest does not exist

### DIFF
--- a/scripts/image-mirror.sh
+++ b/scripts/image-mirror.sh
@@ -101,6 +101,11 @@ function mirror_image {
 
   # Grab raw manifest or manifest list and extract schema info
   MANIFEST=$(skopeo inspect docker://${SOURCE}:${TAG} --raw)
+  # Return if it doesn't exist
+  if [ $? -ne 0 ]; then
+    echo "${SOURCE}:${TAG} does not exist"
+    return 1
+  fi
   SCHEMAVERSION=$(jq -r '.schemaVersion' <<< ${MANIFEST})
   MEDIATYPE=$(jq -r '.mediaType' <<< ${MANIFEST})
   SOURCES=()


### PR DESCRIPTION
Currently, the image still gets processed even if the `skopeo inspect` returns an error. This should save time and allow us to grep the log files more easily to find non-existent images (to clean up)