### PR TITLE
Bump up neuvector product version to 5.2.2

### DIFF
--- a/images-list
+++ b/images-list
@@ -725,6 +725,7 @@ neuvector/controller rancher/mirrored-neuvector-controller 5.1.3
 neuvector/controller rancher/mirrored-neuvector-controller 5.2.0
 neuvector/controller rancher/mirrored-neuvector-controller 5.2.0-s1
 neuvector/controller rancher/mirrored-neuvector-controller 5.2.1
+neuvector/controller rancher/mirrored-neuvector-controller 5.2.2
 neuvector/enforcer rancher/mirrored-neuvector-enforcer 5.0.0
 neuvector/enforcer rancher/mirrored-neuvector-enforcer 5.0.0-b1
 neuvector/enforcer rancher/mirrored-neuvector-enforcer 5.0.0-b2
@@ -739,6 +740,7 @@ neuvector/enforcer rancher/mirrored-neuvector-enforcer 5.1.3
 neuvector/enforcer rancher/mirrored-neuvector-enforcer 5.2.0
 neuvector/enforcer rancher/mirrored-neuvector-enforcer 5.2.0-s1
 neuvector/enforcer rancher/mirrored-neuvector-enforcer 5.2.1
+neuvector/enforcer rancher/mirrored-neuvector-enforcer 5.2.2
 neuvector/manager rancher/mirrored-neuvector-manager 5.0.0
 neuvector/manager rancher/mirrored-neuvector-manager 5.0.0-b1
 neuvector/manager rancher/mirrored-neuvector-manager 5.0.0-b2
@@ -753,8 +755,10 @@ neuvector/manager rancher/mirrored-neuvector-manager 5.1.3
 neuvector/manager rancher/mirrored-neuvector-manager 5.2.0
 neuvector/manager rancher/mirrored-neuvector-manager 5.2.0-s1
 neuvector/manager rancher/mirrored-neuvector-manager 5.2.1
+neuvector/manager rancher/mirrored-neuvector-manager 5.2.2
 neuvector/prometheus-exporter rancher/mirrored-neuvector-prometheus-exporter 5.2.0
 neuvector/prometheus-exporter rancher/mirrored-neuvector-prometheus-exporter 5.2.1
+neuvector/prometheus-exporter rancher/mirrored-neuvector-prometheus-exporter 5.2.2
 neuvector/registry-adapter rancher/mirrored-neuvector-registry-adapter 0.1.0
 neuvector/registry-adapter rancher/mirrored-neuvector-registry-adapter 0.1.1
 openpolicyagent/gatekeeper rancher/mirrored-openpolicyagent-gatekeeper v3.3.0


### PR DESCRIPTION
#### Pull Request Checklist ####

- [ ] Change does not remove any existing Images or Tags in the images-list file
- [ ] Change does not remove / overwrite exiting Images or Tags in Rancher DockerHub
- [ ] If updating an existing entry, verify the `SOURCE` is still accurate and upstream hasn't been migrated to a new regitry or repo (if they've migrated, a new repo request to EIO is needed to comply with the `SOURCE DESTINATION TAG` pattern)
- [ ] New entries are in format `SOURCE DESTINATION TAG`
- [ ] New entries are added to the correct section of the list (sorted lexicographically)
- [ ] New entries have a repo created in Rancher Dockerhub (where the image will be mirrored to)
- [ ] New entries are licensed with Rancher favored licenses - Apache 2 and MIT - or approved licenses - as according to [CNCF approved licenses](https://github.com/cncf/foundation/blob/main/allowed-third-party-license-policy.md).
- [ ] New entries, when used in Rancher or Rancher's provided charts, have their corresponding origin added in Rancher's images [origins](https://github.com/rancher/rancher/blob/release/v2.7/pkg/image/origins.go) file (must be added for all Rancher versions `>= v2.7`).
- [ ] Changes to scripting or CI config have been tested to the best of your ability

#### Types of Change ####

<!-- New image, version bump. script update, etc etc -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request.  -->

#### Additional Notes ####

<!-- Any additional details / test results / etc -->

#### Final Checks after the PR is merged ####
- [ ] Confirm that you can pull the new images and tags from DockerHub
