### PR TITLE
Revert "chore: Remove unused Dockerfile.dapper"

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,0 +1,18 @@
+FROM quay.io/skopeo/stable:v1.13.2
+
+# Add jq, git, helm
+RUN yum -y update && yum -y install jq git helm && yum -y clean all && rm -rf /var/cache/dnf/* /var/log/dnf* /var/log/yum*
+
+# Add docker cli
+COPY --from=docker.io/library/docker:19.03.12 /usr/local/bin/docker /usr/local/bin/
+
+# Add buildx plugin from github
+RUN mkdir -p /usr/libexec/docker/cli-plugins/ && curl -sLo /usr/libexec/docker/cli-plugins/docker-buildx https://github.com/docker/buildx/releases/download/v0.4.2/buildx-v0.4.2.linux-amd64 && chmod a+x /usr/libexec/docker/cli-plugins/*
+
+ENV DAPPER_SOURCE /source
+ENV DAPPER_OUTPUT ./images-list
+ENV DAPPER_ENV DEST_ORG_OVERRIDE DOCKER_REGISTRY DOCKER_USERNAME DOCKER_PASSWORD FULL_IMAGES IMAGES TAGS IMAGES_FILE DRONE DRONE_COMMIT_BEFORE DRONE_COMMIT_AFTER
+ENV HOME ${DAPPER_SOURCE}
+WORKDIR ${DAPPER_SOURCE}
+
+ENTRYPOINT ["./entrypoint.sh"]


### PR DESCRIPTION
This reverts commit c402a5abad87ac7da57a3dd9620f10e1815dcfe2.

#### Types of Change ####

Dapper is still used in the validate-retrieve-image-tags-config.yml GitHub action so reverting the removal of the Dapper Dockerfile.