### PR TITLE
vsphere 1.29 support

### DIFF
--- a/images-list
+++ b/images-list
@@ -147,6 +147,7 @@ gcr.io/cloud-provider-vsphere/cpi/release/manager rancher/mirrored-cloud-provide
 gcr.io/cloud-provider-vsphere/cpi/release/manager rancher/mirrored-cloud-provider-vsphere-cpi-release-manager v1.26.2
 gcr.io/cloud-provider-vsphere/cpi/release/manager rancher/mirrored-cloud-provider-vsphere-cpi-release-manager v1.27.0
 gcr.io/cloud-provider-vsphere/cpi/release/manager rancher/mirrored-cloud-provider-vsphere-cpi-release-manager v1.28.0
+gcr.io/cloud-provider-vsphere/cpi/release/manager rancher/mirrored-cloud-provider-vsphere-cpi-release-manager v1.29.0
 gcr.io/cloud-provider-vsphere/csi/release/driver rancher/mirrored-cloud-provider-vsphere-csi-release-driver v2.1.0
 gcr.io/cloud-provider-vsphere/csi/release/driver rancher/mirrored-cloud-provider-vsphere-csi-release-driver v2.2.0
 gcr.io/cloud-provider-vsphere/csi/release/driver rancher/mirrored-cloud-provider-vsphere-csi-release-driver v2.2.1

--- a/images-list
+++ b/images-list
@@ -174,6 +174,7 @@ gcr.io/cloud-provider-vsphere/csi/release/driver rancher/mirrored-cloud-provider
 gcr.io/cloud-provider-vsphere/csi/release/driver rancher/mirrored-cloud-provider-vsphere-csi-release-driver v3.1.0
 gcr.io/cloud-provider-vsphere/csi/release/driver rancher/mirrored-cloud-provider-vsphere-csi-release-driver v3.1.1
 gcr.io/cloud-provider-vsphere/csi/release/driver rancher/mirrored-cloud-provider-vsphere-csi-release-driver v3.1.2
+gcr.io/cloud-provider-vsphere/csi/release/driver rancher/mirrored-cloud-provider-vsphere-csi-release-driver v3.2.0
 gcr.io/cloud-provider-vsphere/csi/release/syncer rancher/mirrored-cloud-provider-vsphere-csi-release-syncer v2.1.0
 gcr.io/cloud-provider-vsphere/csi/release/syncer rancher/mirrored-cloud-provider-vsphere-csi-release-syncer v2.2.0
 gcr.io/cloud-provider-vsphere/csi/release/syncer rancher/mirrored-cloud-provider-vsphere-csi-release-syncer v2.2.1
@@ -200,6 +201,7 @@ gcr.io/cloud-provider-vsphere/csi/release/syncer rancher/mirrored-cloud-provider
 gcr.io/cloud-provider-vsphere/csi/release/syncer rancher/mirrored-cloud-provider-vsphere-csi-release-syncer v3.1.0
 gcr.io/cloud-provider-vsphere/csi/release/syncer rancher/mirrored-cloud-provider-vsphere-csi-release-syncer v3.1.1
 gcr.io/cloud-provider-vsphere/csi/release/syncer rancher/mirrored-cloud-provider-vsphere-csi-release-syncer v3.1.2
+gcr.io/cloud-provider-vsphere/csi/release/syncer rancher/mirrored-cloud-provider-vsphere-csi-release-syncer v3.2.0
 gcr.io/google-containers/k8s-dns-node-cache rancher/mirrored-k8s-dns-node-cache 1.15.7
 gcr.io/google-containers/k8s-dns-node-cache rancher/mirrored-k8s-dns-node-cache 1.15.13
 gcr.io/google_containers/k8s-dns-dnsmasq-nanny rancher/mirrored-k8s-dns-dnsmasq-nanny 1.15.0
@@ -1614,6 +1616,7 @@ registry.k8s.io/sig-storage/csi-attacher rancher/mirrored-sig-storage-csi-attach
 registry.k8s.io/sig-storage/csi-attacher rancher/mirrored-sig-storage-csi-attacher v4.4.0
 registry.k8s.io/sig-storage/csi-attacher rancher/mirrored-sig-storage-csi-attacher v4.4.1
 registry.k8s.io/sig-storage/csi-attacher rancher/mirrored-sig-storage-csi-attacher v4.4.2
+registry.k8s.io/sig-storage/csi-attacher rancher/mirrored-sig-storage-csi-attacher v4.5.0
 registry.k8s.io/sig-storage/csi-node-driver-registrar rancher/mirrored-sig-storage-csi-node-driver-registrar v2.3.0
 registry.k8s.io/sig-storage/csi-node-driver-registrar rancher/mirrored-sig-storage-csi-node-driver-registrar v2.5.0
 registry.k8s.io/sig-storage/csi-node-driver-registrar rancher/mirrored-sig-storage-csi-node-driver-registrar v2.5.1
@@ -1622,6 +1625,7 @@ registry.k8s.io/sig-storage/csi-node-driver-registrar rancher/mirrored-sig-stora
 registry.k8s.io/sig-storage/csi-node-driver-registrar rancher/mirrored-sig-storage-csi-node-driver-registrar v2.8.0
 registry.k8s.io/sig-storage/csi-node-driver-registrar rancher/mirrored-sig-storage-csi-node-driver-registrar v2.9.0
 registry.k8s.io/sig-storage/csi-node-driver-registrar rancher/mirrored-sig-storage-csi-node-driver-registrar v2.9.1
+registry.k8s.io/sig-storage/csi-node-driver-registrar rancher/mirrored-sig-storage-csi-node-driver-registrar v2.10.0
 registry.k8s.io/sig-storage/csi-provisioner rancher/mirrored-sig-storage-csi-provisioner v2.2.0
 registry.k8s.io/sig-storage/csi-provisioner rancher/mirrored-sig-storage-csi-provisioner v3.0.0
 registry.k8s.io/sig-storage/csi-provisioner rancher/mirrored-sig-storage-csi-provisioner v3.1.0
@@ -1632,6 +1636,7 @@ registry.k8s.io/sig-storage/csi-provisioner rancher/mirrored-sig-storage-csi-pro
 registry.k8s.io/sig-storage/csi-provisioner rancher/mirrored-sig-storage-csi-provisioner v3.6.0
 registry.k8s.io/sig-storage/csi-provisioner rancher/mirrored-sig-storage-csi-provisioner v3.6.1
 registry.k8s.io/sig-storage/csi-provisioner rancher/mirrored-sig-storage-csi-provisioner v3.6.2
+registry.k8s.io/sig-storage/csi-provisioner rancher/mirrored-sig-storage-csi-provisioner v4.0.0
 registry.k8s.io/sig-storage/csi-resizer rancher/mirrored-sig-storage-csi-resizer v1.3.0
 registry.k8s.io/sig-storage/csi-resizer rancher/mirrored-sig-storage-csi-resizer v1.4.0
 registry.k8s.io/sig-storage/csi-resizer rancher/mirrored-sig-storage-csi-resizer v1.6.0
@@ -1640,10 +1645,12 @@ registry.k8s.io/sig-storage/csi-resizer rancher/mirrored-sig-storage-csi-resizer
 registry.k8s.io/sig-storage/csi-resizer rancher/mirrored-sig-storage-csi-resizer v1.9.0
 registry.k8s.io/sig-storage/csi-resizer rancher/mirrored-sig-storage-csi-resizer v1.9.1
 registry.k8s.io/sig-storage/csi-resizer rancher/mirrored-sig-storage-csi-resizer v1.9.2
+registry.k8s.io/sig-storage/csi-resizer rancher/mirrored-sig-storage-csi-resizer v1.10.0
 registry.k8s.io/sig-storage/csi-snapshotter rancher/mirrored-sig-storage-csi-snapshotter v5.0.1
 registry.k8s.io/sig-storage/csi-snapshotter rancher/mirrored-sig-storage-csi-snapshotter v6.0.1
 registry.k8s.io/sig-storage/csi-snapshotter rancher/mirrored-sig-storage-csi-snapshotter v6.2.1
 registry.k8s.io/sig-storage/csi-snapshotter rancher/mirrored-sig-storage-csi-snapshotter v6.2.2
+registry.k8s.io/sig-storage/csi-snapshotter rancher/mirrored-sig-storage-csi-snapshotter v7.0.1
 registry.k8s.io/sig-storage/livenessprobe rancher/mirrored-sig-storage-livenessprobe v2.4.0
 registry.k8s.io/sig-storage/livenessprobe rancher/mirrored-sig-storage-livenessprobe v2.6.0
 registry.k8s.io/sig-storage/livenessprobe rancher/mirrored-sig-storage-livenessprobe v2.7.0
@@ -1651,6 +1658,7 @@ registry.k8s.io/sig-storage/livenessprobe rancher/mirrored-sig-storage-livenessp
 registry.k8s.io/sig-storage/livenessprobe rancher/mirrored-sig-storage-livenessprobe v2.9.0
 registry.k8s.io/sig-storage/livenessprobe rancher/mirrored-sig-storage-livenessprobe v2.10.0
 registry.k8s.io/sig-storage/livenessprobe rancher/mirrored-sig-storage-livenessprobe v2.11.0
+registry.k8s.io/sig-storage/livenessprobe rancher/mirrored-sig-storage-livenessprobe v2.12.0
 registry.k8s.io/sig-storage/snapshot-controller rancher/mirrored-sig-storage-snapshot-controller v6.1.0
 registry.k8s.io/sig-storage/snapshot-controller rancher/mirrored-sig-storage-snapshot-controller v6.2.1
 registry.k8s.io/sig-storage/snapshot-validation-webhook rancher/mirrored-sig-storage-snapshot-validation-webhook v6.1.0


### PR DESCRIPTION
### Updates

- Added images for `vsphere-cpi-release-manager: v1.29.0`
- Added images for `vsphere-csi` version v3.2.0 support images


### Releated

- https://github.com/rancher/rancher/issues/45463
- https://github.com/rancher/rancher/issues/45464