### PR TITLE
Add additional version options

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ Helm specific options:
 - `imageDenylist`: An array of images that will not be added (in case the image matching finds images that shouldn't be added as the automation only accounts for adding tags to existing images, not adding new images as they need to be approved first)
 - `kubeVersion`: What version to pass to `--kube-version` when running `helm template`
 - `devel`: Use chart development versions (adds `--devel` to `helm template` and `helm show values` commands)
+- `additionalVersionFilter`: Next to retrieving the latest Helm chart, it will also run `helm template` and `helm show values` commands with `--version` parameters from this array. This is useful if you want to include images from multiple versions in a single pull request.
+- `versionFilter`: Specify what version of the Helm chart needs to be used (this will only run `helm template` and `helm show values` with the configured `versionFilter`)
 
 See example configuration for `github-releases`, `github-latest-release` and `registry`:
 
@@ -181,7 +183,25 @@ See example configuration for `helm-latest:helm-repo-fqdn`:
     "helmCharts": {
       "core": {}
     }
+  },
+  "longhorn": {
+    "versionSource": "helm-latest:https://charts.longhorn.io",
+    "additionalVersionFilter": [
+      "v1.4.*"
+    ],
+    "helmCharts": {
+      "longhorn": {}
+    }
+  },
+  "longhorn": {
+    "versionSource": "helm-latest:https://charts.longhorn.io",
+    "helmCharts": {
+      "longhorn": {
+        "versionFilter": "v1.4.*"
+      }
+    }
   }
+
 }
 ```
 

--- a/retrieve-image-tags/config.json
+++ b/retrieve-image-tags/config.json
@@ -97,7 +97,9 @@
     "versionSource": "helm-latest:https://helm.cilium.io",
     "imageDenylist": [
       "quay.io/cilium/operator",
-      "quay.io/cilium/startup-script"
+      "quay.io/cilium/startup-script",
+      "ghcr.io/spiffe/spire-agent",
+      "ghcr.io/spiffe/spire-server"
     ],
     "helmCharts": {
       "cilium": {


### PR DESCRIPTION
https://github.com/rancher/image-mirror/issues/506

This adds two options to filter versions, one to include additional versions to a PR and one to specify a version (filter).

Because I was testing with Longhorn, I also optimized getting images from `helm show values` as the chart nested the images 3 levels deep and the code only looked 2 levels. I added a function that recursively walks through the dict. This also found 2 new images in cilium chart that I added to the `imageDenylist`