### PR TITLE
bump pause to 3.10

### DIFF
--- a/images-list
+++ b/images-list
@@ -1595,6 +1595,7 @@ registry.k8s.io/pause rancher/mirrored-pause 3.6
 registry.k8s.io/pause rancher/mirrored-pause 3.7
 registry.k8s.io/pause rancher/mirrored-pause 3.8
 registry.k8s.io/pause rancher/mirrored-pause 3.9
+registry.k8s.io/pause rancher/mirrored-pause 3.10
 registry.k8s.io/prometheus-adapter/prometheus-adapter rancher/mirrored-prometheus-adapter-prometheus-adapter v0.9.0
 registry.k8s.io/prometheus-adapter/prometheus-adapter rancher/mirrored-prometheus-adapter-prometheus-adapter v0.10.0
 registry.k8s.io/prometheus-adapter/prometheus-adapter rancher/mirrored-prometheus-adapter-prometheus-adapter v0.11.2


### PR DESCRIPTION
#### Pull Request Checklist ####

- [x] Change does not remove any existing Images or Tags in the images-list file
- [x] Change does not remove / overwrite exiting Images or Tags in Rancher DockerHub
- [x] If updating an existing entry, verify the `SOURCE` is still accurate and upstream hasn't been migrated to a new regitry or repo (if they've migrated, a new repo request to EIO is needed to comply with the `SOURCE DESTINATION TAG` pattern)
- [x] New entries are in format `SOURCE DESTINATION TAG`
- [x] New entries are added to the correct section of the list (sorted lexicographically)
- [ ] New entries have a repo created in Rancher Dockerhub (where the image will be mirrored to)
- [ ] New entries are licensed with Rancher favored licenses - Apache 2 and MIT - or approved licenses - as according to [CNCF approved licenses](https://github.com/cncf/foundation/blob/main/allowed-third-party-license-policy.md).
- [ ] New entries, when used in Rancher or Rancher's provided charts, have their corresponding origin added in Rancher's images [origins](https://github.com/rancher/rancher/blob/release/v2.7/pkg/image/origins.go) file (must be added for all Rancher versions `>= v2.7`).
- [ ] Changes to scripting or CI config have been tested to the best of your ability

#### Types of Change ####

<!-- New image, version bump. script update, etc etc -->

new version of pause image from k8s has been released (registry.k8s.io/pause:3.10). Ref: https://github.com/kubernetes/k8s.io/pull/6840

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request.  -->

#### Additional Notes ####

<!-- Any additional details / test results / etc -->

#### Final Checks after the PR is merged ####
- [ ] Confirm that you can pull the new images and tags from DockerHub
