### PR TITLE
Add new image tags need for monitoring 105.2.0-rc.1+up65.5.1

### DIFF
--- a/images-list
+++ b/images-list
@@ -297,6 +297,7 @@ grafana/grafana rancher/mirrored-grafana-grafana 9.5.14
 grafana/grafana rancher/mirrored-grafana-grafana 10.3.3
 grafana/grafana rancher/mirrored-grafana-grafana 10.4.9
 grafana/grafana rancher/mirrored-grafana-grafana 11.1.0
+grafana/grafana rancher/mirrored-grafana-grafana 11.3.0
 grafana/grafana-image-renderer rancher/grafana-grafana-image-renderer 2.0.0
 grafana/grafana-image-renderer rancher/mirrored-grafana-grafana-image-renderer 2.0.1
 grafana/grafana-image-renderer rancher/mirrored-grafana-grafana-image-renderer 3.0.1
@@ -304,6 +305,7 @@ grafana/grafana-image-renderer rancher/mirrored-grafana-grafana-image-renderer 3
 grafana/grafana-image-renderer rancher/mirrored-grafana-grafana-image-renderer 3.10.1
 grafana/grafana-image-renderer rancher/mirrored-grafana-grafana-image-renderer 3.10.5
 grafana/grafana-image-renderer rancher/mirrored-grafana-grafana-image-renderer 3.11.1
+grafana/grafana-image-renderer rancher/mirrored-grafana-grafana-image-renderer 3.11.6
 idealista/prom2teams rancher/mirrored-idealista-prom2teams 3.2.1
 idealista/prom2teams rancher/mirrored-idealista-prom2teams 3.2.2
 idealista/prom2teams rancher/mirrored-idealista-prom2teams 3.2.3
@@ -534,6 +536,7 @@ library/busybox rancher/mirrored-library-busybox 1.31.1
 library/busybox rancher/mirrored-library-busybox 1.32.1
 library/busybox rancher/mirrored-library-busybox 1.34.1
 library/busybox rancher/mirrored-library-busybox 1.36.1
+library/busybox rancher/mirrored-library-busybox 1.37.0
 library/nginx rancher/library-nginx 1.19.2-alpine
 library/nginx rancher/mirrored-library-nginx 1.19.2-alpine
 library/nginx rancher/mirrored-library-nginx 1.19.9-alpine
@@ -543,6 +546,7 @@ library/nginx rancher/mirrored-library-nginx 1.21.6-alpine
 library/nginx rancher/mirrored-library-nginx 1.23.0-alpine
 library/nginx rancher/mirrored-library-nginx 1.23.2-alpine
 library/nginx rancher/mirrored-library-nginx 1.24.0-alpine
+library/nginx rancher/mirrored-library-nginx 1.27.2-alpine
 library/registry rancher/mirrored-library-registry 2.7.1
 library/registry rancher/mirrored-library-registry 2.8.1
 library/traefik rancher/library-traefik 2.4.2
@@ -1626,9 +1630,11 @@ quay.io/kiwigrid/k8s-sidecar rancher/mirrored-kiwigrid-k8s-sidecar 1.15.9
 quay.io/kiwigrid/k8s-sidecar rancher/mirrored-kiwigrid-k8s-sidecar 1.19.2
 quay.io/kiwigrid/k8s-sidecar rancher/mirrored-kiwigrid-k8s-sidecar 1.24.6
 quay.io/kiwigrid/k8s-sidecar rancher/mirrored-kiwigrid-k8s-sidecar 1.26.1
+quay.io/kiwigrid/k8s-sidecar rancher/mirrored-kiwigrid-k8s-sidecar 1.28.0
 quay.io/minio/minio rancher/mirrored-minio-minio RELEASE.2022-03-24T00-43-44Z
 quay.io/prometheus-operator/admission-webhook rancher/mirrored-prometheus-operator-admission-webhook v0.72.0
 quay.io/prometheus-operator/admission-webhook rancher/mirrored-prometheus-operator-admission-webhook v0.75.1
+quay.io/prometheus-operator/admission-webhook rancher/mirrored-prometheus-operator-admission-webhook v0.77.2
 quay.io/prometheus-operator/prometheus-config-reloader rancher/coreos-prometheus-config-reloader v0.43.0
 quay.io/prometheus-operator/prometheus-config-reloader rancher/mirrored-prometheus-operator-prometheus-config-reloader v0.46.0
 quay.io/prometheus-operator/prometheus-config-reloader rancher/mirrored-prometheus-operator-prometheus-config-reloader v0.48.0
@@ -1638,6 +1644,7 @@ quay.io/prometheus-operator/prometheus-config-reloader rancher/mirrored-promethe
 quay.io/prometheus-operator/prometheus-config-reloader rancher/mirrored-prometheus-operator-prometheus-config-reloader v0.70.0
 quay.io/prometheus-operator/prometheus-config-reloader rancher/mirrored-prometheus-operator-prometheus-config-reloader v0.72.0
 quay.io/prometheus-operator/prometheus-config-reloader rancher/mirrored-prometheus-operator-prometheus-config-reloader v0.75.1
+quay.io/prometheus-operator/prometheus-config-reloader rancher/mirrored-prometheus-operator-prometheus-config-reloader v0.77.2
 quay.io/prometheus-operator/prometheus-operator rancher/coreos-prometheus-operator v0.43.0
 quay.io/prometheus-operator/prometheus-operator rancher/mirrored-prometheus-operator-prometheus-operator v0.46.0
 quay.io/prometheus-operator/prometheus-operator rancher/mirrored-prometheus-operator-prometheus-operator v0.48.0
@@ -1647,6 +1654,7 @@ quay.io/prometheus-operator/prometheus-operator rancher/mirrored-prometheus-oper
 quay.io/prometheus-operator/prometheus-operator rancher/mirrored-prometheus-operator-prometheus-operator v0.70.0
 quay.io/prometheus-operator/prometheus-operator rancher/mirrored-prometheus-operator-prometheus-operator v0.72.0
 quay.io/prometheus-operator/prometheus-operator rancher/mirrored-prometheus-operator-prometheus-operator v0.75.1
+quay.io/prometheus-operator/prometheus-operator rancher/mirrored-prometheus-operator-prometheus-operator v0.77.2
 quay.io/prometheus/alertmanager rancher/mirrored-prometheus-alertmanager v0.22.0
 quay.io/prometheus/alertmanager rancher/mirrored-prometheus-alertmanager v0.22.2
 quay.io/prometheus/alertmanager rancher/mirrored-prometheus-alertmanager v0.24.0
@@ -1667,6 +1675,7 @@ quay.io/prometheus/prometheus rancher/mirrored-prometheus-prometheus v2.45.0
 quay.io/prometheus/prometheus rancher/mirrored-prometheus-prometheus v2.48.1
 quay.io/prometheus/prometheus rancher/mirrored-prometheus-prometheus v2.50.1
 quay.io/prometheus/prometheus rancher/mirrored-prometheus-prometheus v2.53.1
+quay.io/prometheus/prometheus rancher/mirrored-prometheus-prometheus v2.55.0
 quay.io/prometheus/prometheus rancher/mirrored-prom-prometheus v2.18.2
 quay.io/prometheus/prometheus rancher/prom-prometheus v2.19.2
 quay.io/prometheus/prometheus rancher/prom-prometheus v2.22.0
@@ -1678,6 +1687,7 @@ quay.io/thanos/thanos rancher/mirrored-thanos-thanos v0.28.0
 quay.io/thanos/thanos rancher/mirrored-thanos-thanos v0.30.2
 quay.io/thanos/thanos rancher/mirrored-thanos-thanos v0.34.1
 quay.io/thanos/thanos rancher/mirrored-thanos-thanos v0.35.1
+quay.io/thanos/thanos rancher/mirrored-thanos-thanos v0.36.1
 quay.io/tigera/operator rancher/mirrored-calico-operator v1.15.1
 quay.io/tigera/operator rancher/mirrored-calico-operator v1.17.2
 quay.io/tigera/operator rancher/mirrored-calico-operator v1.17.4
@@ -1785,6 +1795,7 @@ registry.k8s.io/kube-state-metrics/kube-state-metrics rancher/mirrored-kube-stat
 registry.k8s.io/kube-state-metrics/kube-state-metrics rancher/mirrored-kube-state-metrics-kube-state-metrics v2.6.0
 registry.k8s.io/kube-state-metrics/kube-state-metrics rancher/mirrored-kube-state-metrics-kube-state-metrics v2.10.1
 registry.k8s.io/kube-state-metrics/kube-state-metrics rancher/mirrored-kube-state-metrics-kube-state-metrics v2.12.0
+registry.k8s.io/kube-state-metrics/kube-state-metrics rancher/mirrored-kube-state-metrics-kube-state-metrics v2.13.0
 registry.k8s.io/metrics-server/metrics-server rancher/metrics-server v0.4.1
 registry.k8s.io/metrics-server/metrics-server rancher/mirrored-metrics-server v0.4.1
 registry.k8s.io/metrics-server/metrics-server rancher/mirrored-metrics-server v0.4.4


### PR DESCRIPTION
#### Pull Request Checklist ####

- [x] Change does not remove any existing Images or Tags in the images-list file
- [x] Change does not remove / overwrite exiting Images or Tags in Rancher DockerHub
- [x] If updating an existing entry, verify the `SOURCE` is still accurate and upstream hasn't been migrated to a new regitry or repo (if they've migrated, a new repo request to EIO is needed to comply with the `SOURCE DESTINATION TAG` pattern)
- [n/a] New entries are in format `SOURCE DESTINATION TAG`
- [n/a] New entries are added to the correct section of the list (sorted lexicographically)
- [n/a] New entries have a repo created in Rancher Dockerhub (where the image will be mirrored to)
- [n/a] New entries are licensed with Rancher favored licenses - Apache 2 and MIT - or approved licenses - as according to [CNCF approved licenses](https://github.com/cncf/foundation/blob/main/allowed-third-party-license-policy.md).
- [n/a] New entries, when used in Rancher or Rancher's provided charts, have their corresponding origin added in Rancher's images [origins](https://github.com/rancher/rancher/blob/release/v2.7/pkg/image/origins.go) file (must be added for all Rancher versions `>= v2.7`).
- [n/a] Changes to scripting or CI config have been tested to the best of your ability

#### Types of Change ####

Bump tags for monitoring 105.2.0-rc.1+up65.5.1

#### Linked Issues ####

https://github.com/rancher/rancher/issues/47782

#### Additional Notes ####

<!-- Any additional details / test results / etc -->

#### Final Checks after the PR is merged ####
- [ ] Confirm that you can pull the new images and tags from DockerHub
