### PR TITLE
Add tonistiigi/xx:1.5.0 image

### DIFF
--- a/images-list
+++ b/images-list
@@ -1894,5 +1894,6 @@ thanosio/thanos rancher/mirrored-thanosio-thanos v0.15.0
 thanosio/thanos rancher/mirrored-thanosio-thanos v0.21.1
 thanosio/thanos rancher/thanosio-thanos v0.15.0
 tonistiigi/xx rancher/mirrored-tonistiigi-xx 1.3.0
+tonistiigi/xx rancher/mirrored-tonistiigi-xx 1.5.0
 us.gcr.io/k8s-artifacts-prod/external-dns/external-dns rancher/kubernetes-external-dns v0.7.3
 us.gcr.io/k8s-artifacts-prod/external-dns/external-dns rancher/mirrored-kubernetes-external-dns v0.7.3


### PR DESCRIPTION
#### Pull Request Checklist ####

- [x] Change does not remove any existing Images or Tags in the images-list file
- [x] Change does not remove / overwrite exiting Images or Tags in Rancher DockerHub
- [x] If updating an existing entry, verify the `SOURCE` is still accurate and upstream hasn't been migrated to a new regitry or repo (if they've migrated, a new repo request to EIO is needed to comply with the `SOURCE DESTINATION TAG` pattern)
- [x] New entries are in format `SOURCE DESTINATION TAG`
- [x] New entries are added to the correct section of the list (sorted lexicographically)
- [x] New entries have a repo created in Rancher Dockerhub (where the image will be mirrored to)
- [x] New entries are licensed with Rancher favored licenses - Apache 2 and MIT - or approved licenses - as according to [CNCF approved licenses](https://github.com/cncf/foundation/blob/main/allowed-third-party-license-policy.md).
- [n/a] New entries, when used in Rancher or Rancher's provided charts, have their corresponding origin added in Rancher's images [origins](https://github.com/rancher/rancher/blob/release/v2.7/pkg/image/origins.go) file (must be added for all Rancher versions `>= v2.7`).
- [x] Changes to scripting or CI config have been tested to the best of your ability

#### Types of Change ####

Version bump for xx image

#### Linked Issues ####

n/a; just bumping as it's used in some build processes

#### Additional Notes ####

This image doesn't end up part of rancher origins, just used as part of build pipeline in various docker images.

#### Final Checks after the PR is merged ####
- [ ] Confirm that you can pull the new images and tags from DockerHub
