### PR TITLE
Added new image node-driver-registrar for calico

### DIFF
--- a/images-list
+++ b/images-list
@@ -914,6 +914,7 @@ quay.io/calico/cni rancher/mirrored-calico-cni v3.26.2
 quay.io/calico/cni rancher/mirrored-calico-cni v3.26.3
 quay.io/calico/cni rancher/mirrored-calico-cni v3.26.4
 quay.io/calico/cni rancher/mirrored-calico-cni v3.27.0
+quay.io/calico/csi rancher/mirrored-calico-csi v3.27.0
 quay.io/calico/ctl rancher/calico-ctl v3.16.5
 quay.io/calico/ctl rancher/calico-ctl v3.16.6
 quay.io/calico/ctl rancher/calico-ctl v3.17.1
@@ -1018,6 +1019,7 @@ quay.io/calico/node rancher/mirrored-calico-node v3.26.2
 quay.io/calico/node rancher/mirrored-calico-node v3.26.3
 quay.io/calico/node rancher/mirrored-calico-node v3.26.4
 quay.io/calico/node rancher/mirrored-calico-node v3.27.0
+quay.io/calico/node-driver-registrar rancher/mirrored-calico-node-driver-registrar v3.27.0
 quay.io/calico/pod2daemon-flexvol rancher/calico-pod2daemon-flexvol v3.16.5
 quay.io/calico/pod2daemon-flexvol rancher/calico-pod2daemon-flexvol v3.16.6
 quay.io/calico/pod2daemon-flexvol rancher/calico-pod2daemon-flexvol v3.17.1

--- a/retrieve-image-tags/config.json
+++ b/retrieve-image-tags/config.json
@@ -15,9 +15,11 @@
     "images": [
       "quay.io/calico/apiserver",
       "quay.io/calico/cni",
+      "quay.io/calico/csi",
       "quay.io/calico/ctl",
       "quay.io/calico/kube-controllers",
       "quay.io/calico/node",
+      "quay.io/calico/node-driver-registrar",
       "quay.io/calico/pod2daemon-flexvol",
       "quay.io/calico/typha"
     ],


### PR DESCRIPTION
#### Pull Request Checklist ####

- [ ] Change does not remove any existing Images or Tags in the images-list file
- [ ] Change does not remove / overwrite exiting Images or Tags in Rancher DockerHub
- [ ] If updating an existing entry, verify the `SOURCE` is still accurate and upstream hasn't been migrated to a new regitry or repo (if they've migrated, a new repo request to EIO is needed to comply with the `SOURCE DESTINATION TAG` pattern)
- [ ] New entries are in format `SOURCE DESTINATION TAG`
- [ ] New entries are added to the correct section of the list (sorted lexicographically)
- [ ] New entries have a repo created in Rancher Dockerhub (where the image will be mirrored to)
- [ ] New entries are licensed with Rancher favored licenses - Apache 2 and MIT - or approved licenses - as according to [CNCF approved licenses](https://github.com/cncf/foundation/blob/main/allowed-third-party-license-policy.md).
- [ ] New entries, when used in Rancher or Rancher's provided charts, have their corresponding origin added in Rancher's images [origins](https://github.com/rancher/rancher/blob/release/v2.7/pkg/image/origins.go) file (must be added for all Rancher versions `>= v2.7`).
- [ ] Changes to scripting or CI config have been tested to the best of your ability

#### Types of Change ####

<!-- New image, version bump. script update, etc etc -->
This adds the new image for calico needed for the csi-node-driver

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request.  -->

#### Additional Notes ####

<!-- Any additional details / test results / etc -->

#### Final Checks after the PR is merged ####
- [ ] Confirm that you can pull the new images and tags from DockerHub
