### PR TITLE
Remove dapper from GHA calls

### DIFF
--- a/.github/workflows/add-tag-to-existing-image.yml
+++ b/.github/workflows/add-tag-to-existing-image.yml
@@ -32,10 +32,10 @@ jobs:
         uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
       - name: Run add-tag-to-existing-image.sh
         if: github.event.inputs.images != '' && github.event.inputs.tags != ''
-        run: make add-tag-to-existing-image.sh
+        run: ./scripts/add-tag-to-existing-image.sh
       - name: Run add-full-image-wrapper.sh
         if: github.event.inputs.full_images != ''
-        run: make add-full-image-wrapper.sh
+        run: ./scripts/add-full-image-wrapper.sh
       - name: Check for repository changes
         run: |
           if git diff --name-only --exit-code; then


### PR DESCRIPTION
#### Types of Change ####

Removes dapper from GHA workflows by calling the scripts directly.

#### Linked Issues ####

Follow up for:
https://github.com/rancher/image-mirror/pull/668
https://github.com/rancher/image-mirror/pull/669

Will fix: https://github.com/rancher/image-mirror/issues/666

#### Additional Notes ####

<!-- Any additional details / test results / etc -->

