### PR TITLE
add tag 1.24.0-alpine for nginx

### DIFF
--- a/images-list
+++ b/images-list
@@ -412,6 +412,7 @@ library/nginx rancher/mirrored-library-nginx 1.21.1-alpine
 library/nginx rancher/mirrored-library-nginx 1.21.6-alpine
 library/nginx rancher/mirrored-library-nginx 1.23.0-alpine
 library/nginx rancher/mirrored-library-nginx 1.23.2-alpine
+library/nginx rancher/mirrored-library-nginx 1.24.0-alpine
 library/registry rancher/mirrored-library-registry 2.7.1
 library/registry rancher/mirrored-library-registry 2.8.1
 library/traefik rancher/library-traefik 2.4.2


### PR DESCRIPTION
#### Pull Request Checklist ####

- [x] Change does not remove any existing Images or Tags in the images-list file
- [x] Change does not remove / overwrite exiting Images or Tags in Rancher DockerHub
- [x] If updating an existing entry, verify the `SOURCE` is still accurate and upstream hasn't been migrated to a new regitry or repo (if they've migrated, a new repo request to EIO is needed to comply with the `SOURCE DESTINATION TAG` pattern)
- [x] New entries are in format `SOURCE DESTINATION TAG`
- [x] New entries are added to the correct section of the list (sorted lexicographically)
- [ ] ~New entries have a repo created in Rancher Dockerhub (where the image will be mirrored to)~
- [ ] ~New entries are licensed with Rancher favored licenses - Apache 2 and MIT - or approved licenses - as according to [CNCF approved licenses](https://github.com/cncf/foundation/blob/main/allowed-third-party-license-policy.md).~
- [ ] ~Changes to scripting or CI config have been tested to the best of your ability~

#### Types of Change ####

<!-- New image, version bump. script update, etc etc -->

`rancher/mirrored-library-nginx` version bump to `1.24.0-alpine`

#### Linked Issues ####

https://github.com/rancher/charts/pull/2589

#### Additional Notes ####

#### Final Checks after the PR is merged ####
- [ ] Confirm that you can pull the new images and tags from DockerHub