### PR TITLE
new tag for external-snapshotter images

### DIFF
--- a/images-list
+++ b/images-list
@@ -1830,9 +1830,11 @@ registry.k8s.io/sig-storage/livenessprobe rancher/mirrored-sig-storage-livenessp
 registry.k8s.io/sig-storage/livenessprobe rancher/mirrored-sig-storage-livenessprobe v2.14.0
 registry.k8s.io/sig-storage/snapshot-controller rancher/mirrored-sig-storage-snapshot-controller v6.1.0
 registry.k8s.io/sig-storage/snapshot-controller rancher/mirrored-sig-storage-snapshot-controller v6.2.1
+registry.k8s.io/sig-storage/snapshot-controller rancher/mirrored-sig-storage-snapshot-controller v8.1.0
 registry.k8s.io/sig-storage/snapshot-validation-webhook rancher/mirrored-sig-storage-snapshot-validation-webhook v6.1.0
 registry.k8s.io/sig-storage/snapshot-validation-webhook rancher/mirrored-sig-storage-snapshot-validation-webhook v6.2.1
 registry.k8s.io/sig-storage/snapshot-validation-webhook rancher/mirrored-sig-storage-snapshot-validation-webhook v6.2.2
+registry.k8s.io/sig-storage/snapshot-validation-webhook rancher/mirrored-sig-storage-snapshot-validation-webhook v8.1.0
 registry.suse.com/bci/bci-busybox rancher/mirrored-bci-busybox 15.4.11.2
 registry.suse.com/bci/bci-busybox rancher/mirrored-bci-busybox 15.6.19.1
 registry.suse.com/bci/bci-busybox rancher/mirrored-bci-busybox 15.6.24.2

--- a/retrieve-image-tags/config.json
+++ b/retrieve-image-tags/config.json
@@ -70,6 +70,18 @@
     ],
     "versionSource": "github-latest-release:kubernetes-csi/external-resizer"
   },
+  "snapshot-controller": {
+    "images": [
+      "registry.k8s.io/sig-storage/snapshot-controller"
+    ],
+    "versionSource": "github-latest-release:kubernetes-csi/external-snapshotter"
+  },
+  "snapshot-validation-webhook": {
+    "images": [
+      "registry.k8s.io/sig-storage/snapshot-validation-webhook"
+    ],
+    "versionSource": "github-latest-release:kubernetes-csi/external-snapshotter"
+  },
   "storage-livenessprobe": {
     "images": [
       "registry.k8s.io/sig-storage/livenessprobe"


### PR DESCRIPTION
#### Pull Request Checklist ####

- [x] Change does not remove any existing Images or Tags in the images-list file
- [x] Change does not remove / overwrite exiting Images or Tags in Rancher DockerHub
- [x] If updating an existing entry, verify the `SOURCE` is still accurate and upstream hasn't been migrated to a new regitry or repo (if they've migrated, a new repo request to EIO is needed to comply with the `SOURCE DESTINATION TAG` pattern)
- [x] New entries are in format `SOURCE DESTINATION TAG`
- [x] New entries are added to the correct section of the list (sorted lexicographically)
- [x] New entries have a repo created in Rancher Dockerhub (where the image will be mirrored to)
- [x] New entries are licensed with Rancher favored licenses - Apache 2 and MIT - or approved licenses - as according to [CNCF approved licenses](https://github.com/cncf/foundation/blob/main/allowed-third-party-license-policy.md).
- [x] New entries, when used in Rancher or Rancher's provided charts, have their corresponding origin added in Rancher's images [origins](https://github.com/rancher/rancher/blob/release/v2.7/pkg/image/origins.go) file (must be added for all Rancher versions `>= v2.7`).
- [x] Changes to scripting or CI config have been tested to the best of your ability

#### Types of Change ####

<!-- New image, version bump. script update, etc etc -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request.  -->

#### Additional Notes ####

<!-- Any additional details / test results / etc -->

#### Final Checks after the PR is merged ####
- [ ] Confirm that you can pull the new images and tags from DockerHub
