### PR TITLE
Correct tag for epinio-server:v0.7.1

### DIFF
--- a/images-list
+++ b/images-list
@@ -194,7 +194,7 @@ ghcr.io/banzaicloud/logging-operator rancher/mirrored-banzaicloud-logging-operat
 ghcr.io/banzaicloud/logging-operator rancher/mirrored-banzaicloud-logging-operator 3.17.9
 ghcr.io/banzaicloud/logging-operator rancher/mirrored-banzaicloud-logging-operator 3.17.10
 ghcr.io/dexidp/dex rancher/mirrored-dexidp-dex v2.35.3
-ghcr.io/epinio/epinio-server rancher/mirrored-epinio-epinio-server 0.7.1
+ghcr.io/epinio/epinio-server rancher/mirrored-epinio-epinio-server v0.7.1
 ghcr.io/epinio/epinio-server rancher/mirrored-epinio-epinio-server v1.0.0
 ghcr.io/epinio/epinio-server rancher/mirrored-epinio-epinio-server v1.2.0
 ghcr.io/epinio/epinio-server rancher/mirrored-epinio-epinio-server v1.4.0

--- a/scripts/check-new-images-exist.sh
+++ b/scripts/check-new-images-exist.sh
@@ -7,7 +7,7 @@ fi
 
 echo "Checking for new images in commit(s) against ${DIFF_CHECK}"
 
-NEW_IMAGES=$(git diff -U0 $DIFF_CHECK -- images-list | tail -n +5 | grep -v ^@@ | cut -d+ -f2 | awk '{ print $1":"$3 }')
+NEW_IMAGES=$(git diff -U0 $DIFF_CHECK -- images-list | tail -n +5 | grep -v ^@@ | grep -v ^- | cut -d+ -f2 | awk '{ print $1":"$3 }')
 
 if [ -z "${NEW_IMAGES}" ]; then
   echo "Could not find new images in commit(s) against ${DIFF_CHECK}"


### PR DESCRIPTION
Checked with @andreas-kupries, tag `0.7.1` was never mirrored and `v0.7.1` does exist. Decision was to correct it so any potential usage of `v0.7.1` is going to work.

Also included a fix to the check script to ignore removed images.