### PR TITLE
CoreDNS 1.8.1 was never properly released/mirrored

### DIFF
--- a/images-list
+++ b/images-list
@@ -33,7 +33,6 @@ bats/bats rancher/mirrored-bats-bats v1.4.1
 coredns/coredns rancher/coredns-coredns 1.7.0
 coredns/coredns rancher/coredns-coredns 1.7.1
 coredns/coredns rancher/coredns-coredns 1.8.0
-coredns/coredns rancher/coredns-coredns 1.8.1
 coredns/coredns rancher/coredns-coredns 1.8.3
 coredns/coredns rancher/mirrored-coredns-coredns 1.6.2
 coredns/coredns rancher/mirrored-coredns-coredns 1.6.5


### PR DESCRIPTION
See https://github.com/coredns/coredns/issues/4418 and https://github.com/rancher/rancher/issues/30134#issuecomment-769556753

It has never been mirrored, does not exist in our Docker Hub.