### PR TITLE
New image tags for logging rebase to 4.10.0

### DIFF
--- a/images-list
+++ b/images-list
@@ -124,6 +124,8 @@ fluent/fluent-bit rancher/mirrored-fluent-fluent-bit 2.2.0
 fluent/fluent-bit rancher/mirrored-fluent-fluent-bit 2.2.0-debug
 fluent/fluent-bit rancher/mirrored-fluent-fluent-bit 3.0.4
 fluent/fluent-bit rancher/mirrored-fluent-fluent-bit 3.0.4-debug
+fluent/fluent-bit rancher/mirrored-fluent-fluent-bit 3.1.8
+fluent/fluent-bit rancher/mirrored-fluent-fluent-bit 3.1.8-debug
 gcr.io/cloud-provider-vsphere/cpi/release/manager rancher/mirrored-cloud-provider-vsphere-cpi-release-manager v1.2.1
 gcr.io/cloud-provider-vsphere/cpi/release/manager rancher/mirrored-cloud-provider-vsphere-cpi-release-manager v1.18.0
 gcr.io/cloud-provider-vsphere/cpi/release/manager rancher/mirrored-cloud-provider-vsphere-cpi-release-manager v1.19.0
@@ -276,11 +278,14 @@ ghcr.io/epinio/epinio-unpacker rancher/mirrored-epinio-epinio-unpacker v1.9.0
 ghcr.io/epinio/epinio-unpacker rancher/mirrored-epinio-epinio-unpacker v1.10.0
 ghcr.io/jimmidyson/configmap-reload rancher/mirrored-jimmidyson-configmap-reload v0.13.1
 ghcr.io/kube-logging/config-reloader rancher/mirrored-kube-logging-config-reloader v0.0.5
+ghcr.io/kube-logging/config-reloader rancher/mirrored-kube-logging-config-reloader v0.0.6
 ghcr.io/kube-logging/fluentd rancher/mirrored-kube-logging-fluentd v1.16-4.8-full
 ghcr.io/kube-logging/fluentd rancher/mirrored-kube-logging-fluentd v1.16-ruby3.3-full-build.140
+ghcr.io/kube-logging/fluentd rancher/mirrored-kube-logging-fluentd v1.16-4.10-full
 ghcr.io/kube-logging/logging-operator rancher/mirrored-kube-logging-logging-operator 4.4.0
 ghcr.io/kube-logging/logging-operator rancher/mirrored-kube-logging-logging-operator 4.8.0
 ghcr.io/kube-logging/logging-operator rancher/mirrored-kube-logging-logging-operator 4.9.1
+ghcr.io/kube-logging/logging-operator rancher/mirrored-kube-logging-logging-operator 4.10.0
 ghcr.io/kube-vip/kube-vip-iptables rancher/mirrored-kube-vip-kube-vip-iptables v0.6.0
 ghcr.io/kube-vip/kube-vip-iptables rancher/mirrored-kube-vip-kube-vip-iptables v0.8.4
 ghcr.io/prometheus-community/windows-exporter rancher/mirrored-prometheus-windows-exporter 0.25.1

--- a/images-list
+++ b/images-list
@@ -280,8 +280,8 @@ ghcr.io/jimmidyson/configmap-reload rancher/mirrored-jimmidyson-configmap-reload
 ghcr.io/kube-logging/config-reloader rancher/mirrored-kube-logging-config-reloader v0.0.5
 ghcr.io/kube-logging/config-reloader rancher/mirrored-kube-logging-config-reloader v0.0.6
 ghcr.io/kube-logging/fluentd rancher/mirrored-kube-logging-fluentd v1.16-4.8-full
-ghcr.io/kube-logging/fluentd rancher/mirrored-kube-logging-fluentd v1.16-ruby3.3-full-build.140
 ghcr.io/kube-logging/fluentd rancher/mirrored-kube-logging-fluentd v1.16-4.10-full
+ghcr.io/kube-logging/fluentd rancher/mirrored-kube-logging-fluentd v1.16-ruby3.3-full-build.140
 ghcr.io/kube-logging/logging-operator rancher/mirrored-kube-logging-logging-operator 4.4.0
 ghcr.io/kube-logging/logging-operator rancher/mirrored-kube-logging-logging-operator 4.8.0
 ghcr.io/kube-logging/logging-operator rancher/mirrored-kube-logging-logging-operator 4.9.1


### PR DESCRIPTION
#### Pull Request Checklist ####

- [x] Change does not remove any existing Images or Tags in the images-list file
- [x] Change does not remove / overwrite exiting Images or Tags in Rancher DockerHub
- [x] If updating an existing entry, verify the `SOURCE` is still accurate and upstream hasn't been migrated to a new regitry or repo (if they've migrated, a new repo request to EIO is needed to comply with the `SOURCE DESTINATION TAG` pattern)
- [x] New entries are in format `SOURCE DESTINATION TAG`
- [x] New entries are added to the correct section of the list (sorted lexicographically)
- [x] New entries have a repo created in Rancher Dockerhub (where the image will be mirrored to)
- [x] New entries are licensed with Rancher favored licenses - Apache 2 and MIT - or approved licenses - as according to [CNCF approved licenses](https://github.com/cncf/foundation/blob/main/allowed-third-party-license-policy.md).
- [x] New entries, when used in Rancher or Rancher's provided charts, have their corresponding origin added in Rancher's images [origins](https://github.com/rancher/rancher/blob/release/v2.7/pkg/image/origins.go) file (must be added for all Rancher versions `>= v2.7`).
- [x] Changes to scripting or CI config have been tested to the best of your ability

#### Types of Change ####

<!-- New image, version bump. script update, etc etc -->

#### Linked Issues ####

https://github.com/rancher/rancher/issues/47783

#### Additional Notes ####

<!-- Any additional details / test results / etc -->

#### Final Checks after the PR is merged ####
- [ ] Confirm that you can pull the new images and tags from DockerHub
