### PR TITLE
Add new image tags need for monitoring 105.2.0-rc.1+up65.5.1

### DIFF
--- a/images-list
+++ b/images-list
@@ -278,11 +278,13 @@ grafana/grafana rancher/mirrored-grafana-grafana 8.5.3
 grafana/grafana rancher/mirrored-grafana-grafana 9.1.5
 grafana/grafana rancher/mirrored-grafana-grafana 9.5.14
 grafana/grafana rancher/mirrored-grafana-grafana 10.3.3
+grafana/grafana rancher/mirrored-grafana-grafana 11.3.0
 grafana/grafana-image-renderer rancher/grafana-grafana-image-renderer 2.0.0
 grafana/grafana-image-renderer rancher/mirrored-grafana-grafana-image-renderer 2.0.1
 grafana/grafana-image-renderer rancher/mirrored-grafana-grafana-image-renderer 3.0.1
 grafana/grafana-image-renderer rancher/mirrored-grafana-grafana-image-renderer 3.8.0
 grafana/grafana-image-renderer rancher/mirrored-grafana-grafana-image-renderer 3.10.1
+grafana/grafana-image-renderer rancher/mirrored-grafana-grafana-image-renderer 3.11.6
 idealista/prom2teams rancher/mirrored-idealista-prom2teams 3.2.1
 idealista/prom2teams rancher/mirrored-idealista-prom2teams 3.2.2
 idealista/prom2teams rancher/mirrored-idealista-prom2teams 3.2.3
@@ -514,6 +516,7 @@ library/nginx rancher/mirrored-library-nginx 1.21.6-alpine
 library/nginx rancher/mirrored-library-nginx 1.23.0-alpine
 library/nginx rancher/mirrored-library-nginx 1.23.2-alpine
 library/nginx rancher/mirrored-library-nginx 1.24.0-alpine
+library/nginx rancher/mirrored-library-nginx 1.27.2-alpine
 library/registry rancher/mirrored-library-registry 2.7.1
 library/registry rancher/mirrored-library-registry 2.8.1
 library/traefik rancher/library-traefik 2.4.2
@@ -1510,6 +1513,7 @@ quay.io/prometheus/prometheus rancher/mirrored-prometheus-prometheus v2.42.0
 quay.io/prometheus/prometheus rancher/mirrored-prometheus-prometheus v2.45.0
 quay.io/prometheus/prometheus rancher/mirrored-prometheus-prometheus v2.48.1
 quay.io/prometheus/prometheus rancher/mirrored-prometheus-prometheus v2.50.1
+quay.io/prometheus/prometheus rancher/mirrored-prometheus-prometheus v2.55.0
 quay.io/prometheus/prometheus rancher/mirrored-prom-prometheus v2.18.2
 quay.io/prometheus/prometheus rancher/prom-prometheus v2.19.2
 quay.io/prometheus/prometheus rancher/prom-prometheus v2.22.0
@@ -1520,6 +1524,7 @@ quay.io/thanos/thanos rancher/mirrored-thanos-thanos v0.17.2
 quay.io/thanos/thanos rancher/mirrored-thanos-thanos v0.28.0
 quay.io/thanos/thanos rancher/mirrored-thanos-thanos v0.30.2
 quay.io/thanos/thanos rancher/mirrored-thanos-thanos v0.34.1
+quay.io/thanos/thanos rancher/mirrored-thanos-thanos v0.36.1
 quay.io/tigera/operator rancher/mirrored-calico-operator v1.15.1
 quay.io/tigera/operator rancher/mirrored-calico-operator v1.17.2
 quay.io/tigera/operator rancher/mirrored-calico-operator v1.17.4


### PR DESCRIPTION
#### Pull Request Checklist ####

- [x] Change does not remove any existing Images or Tags in the images-list file
- [x] Change does not remove / overwrite exiting Images or Tags in Rancher DockerHub
- [x] If updating an existing entry, verify the `SOURCE` is still accurate and upstream hasn't been migrated to a new regitry or repo (if they've migrated, a new repo request to EIO is needed to comply with the `SOURCE DESTINATION TAG` pattern)
- [n/a] New entries are in format `SOURCE DESTINATION TAG`
- [n/a] New entries are added to the correct section of the list (sorted lexicographically)
- [n/a] New entries have a repo created in Rancher Dockerhub (where the image will be mirrored to)
- [n/a] New entries are licensed with Rancher favored licenses - Apache 2 and MIT - or approved licenses - as according to [CNCF approved licenses](https://github.com/cncf/foundation/blob/main/allowed-third-party-license-policy.md).
- [n/a] New entries, when used in Rancher or Rancher's provided charts, have their corresponding origin added in Rancher's images [origins](https://github.com/rancher/rancher/blob/release/v2.7/pkg/image/origins.go) file (must be added for all Rancher versions `>= v2.7`).
- [n/a] Changes to scripting or CI config have been tested to the best of your ability

#### Types of Change ####

Bump tags for monitoring 105.2.0-rc.1+up65.5.1

#### Linked Issues ####

https://github.com/rancher/rancher/issues/47782

#### Additional Notes ####

<!-- Any additional details / test results / etc -->

#### Final Checks after the PR is merged ####
- [ ] Confirm that you can pull the new images and tags from DockerHub
