### PR TITLE
[Improvement] Add a new data source, github-tagged-images-file, to automate retrieving images from a image-list file of a GitHub release

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ There is also a scheduled workflow called [Retrieve image tags](https://github.c
 
 - `github-releases`: This will use GitHub releases as source, excluding pre-releases. This can be used if you need to keep all tags from the configured images in sync with GitHub releases
 - `github-latest-release`: This will use the release on GitHub marked as `Latest release`. This can be used if you only want one release to be added that is marked as latest.
+- `github-tagged-images-file`: This will look up GitHub git repository tags, and find the list of images inside a specified file. The tag must have an associated release, with the pre-release flag unset. This can be used if your project maintains a list of images in a file, e.g., https://github.com/longhorn/longhorn/blob/master/deploy/longhorn-images.txt
 - `registry`: This will use the registry of the first image and look up available tags.
 - `helm-latest:helm-repo-fqdn`: This will add the helm-repo-fqdn, and use the latest version of configured Helm chart(s) (`helmCharts`) configured to extract the images. It uses `helm template` and `helm show values` to extract images. You can specify one ore more iterations of `helm template` by specifying one ore more `values` configurations to make sure all required images are extracted. If you want to block certain images from being extracted, you can use `imageDenylist` in the configuration. See example below.
 - `helm-oci`: This is the same as `helm-latest`, except you don't need to provide a repository but it will use the charts directly from the provided `helmCharts` (which should be formatted as `oci://hostname/chart`).
@@ -49,6 +50,9 @@ The current filters for tags are:
 - `latest`: Sorts the found tags numerically and returns only the latest tag
 - `latest_entry`: Returns the last found (newest) tag only (can be used when tags are not semver/cannot be sorted numerically)
 
+`github-tagged-images-file` specific options:
+- `imagesFilePath`: the path to the list of images inside a GitHub git repository
+
 Helm specific options:
 
 - `imageDenylist`: An array of images that will not be added (in case the image matching finds images that shouldn't be added as the automation only accounts for adding tags to existing images, not adding new images as they need to be approved first)
@@ -59,7 +63,7 @@ Helm specific options:
 
 See example configuration for `github-releases`, `github-latest-release` and `registry`:
 
-```
+```json
 {
   "vsphere-cpi": {
     "images": [
@@ -117,9 +121,20 @@ See example configuration for `github-releases`, `github-latest-release` and `re
 }
 ```
 
+See example configuration for `github-tagged-images-file`:
+```json
+{
+  "longhorn": {
+    "versionSource": "github-tagged-images-file:longhorn/longhorn",
+    "imagesFilePath": "deploy/longhorn-images.txt",
+    "versionConstraint": ">=1.4.0"
+  }
+}
+```
+
 See example configuration for `helm-latest:helm-repo-fqdn`:
 
-```
+```json
 {
   "cilium": {
     "versionSource": "helm-latest:https://helm.cilium.io",

--- a/retrieve-image-tags/config.json
+++ b/retrieve-image-tags/config.json
@@ -86,6 +86,11 @@
     ],
     "versionSource": "github-latest-release:kubernetes-csi/node-driver-registrar"
   },
+  "longhorn": {
+    "imagesFilePath": "deploy/longhorn-images.txt",
+    "versionSource": "github-tagged-images-file:longhorn/longhorn",
+    "versionConstraint": ">=1.4.0"
+  },
   "cpi-release-manager": {
     "images": [
       "gcr.io/cloud-provider-vsphere/cpi/release/manager"


### PR DESCRIPTION
### Current issue:

Longhorn would like to automate adding/mirroring images. However, the currently available list of data sources don't fit the use-case of Longhorn:
1. `github-releases` data source: This one finds new GitHub release tag and adds the images defined in the `images` field in the `config.json` file. For example:
    ```json
    {
      "vsphere-cpi": {
        "images": [
          "gcr.io/cloud-provider-vsphere/cpi/release/manager"
        ],
        "versionSource": "github-releases:kubernetes/cloud-provider-vsphere",
        "versionConstraint": ">1.21.0"
      }
    }
    ```
    This `config.json` file instructs the script to find GitHub release tags in the repo `kubernetes/cloud-provider-vsphere`. Then only add the `gcr.io/cloud-provider-vsphere/cpi/release/manager` image with the found tags to the [images-list](https://github.com/rancher/image-mirror/blob/master/images-list). This doesn't fit the use-case of Longhorn because the list of Longhorn images are not fixed. We added/removed images between the releases. Therefore, it would require manual works to modify the ` "images"` fied of the `config.json` oftenly 
1. `github-latest-release` data source: this data source has same limitation as the `github-releases`. Additionaly, Longhorn maintain multiple minor releases so a smaller version (e.g., `v1.4.5`) might be released after the current latest version (e.g., `v1.5.3`). This data source will not sync and add the smaller version (e.g., `v1.4.5`)
1. `registry` data source: Longhorn doesn't maintain a registry. Not applicable 
1. `helm-latest`, `helm-oci`, and `helm-directory` data sources. With these data sources, the workflow attempts to run `helm template` and extract the images from the workload (deployment/daemonset/pod) output of `helm template`. This approach doesn't work for Longhorn because not all Longhorn images appears in the output of `Helm template` (the images of Longhorn system managed components)

### Proposal

Add a new data source to automate retrieving images from file which contains the list of images of a GitHub release, `github-releases-images-file`. This will look up GitHub releases, excluding pre-releases, and find the list of images inside a specified file of the release. This can be used if your project maintains a list of images in a file, e.g., https://github.com/longhorn/longhorn/blob/master/deploy/longhorn-images.txt

An example of configuration for `github-releases-images-file` could be:
```json
{
  "longhorn": {
    "versionSource": "github-releases-images-file:longhorn/longhorn",
    "imagesFilePath": "deploy/longhorn-images.txt",
    "versionConstraint": ">=1.4.0"
  }
}
```

With the new `github-releases-images-file` data source, the above `config.json` instructs the GitHub workflow to:
1. Look up GitHub releases at the repo `longhorn/longhorn`, excluding pre-releases
1. Only consider the releases which are >=1.4.0
1. For each release, download the image list at `deploy/longhorn-images.txt` and add the newly found images to the [images-list](https://github.com/rancher/image-mirror/blob/master/images-list).

