### PR TITLE
Authenticate using skopeo to avoid rate limit

### DIFF
--- a/scripts/image-mirror.sh
+++ b/scripts/image-mirror.sh
@@ -6,6 +6,7 @@ if [ ! -z "${DOCKER_USERNAME:-}" ] && [ ! -z "${DOCKER_PASSWORD:-}" ]; then
   echo "Logging in to ${DOCKER_REGISTRY:-docker.io} as ${DOCKER_USERNAME}"
   docker login ${DOCKER_REGISTRY:-docker.io} --username=${DOCKER_USERNAME} --password-stdin <<< ${DOCKER_PASSWORD}
   export DOCKER_TOKEN=$(curl -s -d @- -X POST -H "Content-Type: application/json" https://hub.docker.com/v2/users/login/ <<< '{"username": "'${DOCKER_USERNAME}'", "password": "'${DOCKER_PASSWORD}'"}' | jq -r '.token')
+  skopeo login ${DOCKER_REGISTRY:-docker.io} --username=${DOCKER_USERNAME} --password-stdin <<< ${DOCKER_PASSWORD}
 fi
 
 export DOCKER_CLI_EXPERIMENTAL="enabled"


### PR DESCRIPTION
[The bump](https://github.com/rancher/image-mirror/pull/456) to a newer version of `skopeo` seems to cause issues with authentication, as there are lots of `toomanyrequests` and access errors in the log.

It seems to no longer use the auth file created by `docker login`, and although we could point to it, we might as well just use the "native" `skopeo login` to make sure it will use whatever `skopeo` requires to work.