### PR TITLE
Moved vsphere cloud-pv registry to k8s

### DIFF
--- a/retrieve-image-tags/config.json
+++ b/retrieve-image-tags/config.json
@@ -53,8 +53,8 @@
   },
   "vsphere-csi": {
     "images": [
-      "gcr.io/cloud-provider-vsphere/csi/release/driver",
-      "gcr.io/cloud-provider-vsphere/csi/release/syncer"
+      "registry.k8s.io/csi-vsphere/driver",
+      "registry.k8s.io/csi-vsphere/syncer"
     ],
     "versionSource": "github-latest-release:kubernetes-sigs/vsphere-csi-driver"
   },
@@ -95,7 +95,7 @@
   },
   "cpi-release-manager": {
     "images": [
-      "gcr.io/cloud-provider-vsphere/cpi/release/manager"
+      "registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere"
     ],
     "versionSource": "registry",
     "versionFilter": "^v1\\.(2[4-9]|[3-9][0-9])\\.[0-9]+$"


### PR DESCRIPTION
#### Pull Request Checklist ####

- [ ] Change does not remove any existing Images or Tags in the images-list file
- [ ] Change does not remove / overwrite exiting Images or Tags in Rancher DockerHub
- [ ] If updating an existing entry, verify the `SOURCE` is still accurate and upstream hasn't been migrated to a new regitry or repo (if they've migrated, a new repo request to EIO is needed to comply with the `SOURCE DESTINATION TAG` pattern)
- [ ] New entries are in format `SOURCE DESTINATION TAG`
- [ ] New entries are added to the correct section of the list (sorted lexicographically)
- [ ] New entries have a repo created in Rancher Dockerhub (where the image will be mirrored to)
- [ ] New entries are licensed with Rancher favored licenses - Apache 2 and MIT - or approved licenses - as according to [CNCF approved licenses](https://github.com/cncf/foundation/blob/main/allowed-third-party-license-policy.md).
- [ ] New entries, when used in Rancher or Rancher's provided charts, have their corresponding origin added in Rancher's images [origins](https://github.com/rancher/rancher/blob/release/v2.7/pkg/image/origins.go) file (must be added for all Rancher versions `>= v2.7`).
- [ ] Changes to scripting or CI config have been tested to the best of your ability

#### Types of Change ####

<!-- New image, version bump. script update, etc etc -->
This PR moves the registry used to mirror vsphere cloud provider from gcr.io to registry,k8s.io because it was moved from 1.30 and the github action is failing for the missing images.

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request.  -->

#### Additional Notes ####

<!-- Any additional details / test results / etc -->

#### Final Checks after the PR is merged ####
- [ ] Confirm that you can pull the new images and tags from DockerHub
