### PR TITLE
Add devel configuration option

### DIFF
--- a/.github/workflows/validate-retrieve-image-tags-config.yml
+++ b/.github/workflows/validate-retrieve-image-tags-config.yml
@@ -2,7 +2,7 @@ name: Validate retrieve-image-tags config
 on:
   pull_request:
     paths:
-      - 'retrieve-image-tags/config.json'
+      - 'retrieve-image-tags/**'
 
 permissions:
   contents: read

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Helm specific options:
 
 - `imageDenylist`: An array of images that will not be added (in case the image matching finds images that shouldn't be added as the automation only accounts for adding tags to existing images, not adding new images as they need to be approved first)
 - `kubeVersion`: What version to pass to `--kube-version` when running `helm template`
+- `devel`: Use chart development versions (adds `--devel` to `helm template` and `helm show values` commands)
 
 See example configuration for `github-releases`, `github-latest-release` and `registry`:
 
@@ -125,6 +126,7 @@ See example configuration for `helm-latest:helm-repo-fqdn`:
     ],
     "helmCharts": {
       "cilium": {
+        "devel": true,
         "chartConfig": {
           "aws": {
             "values": [


### PR DESCRIPTION
First part of https://github.com/rancher/image-mirror/issues/500

I went back and forth on this implementation, I started with a `devel` configuration option at first (like in this PR) but felt like maybe it could be more generic. So I transformed it into `helmArgs` but after implementing it, it didn't really make sense as it would not consume global Helm args but specific args for subcommands. And wether we need specific configuration directives for `helm template` and `helm show values`, we'll see in the future. 

For now,  this adds the option to use development versions (mainly used for local testing for now)