### PR TITLE
Moved tigera-operator image tag to the one defined on the chart

### DIFF
--- a/retrieve-image-tags/config.json
+++ b/retrieve-image-tags/config.json
@@ -26,10 +26,10 @@
     "versionSource": "github-latest-release:projectcalico/calico"
   },
   "calico-operator": {
-    "images": [
-      "quay.io/tigera/operator"
-    ],
-    "versionSource": "github-latest-release:tigera/operator"
+    "versionSource": "helm-latest:https://docs.tigera.io/calico/charts",
+    "helmCharts": {
+      "tigera-operator": {}
+    }
   },
   "traefik": {
     "images": [


### PR DESCRIPTION
#### Pull Request Checklist ####

#### Types of Change ####

<!-- New image, version bump. script update, etc etc -->
This PR moved the image tags check for `tigera-operator` to the one defined on the latest calico chart.

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request.  -->

#### Additional Notes ####

<!-- Any additional details / test results / etc -->

#### Final Checks after the PR is merged ####
