### PR TITLE
Added new Cilium images and flannel cni plugin

### DIFF
--- a/images-list
+++ b/images-list
@@ -83,6 +83,7 @@ flannel/flannel rancher/mirrored-flannel-flannel v0.21.4
 flannel/flannel rancher/mirrored-flannel-flannel v0.21.5
 flannel/flannel rancher/mirrored-flannel-flannel v0.22.0
 flannel/flannel rancher/mirrored-flannel-flannel v0.22.1
+flannel/flannel-cni-plugin rancher/mirrored-flannel-flannel-cni-plugin v1.2.0
 fluent/fluent-bit rancher/fluent-fluent-bit 1.5.4
 fluent/fluent-bit rancher/fluent-fluent-bit 1.5.4-debug
 fluent/fluent-bit rancher/fluent-fluent-bit 1.6.1
@@ -967,6 +968,7 @@ quay.io/cilium/cilium rancher/mirrored-cilium-cilium v1.13.0
 quay.io/cilium/cilium rancher/mirrored-cilium-cilium v1.13.2
 quay.io/cilium/cilium rancher/mirrored-cilium-cilium v1.13.4
 quay.io/cilium/cilium rancher/mirrored-cilium-cilium v1.14.0
+quay.io/cilium/cilium-envoy rancher/mirrored-cilium-cilium-envoy v1.25.9-f039e2bd380b7eef2f2feea5750676bb36133699
 quay.io/cilium/cilium-etcd-operator rancher/mirrored-cilium-cilium-etcd-operator v2.0.7
 quay.io/cilium/clustermesh-apiserver rancher/mirrored-cilium-clustermesh-apiserver v1.12.4
 quay.io/cilium/clustermesh-apiserver rancher/mirrored-cilium-clustermesh-apiserver v1.12.5
@@ -988,6 +990,7 @@ quay.io/cilium/hubble-ui-backend rancher/mirrored-cilium-hubble-ui-backend v0.9.
 quay.io/cilium/hubble-ui-backend rancher/mirrored-cilium-hubble-ui-backend v0.10.0
 quay.io/cilium/hubble-ui-backend rancher/mirrored-cilium-hubble-ui-backend v0.11.0
 quay.io/cilium/hubble-ui-backend rancher/mirrored-cilium-hubble-ui-backend v0.12.0
+quay.io/cilium/kvstoremesh rancher/mirrored-cilium-kvstoremesh v1.14.0
 quay.io/cilium/operator-aws rancher/mirrored-cilium-operator-aws v1.9.4
 quay.io/cilium/operator-aws rancher/mirrored-cilium-operator-aws v1.9.6
 quay.io/cilium/operator-aws rancher/mirrored-cilium-operator-aws v1.9.8

--- a/retrieve-image-tags/config.json
+++ b/retrieve-image-tags/config.json
@@ -5,6 +5,12 @@
     ],
     "versionSource": "github-latest-release:flannel-io/flannel"
   },
+  "flannel-cni-plugin": {
+    "images": [
+      "flannel/flannel-cni-plugin"
+    ],
+    "versionSource": "github-latest-release:flannel-io/cni-plugin"
+  },
   "calico": {
     "images": [
       "quay.io/calico/apiserver",
@@ -28,6 +34,7 @@
       "quay.io/cilium/cilium",
       "quay.io/cilium/clustermesh-apiserver",
       "quay.io/cilium/hubble-relay",
+      "quay.io/cilium/kvstoremesh",
       "quay.io/cilium/operator-aws",
       "quay.io/cilium/operator-azure",
       "quay.io/cilium/operator-generic"
@@ -39,6 +46,14 @@
       "quay.io/cilium/certgen"
     ],
     "versionSource": "github-latest-release:cilium/certgen"
+  },
+  "cilium-envoy": {
+    "images": [
+      "quay.io/cilium/cilium-envoy"
+    ],
+    "versionSource": "registry",
+    "versionFilter": "^v[0-9]+\\.[0-9]+\\.[0-9]+(-[0-9a-z]+)?$",
+    "latest_entry": true
   },
   "cilium-hubble-ui": {
     "images": [


### PR DESCRIPTION
#### Pull Request Checklist ####

- [ ] Change does not remove any existing Images or Tags in the images-list file
- [ ] Change does not remove / overwrite exiting Images or Tags in Rancher DockerHub
- [ ] If updating an existing entry, verify the `SOURCE` is still accurate and upstream hasn't been migrated to a new regitry or repo (if they've migrated, a new repo request to EIO is needed to comply with the `SOURCE DESTINATION TAG` pattern)
- [ ] New entries are in format `SOURCE DESTINATION TAG`
- [ ] New entries are added to the correct section of the list (sorted lexicographically)
- [ ] New entries have a repo created in Rancher Dockerhub (where the image will be mirrored to)
- [ ] New entries are licensed with Rancher favored licenses - Apache 2 and MIT - or approved licenses - as according to [CNCF approved licenses](https://github.com/cncf/foundation/blob/main/allowed-third-party-license-policy.md).
- [ ] New entries, when used in Rancher or Rancher's provided charts, have their corresponding origin added in Rancher's images [origins](https://github.com/rancher/rancher/blob/release/v2.7/pkg/image/origins.go) file (must be added for all Rancher versions `>= v2.7`).
- [ ] Changes to scripting or CI config have been tested to the best of your ability

#### Types of Change ####

<!-- New image, version bump. script update, etc etc -->
New images for Cilium and flannel cni-plugin.
For `cilium-envoy` there isn't a proper way to get the latest release.
#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request.  -->

#### Additional Notes ####

<!-- Any additional details / test results / etc -->

#### Final Checks after the PR is merged ####
- [ ] Confirm that you can pull the new images and tags from DockerHub
