### PR TITLE
Handle images which only support Windows

### DIFF
--- a/scripts/check-new-images-exist.sh
+++ b/scripts/check-new-images-exist.sh
@@ -34,7 +34,7 @@ for NEW_IMAGE in $NEW_IMAGES; do
     echo "${TARGET_IMAGE} is not a new target repository"
   fi
   echo "Checking if image ${SOURCE_IMAGE} exists"
-  if ! skopeo inspect --retry-times=3 "docker://${SOURCE_IMAGE}" >/dev/null; then
+  if ! skopeo inspect --retry-times=3 --raw "docker://${SOURCE_IMAGE}" >/dev/null; then
     echo "ERROR: Image ${SOURCE_IMAGE} does not exist"
     exit 1
   fi


### PR DESCRIPTION
#### Pull Request Checklist ####

- [ ] Change does not remove any existing Images or Tags in the images-list file
- [ ] Change does not remove / overwrite exiting Images or Tags in Rancher DockerHub
- [ ] If updating an existing entry, verify the `SOURCE` is still accurate and upstream hasn't been migrated to a new regitry or repo (if they've migrated, a new repo request to EIO is needed to comply with the `SOURCE DESTINATION TAG` pattern)
- [ ] New entries are in format `SOURCE DESTINATION TAG`
- [ ] New entries are added to the correct section of the list (sorted lexicographically)
- [ ] New entries have a repo created in Rancher Dockerhub (where the image will be mirrored to)
- [ ] New entries are licensed with Rancher favored licenses - Apache 2 and MIT - or approved licenses - as according to [CNCF approved licenses](https://github.com/cncf/foundation/blob/main/allowed-third-party-license-policy.md).
- [ ] New entries, when used in Rancher or Rancher's provided charts, have their corresponding origin added in Rancher's images [origins](https://github.com/rancher/rancher/blob/release/v2.7/pkg/image/origins.go) file (must be added for all Rancher versions `>= v2.7`).
- [x] Changes to scripting or CI config have been tested to the best of your ability

#### Types of Change ####

<!-- New image, version bump. script update, etc etc -->
Script Update

#### Change Description #### 

This PR updates the `check-new-images-exist.sh` script to handle Windows only images. By default, `skopeo inspect` will [attempt to find an image supporting the platform the command is run on](https://github.com/containers/skopeo/blob/main/docs/skopeo-inspect.1.md#description) (e.g. `linux/amd64`). For the vast majority of Docker containers this is not a problem, however for Windows only containers this check will obviously fail. 

After this PR, when processing an image which does not contain a `linux/amd64` entry, `check-new-images-exist.sh` will call `skopeo inspect --override-os windows` before declaring that the image does not exist. 

Note that this problem only occurs with the `check-new-images-exist.sh` script. The `image-mirror.sh` script will successfully mirror Windows only images. This is due to all usages of `skopeo inspect` passing the `--raw` flag, grabbing the entire image index regardless of the platform the command is run on. 

#### Updated Script Testing ####

To test this change I have done the following 

+ Updated `images-list` to contain the new entry included in https://github.com/rancher/image-mirror/pull/592
+ Executed `dapper check-new-images-exist.sh` and confirmed that the script exits successfully, and that the log added in this PR is present
+ Created a private registry on an Azure VM 
+ Run `DEST_REGISTRY_OVERRIDE=<my_registry> IMAGES_FILE=images-list dapper image-mirror.sh`
     + confirmed that the script exited successfully, and I was able to pull pushed images
     + note that I trimmed this file down a bit  (1.5k images is just a bit too big for my test registry)
+ Updated the Rancher monitoring chart relating to https://github.com/rancher/windows/issues/234 to pull the windows only image from the private registry 
     + confirmed that the image could be pulled and behaved as expected

#### Alternatives Considered ####

Another solution for this issue would be to pass the `--raw` flag when running `skopeo inspect` in the `check-new-images-exist.sh` script. I opted for the current changes so logs indicate when images do not have `linux/amd64` images, which might be useful if a PR author does not realize that `linux/amd64` is not supported. 

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request.  -->
https://github.com/rancher/windows/issues/234, https://github.com/rancher/image-mirror/pull/592

#### Additional Notes ####


#### Final Checks after the PR is merged ####
- [ ] Confirm that you can pull the new images and tags from DockerHub
