### PR TITLE
Adjust CI job for concurency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,10 @@ name: CI
 on:
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 


### PR DESCRIPTION
This change prevents redundant Actions running on a PR.

Given a situation where a PR has been created and gets updates pushed. Each update will trigger a new CI workflow to run, however only the most recent one is actually valid for the current state. As such this change will prevent the redundant jobs from running, cancelling them without error, and will allow the correct workflow to run sooner.

#### Pull Request Checklist ####

- [x] Changes to scripting or CI config have been tested to the best of your ability

#### Types of Change ####

CI Tweaks

#### Linked Issues ####

N/A; just something I noticed could benefit from this setting while crafting a PR.

#### Additional Notes ####

<!-- Any additional details / test results / etc -->

#### Final Checks after the PR is merged ####
N/A
