### PR TITLE
Cleanup non existent minio/mc tag

### DIFF
--- a/images-list
+++ b/images-list
@@ -639,7 +639,6 @@ longhornio/support-bundle-kit rancher/mirrored-longhornio-support-bundle-kit v0.
 messagebird/sachet rancher/mirrored-messagebird-sachet 0.2.3
 messagebird/sachet rancher/mirrored-messagebird-sachet 0.2.6
 messagebird/sachet rancher/mirrored-messagebird-sachet 0.3.1
-minio/mc rancher/mirrored-minio-mc RELEASE.2020-07-13T18-09-56Z
 minio/mc rancher/mirrored-minio-mc RELEASE.2022-05-09T04-08-26Z
 minio/mc rancher/mirrored-minio-mc RELEASE.2022-09-16T09-16-47Z
 minio/mc rancher/mirrored-minio-mc RELEASE.2022-11-07T23-47-39Z


### PR DESCRIPTION
Tag `RELEASE.2020-07-13T18-09-56Z` was released for `minio/minio` (see https://github.com/minio/minio/releases/tag/RELEASE.2020-07-13T18-09-56Z) but never for `minio/mc` (see non existent tag https://github.com/minio/mc/releases/tag/RELEASE.2020-07-13T18-09-56Z).

It also has never been mirrored (https://hub.docker.com/r/rancher/mirrored-minio-mc/tags)

Checked with @andreas-kupries