### PR TITLE
Cleanup non existent flannel tag v0.19.2

### DIFF
--- a/images-list
+++ b/images-list
@@ -971,7 +971,6 @@ quay.io/coreos/flannel rancher/mirrored-coreos-flannel v0.13.0
 quay.io/coreos/flannel rancher/mirrored-coreos-flannel v0.14.0
 quay.io/coreos/flannel rancher/mirrored-coreos-flannel v0.15.0
 quay.io/coreos/flannel rancher/mirrored-coreos-flannel v0.15.1
-quay.io/coreos/flannel rancher/mirrored-coreos-flannel v0.19.2
 quay.io/coreos/kube-state-metrics rancher/mirrored-coreos-kube-state-metrics v1.9.7
 quay.io/coreos/prometheus-config-reloader rancher/coreos-prometheus-config-reloader v0.39.0
 quay.io/coreos/prometheus-config-reloader rancher/mirrored-coreos-prometheus-config-reloader v0.38.1


### PR DESCRIPTION
This image does not exist in quay.io, it was added in [a k8s 1.25 PR](https://github.com/rancher/image-mirror/commit/8f58c79b73261ed6437e65cb5908acea0917c1f8) and corrected to the correct image in [this KDM PR](https://github.com/rancher/kontainer-driver-metadata/commit/c4a687bbfbb527559a0264231e2afb7391f65ec8#diff-946512550baddbb48e0b41424179a72358b7d614165c87b1eb0bf0b09cd617d2R8389).

v0.19.2 has also never been mirrored at `rancher/mirrored-coreos-flannel` (https://hub.docker.com/r/rancher/mirrored-coreos-flannel/tags)

Checked with @jiaqiluo 