### PR TITLE
Bump skopeo image to v1.13.2

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,4 +1,4 @@
-FROM quay.io/skopeo/stable:v1.1.1
+FROM quay.io/skopeo/stable:v1.13.2
 
 # Add jq
 RUN yum -y update && yum -y install jq git && yum -y clean all && rm -rf /var/cache/dnf/* /var/log/dnf* /var/log/yum*


### PR DESCRIPTION
#### Types of Change ####

<!-- New image, version bump. script update, etc etc -->
Bump skopeo version to `v1.13.2` in Dockerfile.dapper because the image version `v1.1.1` was deleted upstream. Please refer to the snapshot below. 
![Screenshot from 2023-08-30 17-24-51](https://github.com/rancher/image-mirror/assets/32811240/d99f02ac-605e-48a2-93b9-066551ca2aab)

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request.  -->

#### Additional Notes ####
Because of this the CI for mirror image failed. See https://drone-publish.rancher.io/rancher/image-mirror/961
<!-- Any additional details / test results / etc -->

