### PR TITLE
added metrics server v0.7.1 image

### DIFF
--- a/images-list
+++ b/images-list
@@ -1589,6 +1589,7 @@ registry.k8s.io/metrics-server/metrics-server rancher/mirrored-metrics-server v0
 registry.k8s.io/metrics-server/metrics-server rancher/mirrored-metrics-server v0.6.3
 registry.k8s.io/metrics-server/metrics-server rancher/mirrored-metrics-server v0.6.4
 registry.k8s.io/metrics-server/metrics-server rancher/mirrored-metrics-server v0.7.0
+registry.k8s.io/metrics-server/metrics-server rancher/mirrored-metrics-server v0.7.1
 registry.k8s.io/pause rancher/mirrored-pause 3.4.1
 registry.k8s.io/pause rancher/mirrored-pause 3.5
 registry.k8s.io/pause rancher/mirrored-pause 3.6


### PR DESCRIPTION
#### Pull Request Checklist ####

- [X] Change does not remove any existing Images or Tags in the images-list file
- [X] Change does not remove / overwrite exiting Images or Tags in Rancher DockerHub
- [ ] If updating an existing entry, verify the `SOURCE` is still accurate and upstream hasn't been migrated to a new regitry or repo (if they've migrated, a new repo request to EIO is needed to comply with the `SOURCE DESTINATION TAG` pattern)
- [X] New entries are in format `SOURCE DESTINATION TAG`
- [X] New entries are added to the correct section of the list (sorted lexicographically)
- [X] New entries have a repo created in Rancher Dockerhub (where the image will be mirrored to)
- [X] New entries are licensed with Rancher favored licenses - Apache 2 and MIT - or approved licenses - as according to [CNCF approved licenses](https://github.com/cncf/foundation/blob/main/allowed-third-party-license-policy.md).
- [X] New entries, when used in Rancher or Rancher's provided charts, have their corresponding origin added in Rancher's images [origins](https://github.com/rancher/rancher/blob/release/v2.7/pkg/image/origins.go) file (must be added for all Rancher versions `>= v2.7`).
- [ ] Changes to scripting or CI config have been tested to the best of your ability

#### Types of Change ####
added metrics server v0.7.1 image.
<!-- New image, version bump. script update, etc etc -->

#### Linked Issues ####
https://github.com/rancher/rancher/issues/45089

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request.  -->

#### Additional Notes ####
bumping metrics server to use the latest version([v0.7.1](https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.7.1)) with k8s 1.30 version in rke.
<!-- Any additional details / test results / etc -->

#### Final Checks after the PR is merged ####
- [ ] Confirm that you can pull the new images and tags from DockerHub
