### PR TITLE
Add rancher/mirrored-prometheus-prometheus v2.45.0

### DIFF
--- a/images-list
+++ b/images-list
@@ -1384,6 +1384,7 @@ quay.io/prometheus/prometheus rancher/mirrored-prometheus-prometheus v2.27.1
 quay.io/prometheus/prometheus rancher/mirrored-prometheus-prometheus v2.28.1
 quay.io/prometheus/prometheus rancher/mirrored-prometheus-prometheus v2.38.0
 quay.io/prometheus/prometheus rancher/mirrored-prometheus-prometheus v2.42.0
+quay.io/prometheus/prometheus rancher/mirrored-prometheus-prometheus v2.45.0
 quay.io/prometheus/prometheus rancher/mirrored-prometheus-prometheus v2.48.1
 quay.io/prometheus/prometheus rancher/mirrored-prom-prometheus v2.18.2
 quay.io/prometheus/prometheus rancher/prom-prometheus v2.19.2


### PR DESCRIPTION
#### Pull Request Checklist ####

- [x] Change does not remove any existing Images or Tags in the images-list file
- [x] Change does not remove / overwrite exiting Images or Tags in Rancher DockerHub
- [x]  If updating an existing entry, verify the `SOURCE` is still accurate and upstream hasn't been migrated to a new regitry or repo (if they've migrated, a new repo request to EIO is needed to comply with the `SOURCE DESTINATION TAG` pattern)
- [x] n/a:New entries are in format `SOURCE DESTINATION TAG`
- [x] n/a:New entries are added to the correct section of the list (sorted lexicographically)
- [x] n/a:New entries have a repo created in Rancher Dockerhub (where the image will be mirrored to)
- [x] n/a:New entries are licensed with Rancher favored licenses - Apache 2 and MIT - or approved licenses - as according to [CNCF approved licenses](https://github.com/cncf/foundation/blob/main/allowed-third-party-license-policy.md).
- [x] n/a:New entries, when used in Rancher or Rancher's provided charts, have their corresponding origin added in Rancher's images [origins](https://github.com/rancher/rancher/blob/release/v2.7/pkg/image/origins.go) file (must be added for all Rancher versions `>= v2.7`).
- [x] n/a: Changes to scripting or CI config have been tested to the best of your ability

#### Types of Change ####

Version bump (2.45 is the most recent LTS)

#### Linked Issues ####

https://github.com/rancher/rancher/issues/44605

#### Final Checks after the PR is merged ####
- [ ] Confirm that you can pull the new images and tags from DockerHub
