### PR TITLE
Cleanup non-existent images/repository

### DIFF
--- a/images-list
+++ b/images-list
@@ -9,13 +9,6 @@ amazon/aws-cli rancher/mirrored-amazon-aws-cli 2.8.9
 amazon/aws-cli rancher/mirrored-amazon-aws-cli 2.9.0
 amazon/aws-cli rancher/mirrored-amazon-aws-cli 2.9.14
 appscode/kubed rancher/mirrored-appscode-kubed v0.13.2
-banzaicloud/fluentd rancher/banzaicloud-fluentd v1.11.2-alpine-2
-banzaicloud/fluentd rancher/banzaicloud-fluentd v1.11.4-alpine-1
-banzaicloud/fluentd rancher/banzaicloud-fluentd v1.11.5-alpine-1
-banzaicloud/fluentd rancher/banzaicloud-fluentd v1.11.5-alpine-9
-banzaicloud/fluentd rancher/mirrored-banzaicloud-fluentd v1.11.5-alpine-9
-banzaicloud/fluentd rancher/mirrored-banzaicloud-fluentd v1.11.5-alpine-12
-banzaicloud/fluentd rancher/mirrored-banzaicloud-fluentd v1.11.5-alpine-21
 banzaicloud/logging-operator rancher/banzaicloud-logging-operator 3.6.0
 banzaicloud/logging-operator rancher/banzaicloud-logging-operator 3.7.0
 banzaicloud/logging-operator rancher/banzaicloud-logging-operator 3.7.3
@@ -1222,7 +1215,6 @@ quay.io/prometheus/alertmanager rancher/mirrored-prometheus-alertmanager v0.22.0
 quay.io/prometheus/alertmanager rancher/mirrored-prometheus-alertmanager v0.22.2
 quay.io/prometheus/alertmanager rancher/mirrored-prometheus-alertmanager v0.24.0
 quay.io/prometheus/alertmanager rancher/mirrored-prometheus-alertmanager v0.25.0
-quay.io/prometheus/node-exporter rancher/mirrored-coreos-node-exporter v1.0.1
 quay.io/prometheus/node-exporter rancher/mirrored-prometheus-node-exporter v1.1.2
 quay.io/prometheus/node-exporter rancher/mirrored-prometheus-node-exporter v1.2.2
 quay.io/prometheus/node-exporter rancher/mirrored-prometheus-node-exporter v1.3.1


### PR DESCRIPTION
- `docker.io/rancher/mirrored-coreos-node-exporter` never existed?  See list below what has been used:

```
prom/node-exporter rancher/mirrored-prom-node-exporter v1.0.1
prom/node-exporter rancher/prom-node-exporter v1.0.1
quay.io/prometheus/node-exporter rancher/mirrored-prometheus-node-exporter v1.1.2
quay.io/prometheus/node-exporter rancher/mirrored-prometheus-node-exporter v1.2.2
quay.io/prometheus/node-exporter rancher/mirrored-prometheus-node-exporter v1.3.1
```

- `docker.io/banzaicloud/fluentd` tags no longer exist


```
time="2023-10-16T16:23:40Z" level=fatal msg="Error parsing image name \"docker://docker.io/banzaicloud/fluentd:v1.11.2-alpine-2\": reading manifest v1.11.2-alpine-2 in docker.io/banzaicloud/fluentd: requested access to the resource is denied"
time="2023-10-16T16:23:40Z" level=fatal msg="Error parsing image name \"docker://docker.io/banzaicloud/fluentd:v1.11.4-alpine-1\": reading manifest v1.11.4-alpine-1 in docker.io/banzaicloud/fluentd: requested access to the resource is denied"
time="2023-10-16T16:23:41Z" level=fatal msg="Error parsing image name \"docker://docker.io/banzaicloud/fluentd:v1.11.5-alpine-1\": reading manifest v1.11.5-alpine-1 in docker.io/banzaicloud/fluentd: requested access to the resource is denied"
time="2023-10-16T16:23:41Z" level=fatal msg="Error parsing image name \"docker://docker.io/banzaicloud/fluentd:v1.11.5-alpine-9\": reading manifest v1.11.5-alpine-9 in docker.io/banzaicloud/fluentd: requested access to the resource is denied"
time="2023-10-16T16:23:41Z" level=fatal msg="Error parsing image name \"docker://docker.io/banzaicloud/fluentd:v1.11.5-alpine-9\": reading manifest v1.11.5-alpine-9 in docker.io/banzaicloud/fluentd: requested access to the resource is denied"
time="2023-10-16T16:23:41Z" level=fatal msg="Error parsing image name \"docker://docker.io/banzaicloud/fluentd:v1.11.5-alpine-12\": reading manifest v1.11.5-alpine-12 in docker.io/banzaicloud/fluentd: requested access to the resource is denied"
time="2023-10-16T16:23:41Z" level=fatal msg="Error parsing image name \"docker://docker.io/banzaicloud/fluentd:v1.11.5-alpine-21\": reading manifest v1.11.5-alpine-21 in docker.io/banzaicloud/fluentd: requested access to the resource is denied"
time="2023-10-16T17:07:52Z" level=fatal msg="trying to reuse blob sha256:86fa074c6765dda1bcd90264d60cd541980e20eadeb0669031452c721a92f6b9 at destination: checking whether a blob sha256:86fa074c6765dda1bcd90264d60cd541980e20eadeb0669031452c721a92f6b9 exists in docker.io/rancher/mirrored-coreos-node-exporter: requested access to the resource is denied"
time="2023-10-16T17:07:53Z" level=fatal msg="trying to reuse blob sha256:ea9b50efc3848ee7ab994c4ff6f670b695f1266769eb00cc58ffbd3d69a29989 at destination: checking whether a blob sha256:ea9b50efc3848ee7ab994c4ff6f670b695f1266769eb00cc58ffbd3d69a29989 exists in docker.io/rancher/mirrored-coreos-node-exporter: requested access to the resource is denied"
time="2023-10-16T17:07:54Z" level=fatal msg="trying to reuse blob sha256:366d12dcce8d700bdd01523fa484c95673624071a523be018252a3384e22150f at destination: checking whether a blob sha256:366d12dcce8d700bdd01523fa484c95673624071a523be018252a3384e22150f exists in docker.io/rancher/mirrored-coreos-node-exporter: requested access to the resource is denied"
time="2023-10-16T17:07:55Z" level=fatal msg="trying to reuse blob sha256:dd8c951d5d231008ca69f10c54a6047caed5eaca523b346d57fb301f822e054b at destination: checking whether a blob sha256:dd8c951d5d231008ca69f10c54a6047caed5eaca523b346d57fb301f822e054b exists in docker.io/rancher/mirrored-coreos-node-exporter: requested access to the resource is denied"
```