### PR TITLE
Use CODEOWNERS group to reduce review noise

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @brandond @superseb @Oats87 @cbron @kinarashah @aiyengar2 @snasovich @prachidamle
+* @rancher/image-mirror-codeowners


### PR DESCRIPTION
Having the group as automatically requested reviewer will reduce review noise as it will be cleared from the other reviewers as soon as someone approves it.