### PR TITLE
Add calico/cilium to auto PR configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ The current filters for tags are:
 
 - `versionConstraint`: This is a semver constraint that will match the given expression and ignore tags that do not match.
 - `versionFilter`: This is a regex filter that will match the given expression and ignore tags that do not match.
+- `latest`: Sorts the found tags numerically and returns only the latest tag
+- `latest_entry`: Returns the last found (newest) tag only (can be used when tags are not semver/cannot be sorted numerically)
 
 See an example configuration below:
 

--- a/retrieve-image-tags/config.json
+++ b/retrieve-image-tags/config.json
@@ -5,6 +5,48 @@
     ],
     "versionSource": "github-latest-release:flannel-io/flannel"
   },
+  "calico": {
+    "images": [
+      "quay.io/calico/apiserver",
+      "quay.io/calico/cni",
+      "quay.io/calico/ctl",
+      "quay.io/calico/kube-controllers",
+      "quay.io/calico/node",
+      "quay.io/calico/pod2daemon-flexvol",
+      "quay.io/calico/typha"
+    ],
+    "versionSource": "github-latest-release:projectcalico/calico"
+  },
+  "calico-operator": {
+    "images": [
+      "quay.io/tigera/operator"
+    ],
+    "versionSource": "github-latest-release:tigera/operator"
+  },
+  "cilium": {
+    "images": [
+      "quay.io/cilium/cilium",
+      "quay.io/cilium/clustermesh-apiserver",
+      "quay.io/cilium/hubble-relay",
+      "quay.io/cilium/operator-aws",
+      "quay.io/cilium/operator-azure",
+      "quay.io/cilium/operator-generic"
+    ],
+    "versionSource": "github-latest-release:cilium/cilium"
+  },
+  "cilium-certgen": {
+    "images": [
+      "quay.io/cilium/certgen"
+    ],
+    "versionSource": "github-latest-release:cilium/certgen"
+  },
+  "cilium-hubble-ui": {
+    "images": [
+      "quay.io/cilium/hubble-ui",
+      "quay.io/cilium/hubble-ui-backend"
+    ],
+    "versionSource": "github-latest-release:cilium/hubble-ui"
+  },
   "traefik": {
     "images": [
       "library/traefik"

--- a/retrieve-image-tags/retrieve-image-tags.py
+++ b/retrieve-image-tags/retrieve-image-tags.py
@@ -163,7 +163,9 @@ for (key, values) in data.items():
                     found_images.append(image_tag)
             else:
                     found_images.extend(image_tags)
-            if "latest" in values:
+            if "latest_entry" in values:
+                found_releases = [found_images[0]]
+            elif "latest" in values:
                 found_images.sort(key = lambda x: [int(y.removeprefix('v')) for y in x.split('.')])
                 found_releases = [found_images[-1]]
             else:


### PR DESCRIPTION
Adds configuration to automatically create PRs for calico and cilium required images

Because `quay.io/cilium/startup-script` uses a commit hash, I added `latest_entry` as a new config option to just return the first tag in the list.

@rbrtbnfgl can check if the configuration is good regarding source/destination and tags, output can be checked in https://github.com/rancher/image-mirror/actions/runs/5531007770/jobs/10091127096?pr=414#step:6:13