### PR TITLE
Add  k8s-gmsa-webhook v0.6.1

### DIFF
--- a/images-list
+++ b/images-list
@@ -1106,6 +1106,7 @@ registry.k8s.io/dns/k8s-dns-sidecar rancher/mirrored-k8s-dns-sidecar 1.21.1
 registry.k8s.io/dns/k8s-dns-sidecar rancher/mirrored-k8s-dns-sidecar 1.22.8
 registry.k8s.io/dns/k8s-dns-sidecar rancher/mirrored-k8s-dns-sidecar 1.22.20
 registry.k8s.io/git-sync/git-sync rancher/mirrored-git-sync v3.5.0
+registry.k8s.io/gmsa-webhook/k8s-gmsa-webhook rancher/mirrored-sigwindowstools-k8s-gmsa-webhook v0.6.1
 registry.k8s.io/ingress-nginx/kube-webhook-certgen rancher/mirrored-ingress-nginx-kube-webhook-certgen v1.0
 registry.k8s.io/ingress-nginx/kube-webhook-certgen rancher/mirrored-ingress-nginx-kube-webhook-certgen v1.1.1
 registry.k8s.io/ingress-nginx/kube-webhook-certgen rancher/mirrored-ingress-nginx-kube-webhook-certgen v1.3.0


### PR DESCRIPTION
#### Pull Request Checklist ####

- [x] Change does not remove any existing Images or Tags in the images-list file
- [x] Change does not remove / overwrite exiting Images or Tags in Rancher DockerHub
- [x] If updating an existing entry, verify the `SOURCE` is still accurate and upstream hasn't been migrated to a new registry or repo (if they've migrated, a new repo request to EIO is needed to comply with the `SOURCE DESTINATION TAG` pattern)
- [x] New entries are in format `SOURCE DESTINATION TAG`
- [x] New entries are added to the correct section of the list (sorted lexicographically)
- [x] New entries have a repo created in Rancher Dockerhub (where the image will be mirrored to) - **Done during initial introduction of the 0.3.0 tag**
- [x] todo: New entries are licensed with Rancher favored licenses - Apache 2 and MIT - or approved licenses - as according to [CNCF approved licenses](https://github.com/cncf/foundation/blob/main/allowed-third-party-license-policy.md). - **This image uses Apache 2**
- [x] Changes to scripting or CI config have been tested to the best of your ability - **no changes made**

#### Types of Change ####

<!-- New image, version bump. script update, etc etc -->
Mirror the latest version of the kubernetes-sig's windows-gmsa web-hook image, v0.6.1. This new image will be referenced by the newest version of the windows-gmsa chart offered by Rancher, and comes from the new Kubernetes registry. 

#### Linked Issues ####
https://github.com/rancher/windows/issues/22
https://github.com/rancher/charts/pull/2590

#### Additional Notes ####


#### Final Checks after the PR is merged ####
- [ ] Confirm that you can pull the new images and tags from DockerHub