### PR TITLE
Add latest ingress-nginx/kube-webhook-certgen tag

### DIFF
--- a/images-list
+++ b/images-list
@@ -406,6 +406,7 @@ k8s.gcr.io/git-sync/git-sync rancher/mirrored-git-sync v3.5.0
 k8s.gcr.io/ingress-nginx/kube-webhook-certgen rancher/mirrored-ingress-nginx-kube-webhook-certgen v1.0
 k8s.gcr.io/ingress-nginx/kube-webhook-certgen rancher/mirrored-ingress-nginx-kube-webhook-certgen v1.1.1
 k8s.gcr.io/ingress-nginx/kube-webhook-certgen rancher/mirrored-ingress-nginx-kube-webhook-certgen v1.3.0
+k8s.gcr.io/ingress-nginx/kube-webhook-certgen rancher/mirrored-ingress-nginx-kube-webhook-certgen v20230312-helm-chart-4.5.2-28-g66a760794
 k8s.gcr.io/kube-state-metrics/kube-state-metrics rancher/mirrored-kube-state-metrics-kube-state-metrics v1.9.8
 k8s.gcr.io/kube-state-metrics/kube-state-metrics rancher/mirrored-kube-state-metrics-kube-state-metrics v2.0.0
 k8s.gcr.io/kube-state-metrics/kube-state-metrics rancher/mirrored-kube-state-metrics-kube-state-metrics v2.2.0


### PR DESCRIPTION
Signed-off-by: Derek Nola <derek.nola@suse.com>

#### Pull Request Checklist ####

- [x] Change does not remove any existing Images or Tags in the images-list file
- [x] Change does not remove / overwrite exiting Images or Tags in Rancher DockerHub
- [x] If updating an existing entry, verify the `SOURCE` is still accurate and upstream hasn't been migrated to a new regitry or repo (if they've migrated, a new repo request to EIO is needed to comply with the `SOURCE DESTINATION TAG` pattern)
- [ ] New entries are in format `SOURCE DESTINATION TAG`
- [ ] New entries are added to the correct section of the list (sorted lexicographically)
- [ ] New entries have a repo created in Rancher Dockerhub (where the image will be mirrored to)
- [ ] New entries are licensed with Rancher favored licenses - Apache 2 and MIT - or approved licenses - as according to [CNCF approved licenses](https://github.com/cncf/foundation/blob/main/allowed-third-party-license-policy.md).
- [ ] Changes to scripting or CI config have been tested to the best of your ability

#### Types of Change ####
The ingress-nginx/kube-webhook-certgen avaliable is old, last published 8 months ago. The tag is weird becuase upstream no longer published versioned tags, they are based off commit now. 
This is needed for rke2 charts to support the latest hardened ingress-nginx controller. 
This is the last of the `k8s.gcr.io` for this image, future bumps will need to be moved to `registry.k8s.io`.
<!-- New image, version bump. script update, etc etc -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request.  -->

#### Additional Notes ####

<!-- Any additional details / test results / etc -->

#### Final Checks after the PR is merged ####
- [ ] Confirm that you can pull the new images and tags from DockerHub