### PR TITLE
Remove cilium-envoy because too many new tags

### DIFF
--- a/retrieve-image-tags/config.json
+++ b/retrieve-image-tags/config.json
@@ -47,14 +47,6 @@
     ],
     "versionSource": "github-latest-release:cilium/certgen"
   },
-  "cilium-envoy": {
-    "images": [
-      "quay.io/cilium/cilium-envoy"
-    ],
-    "versionSource": "registry",
-    "versionFilter": "^v[0-9]+\\.[0-9]+\\.[0-9]+(-[0-9a-z]+)?$",
-    "latest_entry": true
-  },
   "cilium-hubble-ui": {
     "images": [
       "quay.io/cilium/hubble-ui",


### PR DESCRIPTION
This will be solved when we implement https://github.com/rancher/image-mirror/issues/437, for now there are just too many new tags for this image.

Also see https://github.com/rancher/image-mirror/pull/433