### PR TITLE
add the latest tag for images used in the rancher-vsphere-csi and rancher-vsphere-cpi charts

### DIFF
--- a/images-list-daily
+++ b/images-list-daily
@@ -2,5 +2,13 @@
 # See images-list for more information
 #
 # LIST FORMAT: <SOURCE> <DESTINATION> <TAG>
+gcr.io/cloud-provider-vsphere/cpi/release/manager rancher/mirrored-cloud-provider-vsphere-cpi-release-manager latest
+gcr.io/cloud-provider-vsphere/csi/release/driver rancher/mirrored-cloud-provider-vsphere-csi-release-driver latest
+gcr.io/cloud-provider-vsphere/csi/release/syncer rancher/mirrored-cloud-provider-vsphere-csi-release-syncer latest
 neuvector/scanner rancher/mirrored-neuvector-scanner latest
 neuvector/updater rancher/mirrored-neuvector-updater latest
+registry.k8s.io/sig-storage/csi-attacher rancher/mirrored-sig-storage-csi-attacher latest
+registry.k8s.io/sig-storage/csi-node-driver-registrar rancher/mirrored-sig-storage-csi-node-driver-registrar latest
+registry.k8s.io/sig-storage/csi-provisioner rancher/mirrored-sig-storage-csi-provisioner latest
+registry.k8s.io/sig-storage/csi-resizer rancher/mirrored-sig-storage-csi-resizer latest
+registry.k8s.io/sig-storage/livenessprobe rancher/mirrored-sig-storage-livenessprobe latest


### PR DESCRIPTION

#### Pull Request Checklist ####

- [x] Change does not remove any existing Images or Tags in the images-list file
- [x] Change does not remove / overwrite exiting Images or Tags in Rancher DockerHub
- [ ] If updating an existing entry, verify the `SOURCE` is still accurate and upstream hasn't been migrated to a new regitry or repo (if they've migrated, a new repo request to EIO is needed to comply with the `SOURCE DESTINATION TAG` pattern)
- [x] New entries are in format `SOURCE DESTINATION TAG`
- [x] New entries are added to the correct section of the list (sorted lexicographically)
- [x] New entries have a repo created in Rancher Dockerhub (where the image will be mirrored to)
- [x] New entries are licensed with Rancher favored licenses - Apache 2 and MIT - or approved licenses - as according to [CNCF approved licenses](https://github.com/cncf/foundation/blob/main/allowed-third-party-license-policy.md).
- [ ] Changes to scripting or CI config have been tested to the best of your ability

#### Types of Change ####

<!-- New image, version bump. script update, etc etc -->

New tags for existing images 


#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request.  -->

https://github.com/rancher/rancher/issues/40908


#### Additional Notes ####

<!-- Any additional details / test results / etc -->

The tag `latest` is used in the `rancher-vsphere-csi` and `rancher-vsphere-cpi` charts ([PR](https://github.com/rancher/vsphere-charts/pull/55)). 

Note that the `latest` tags are actually not used, and here is why:

In the vSphere chart, the image tags are overwritten by the `versionOverrides` directives based on the cluster k8s version in the value.yaml file ( [here](https://github.com/rancher/vsphere-charts/blob/main/charts/rancher-vsphere-csi/values.yaml#L140C9-L140C9) and [here](https://github.com/rancher/vsphere-charts/blob/main/charts/rancher-vsphere-cpi/values.yaml)) . And the "latest" tag is only used when the chart is installed into a cluster whose version is NOT in the supported range, as [the comment in the PR](https://github.com/rancher/vsphere-charts/pull/55#discussion_r1199182875) says, "make it obvious when the version overrides are not working properly".


But we still need to mirror them, otherwise the Drone CI will not pass and report missing tags ([example](https://drone-publish.rancher.io/rancher/rancher/9924/5/9)):
```
ERROR: Summary of missing image(s):
rancher/mirrored-cloud-provider-vsphere-cpi-release-manager:latest
rancher/mirrored-cloud-provider-vsphere-csi-release-driver:latest
rancher/mirrored-cloud-provider-vsphere-csi-release-syncer:latest
rancher/mirrored-sig-storage-csi-attacher:latest
rancher/mirrored-sig-storage-csi-node-driver-registrar:latest
rancher/mirrored-sig-storage-csi-provisioner:latest
rancher/mirrored-sig-storage-csi-resizer:latest
rancher/mirrored-sig-storage-livenessprobe:latest
```

#### Final Checks after the PR is merged ####
- [ ] Confirm that you can pull the new images and tags from DockerHub