### PR TITLE
Add tag for fluentd image

### DIFF
--- a/images-list
+++ b/images-list
@@ -225,6 +225,7 @@ ghcr.io/banzaicloud/fluentd rancher/mirrored-banzaicloud-fluentd v1.13.3-alpine-
 ghcr.io/banzaicloud/fluentd rancher/mirrored-banzaicloud-fluentd v1.14.4-alpine-2
 ghcr.io/banzaicloud/fluentd rancher/mirrored-banzaicloud-fluentd v1.14.5-alpine-1
 ghcr.io/banzaicloud/fluentd rancher/mirrored-banzaicloud-fluentd v1.14.6-alpine-5
+ghcr.io/kube-logging/fluentd rancher/mirrored-banzaicloud-fluentd v1.16-ruby3.3-full-build.140
 ghcr.io/banzaicloud/logging-operator rancher/mirrored-banzaicloud-logging-operator 3.14.0
 ghcr.io/banzaicloud/logging-operator rancher/mirrored-banzaicloud-logging-operator 3.15.0
 ghcr.io/banzaicloud/logging-operator rancher/mirrored-banzaicloud-logging-operator 3.17.1

--- a/images-list
+++ b/images-list
@@ -225,7 +225,6 @@ ghcr.io/banzaicloud/fluentd rancher/mirrored-banzaicloud-fluentd v1.13.3-alpine-
 ghcr.io/banzaicloud/fluentd rancher/mirrored-banzaicloud-fluentd v1.14.4-alpine-2
 ghcr.io/banzaicloud/fluentd rancher/mirrored-banzaicloud-fluentd v1.14.5-alpine-1
 ghcr.io/banzaicloud/fluentd rancher/mirrored-banzaicloud-fluentd v1.14.6-alpine-5
-ghcr.io/kube-logging/fluentd rancher/mirrored-kube-logging-fluentd v1.16-ruby3.3-full-build.140
 ghcr.io/banzaicloud/logging-operator rancher/mirrored-banzaicloud-logging-operator 3.14.0
 ghcr.io/banzaicloud/logging-operator rancher/mirrored-banzaicloud-logging-operator 3.15.0
 ghcr.io/banzaicloud/logging-operator rancher/mirrored-banzaicloud-logging-operator 3.17.1
@@ -261,6 +260,7 @@ ghcr.io/epinio/epinio-unpacker rancher/mirrored-epinio-epinio-unpacker v1.6.2
 ghcr.io/epinio/epinio-unpacker rancher/mirrored-epinio-epinio-unpacker v1.8.1
 ghcr.io/epinio/epinio-unpacker rancher/mirrored-epinio-epinio-unpacker v1.9.0
 ghcr.io/epinio/epinio-unpacker rancher/mirrored-epinio-epinio-unpacker v1.10.0
+ghcr.io/kube-logging/fluentd rancher/mirrored-kube-logging-fluentd v1.16-ruby3.3-full-build.140
 ghcr.io/kube-logging/logging-operator rancher/mirrored-kube-logging-logging-operator 4.4.0
 ghcr.io/kube-vip/kube-vip-iptables rancher/mirrored-kube-vip-kube-vip-iptables v0.6.0
 ghcr.io/prometheus-community/windows-exporter rancher/mirrored-prometheus-windows-exporter 0.25.1

--- a/images-list
+++ b/images-list
@@ -225,7 +225,7 @@ ghcr.io/banzaicloud/fluentd rancher/mirrored-banzaicloud-fluentd v1.13.3-alpine-
 ghcr.io/banzaicloud/fluentd rancher/mirrored-banzaicloud-fluentd v1.14.4-alpine-2
 ghcr.io/banzaicloud/fluentd rancher/mirrored-banzaicloud-fluentd v1.14.5-alpine-1
 ghcr.io/banzaicloud/fluentd rancher/mirrored-banzaicloud-fluentd v1.14.6-alpine-5
-ghcr.io/kube-logging/fluentd rancher/mirrored-banzaicloud-fluentd v1.16-ruby3.3-full-build.140
+ghcr.io/kube-logging/fluentd rancher/mirrored-kube-logging-fluentd v1.16-ruby3.3-full-build.140
 ghcr.io/banzaicloud/logging-operator rancher/mirrored-banzaicloud-logging-operator 3.14.0
 ghcr.io/banzaicloud/logging-operator rancher/mirrored-banzaicloud-logging-operator 3.15.0
 ghcr.io/banzaicloud/logging-operator rancher/mirrored-banzaicloud-logging-operator 3.17.1


### PR DESCRIPTION
#### Pull Request Checklist ####

- [x] Change does not remove any existing Images or Tags in the images-list file
- [x] Change does not remove / overwrite exiting Images or Tags in Rancher DockerHub
- [ ] If updating an existing entry, verify the `SOURCE` is still accurate and upstream hasn't been migrated to a new regitry or repo (if they've migrated, a new repo request to EIO is needed to comply with the `SOURCE DESTINATION TAG` pattern)
- [x] New entries are in format `SOURCE DESTINATION TAG`
- [x] New entries are added to the correct section of the list (sorted lexicographically)
- [ ] New entries have a repo created in Rancher Dockerhub (where the image will be mirrored to)
- [x] New entries are licensed with Rancher favored licenses - Apache 2 and MIT - or approved licenses - as according to [CNCF approved licenses](https://github.com/cncf/foundation/blob/main/allowed-third-party-license-policy.md).
- [ ] New entries, when used in Rancher or Rancher's provided charts, have their corresponding origin added in Rancher's images [origins](https://github.com/rancher/rancher/blob/release/v2.7/pkg/image/origins.go) file (must be added for all Rancher versions `>= v2.7`).
- [ ] Changes to scripting or CI config have been tested to the best of your ability

#### Types of Change ####

<!-- New image, version bump. script update, etc etc -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request.  -->

Addresses part of https://github.com/rancherlabs/image-scanning/issues/1366
#### Additional Notes ####

<!-- Any additional details / test results / etc -->

#### Final Checks after the PR is merged ####
- [ ] Confirm that you can pull the new images and tags from DockerHub
