### PR TITLE
Restrict cpi tags to supported versions

### DIFF
--- a/retrieve-image-tags/config.json
+++ b/retrieve-image-tags/config.json
@@ -91,7 +91,7 @@
       "gcr.io/cloud-provider-vsphere/cpi/release/manager"
     ],
     "versionSource": "registry",
-    "versionFilter": "^v1\\.[2-9]+\\.[3-9]+$"
+    "versionFilter": "^v1\\.(2[4-9]|[3-9][0-9])\\.[0-9]+$"
   },
   "cilium": {
     "versionSource": "helm-latest:https://helm.cilium.io",


### PR DESCRIPTION
Based on https://github.com/rancher/image-mirror/pull/488#issuecomment-1761712417, this restricts the tags to just what we need. We have a closed PR today and it won't open a new one, but with new images coming in, there will be new PRs where these versions will still be included as they are matched in the filter. This PR changes the filter to v1.24.x and up.