### PR TITLE
Update missing image for Longhorn 1.6.1 Rancher chart release

### DIFF
--- a/images-list
+++ b/images-list
@@ -777,6 +777,7 @@ longhornio/longhorn-ui rancher/mirrored-longhornio-longhorn-ui v1.5.3
 longhornio/longhorn-ui rancher/mirrored-longhornio-longhorn-ui v1.5.4
 longhornio/longhorn-ui rancher/mirrored-longhornio-longhorn-ui v1.6.0
 longhornio/longhorn-ui rancher/mirrored-longhornio-longhorn-ui v1.6.1
+longhornio/openshift-origin-oauth-proxy rancher/mirrored-longhornio-openshift-origin-oauth-proxy 4.14
 longhornio/support-bundle-kit rancher/mirrored-longhornio-support-bundle-kit v0.0.17
 longhornio/support-bundle-kit rancher/mirrored-longhornio-support-bundle-kit v0.0.19
 longhornio/support-bundle-kit rancher/mirrored-longhornio-support-bundle-kit v0.0.24


### PR DESCRIPTION
https://github.com/rancher/charts/pull/3753
longhorn/longhorn#8329

#### Pull Request Checklist ####

- [x] Change does not remove any existing Images or Tags in the images-list file
- [x] Change does not remove / overwrite exiting Images or Tags in Rancher DockerHub
- [x] If updating an existing entry, verify the `SOURCE` is still accurate and upstream hasn't been migrated to a new regitry or repo (if they've migrated, a new repo request to EIO is needed to comply with the `SOURCE DESTINATION TAG` pattern)
- [x] New entries are in format `SOURCE DESTINATION TAG`
- [x] New entries are added to the correct section of the list (sorted lexicographically)
- [x] New entries have a repo created in Rancher Dockerhub (where the image will be mirrored to)
- [x] New entries are licensed with Rancher favored licenses - Apache 2 and MIT - or approved licenses - as according to [CNCF approved licenses](https://github.com/cncf/foundation/blob/main/allowed-third-party-license-policy.md).
- [ ] New entries, when used in Rancher or Rancher's provided charts, have their corresponding origin added in Rancher's images [origins](https://github.com/rancher/rancher/blob/release/v2.7/pkg/image/origins.go) file (must be added for all Rancher versions `>= v2.7`).
- [x] Changes to scripting or CI config have been tested to the best of your ability

#### Types of Change ####

<!-- New image, version bump. script update, etc etc -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request.  -->

#### Additional Notes ####

<!-- Any additional details / test results / etc -->

#### Final Checks after the PR is merged ####
- [ ] Confirm that you can pull the new images and tags from DockerHub
