### PR TITLE
Bump traefik tag and add action config to auto-bump

### DIFF
--- a/images-list
+++ b/images-list
@@ -420,6 +420,7 @@ library/traefik rancher/mirrored-library-traefik 2.6.2
 library/traefik rancher/mirrored-library-traefik 2.8.7
 library/traefik rancher/mirrored-library-traefik 2.9.1
 library/traefik rancher/mirrored-library-traefik 2.9.4
+library/traefik rancher/mirrored-library-traefik 2.9.10
 longhornio/backing-image-manager rancher/longhornio-backing-image-manager v1_20210422
 longhornio/backing-image-manager rancher/longhornio-backing-image-manager v1_20210422_patch1
 longhornio/backing-image-manager rancher/longhornio-backing-image-manager v2_20210820

--- a/retrieve-image-tags/config.json
+++ b/retrieve-image-tags/config.json
@@ -4,5 +4,13 @@
       "flannel/flannel"
     ],
     "versionSource": "github-latest-release:flannel-io/flannel"
+  },
+  "traefik": {
+    "images": [
+      "library/traefik"
+    ],
+    "versionSource": "registry",
+    "versionFilter": "^2\\.[0-9]+\\.[0-9]+$",
+    "latest": true
   }
 }


### PR DESCRIPTION
#### Pull Request Checklist ####

- [x] Change does not remove any existing Images or Tags in the images-list file
- [x] Change does not remove / overwrite exiting Images or Tags in Rancher DockerHub
- [x] If updating an existing entry, verify the `SOURCE` is still accurate and upstream hasn't been migrated to a new regitry or repo (if they've migrated, a new repo request to EIO is needed to comply with the `SOURCE DESTINATION TAG` pattern)
- [x] New entries are in format `SOURCE DESTINATION TAG`
- [x] New entries are added to the correct section of the list (sorted lexicographically)
- [x] New entries have a repo created in Rancher Dockerhub (where the image will be mirrored to)

#### Types of Change ####

version bump

#### Linked Issues ####

https://github.com/k3s-io/k3s/issues/7301

#### Additional Notes ####

<!-- Any additional details / test results / etc -->

#### Final Checks after the PR is merged ####
- [ ] Confirm that you can pull the new images and tags from DockerHub