### PR TITLE
Add new image ztunnel

### DIFF
--- a/images-list
+++ b/images-list
@@ -375,6 +375,10 @@ istio/install-cni rancher/mirrored-istio-install-cni 1.22.1
 istio/install-cni rancher/mirrored-istio-install-cni 1.22.1-distroless
 istio/install-cni rancher/mirrored-istio-install-cni 1.23.2
 istio/install-cni rancher/mirrored-istio-install-cni 1.23.2-distroless
+istio/install-cni rancher/mirrored-istio-install-cni 1.23.3
+istio/install-cni rancher/mirrored-istio-install-cni 1.23.3-distroless
+istio/install-cni rancher/mirrored-istio-install-cni 1.24.0
+istio/install-cni rancher/mirrored-istio-install-cni 1.24.0-distroless
 istio/kubectl rancher/istio-kubectl 1.5.10
 istio/kubectl rancher/mirrored-istio-kubectl 1.5.9
 istio/mixer rancher/istio-mixer 1.7.0
@@ -440,6 +444,10 @@ istio/pilot rancher/mirrored-istio-pilot 1.22.1
 istio/pilot rancher/mirrored-istio-pilot 1.22.1-distroless
 istio/pilot rancher/mirrored-istio-pilot 1.23.2
 istio/pilot rancher/mirrored-istio-pilot 1.23.2-distroless
+istio/pilot rancher/mirrored-istio-pilot 1.23.3
+istio/pilot rancher/mirrored-istio-pilot 1.23.3-distroless
+istio/pilot rancher/mirrored-istio-pilot 1.24.0
+istio/pilot rancher/mirrored-istio-pilot 1.24.0-distroless
 istio/proxyv2 rancher/istio-proxyv2 1.7.0
 istio/proxyv2 rancher/istio-proxyv2 1.7.1
 istio/proxyv2 rancher/istio-proxyv2 1.7.3
@@ -496,7 +504,15 @@ istio/proxyv2 rancher/mirrored-istio-proxyv2 1.22.1
 istio/proxyv2 rancher/mirrored-istio-proxyv2 1.22.1-distroless
 istio/proxyv2 rancher/mirrored-istio-proxyv2 1.23.2
 istio/proxyv2 rancher/mirrored-istio-proxyv2 1.23.2-distroless
+istio/proxyv2 rancher/mirrored-istio-proxyv2 1.23.3
+istio/proxyv2 rancher/mirrored-istio-proxyv2 1.23.3-distroless
+istio/proxyv2 rancher/mirrored-istio-proxyv2 1.24.0
+istio/proxyv2 rancher/mirrored-istio-proxyv2 1.24.0-distroless
 istio/sidecar_injector rancher/mirrored-istio-sidecar_injector 1.5.9
+istio/ztunnel rancher/mirrored-istio-ztunnel 1.23.3
+istio/ztunnel rancher/mirrored-istio-ztunnel 1.23.3-distroless
+istio/ztunnel rancher/mirrored-istio-ztunnel 1.24.0
+istio/ztunnel rancher/mirrored-istio-ztunnel 1.24.0-distroless
 jaegertracing/all-in-one rancher/jaegertracing-all-in-one 1.20.0
 jaegertracing/all-in-one rancher/mirrored-jaegertracing-all-in-one 1.14
 jaegertracing/all-in-one rancher/mirrored-jaegertracing-all-in-one 1.20.0
@@ -518,6 +534,7 @@ jaegertracing/all-in-one rancher/mirrored-jaegertracing-all-in-one 1.53.0
 jaegertracing/all-in-one rancher/mirrored-jaegertracing-all-in-one 1.56.0
 jaegertracing/all-in-one rancher/mirrored-jaegertracing-all-in-one 1.57.0
 jaegertracing/all-in-one rancher/mirrored-jaegertracing-all-in-one 1.60.0
+jaegertracing/all-in-one rancher/mirrored-jaegertracing-all-in-one 1.63.0
 jenkins/jnlp-slave rancher/mirrored-jenkins-jnlp-slave 3.35-4
 jenkins/jnlp-slave rancher/mirrored-jenkins-jnlp-slave 4.7-1
 jettech/kube-webhook-certgen rancher/jettech-kube-webhook-certgen v1.2.1
@@ -1636,6 +1653,7 @@ quay.io/kiali/kiali rancher/mirrored-kiali-kiali v1.79.0
 quay.io/kiali/kiali rancher/mirrored-kiali-kiali v1.85.0
 quay.io/kiali/kiali rancher/mirrored-kiali-kiali v1.86.0
 quay.io/kiali/kiali rancher/mirrored-kiali-kiali v1.89.3
+quay.io/kiali/kiali rancher/mirrored-kiali-kiali v2.0.0
 quay.io/kiwigrid/k8s-sidecar rancher/mirrored-kiwigrid-k8s-sidecar 1.10.7
 quay.io/kiwigrid/k8s-sidecar rancher/mirrored-kiwigrid-k8s-sidecar 1.12.2
 quay.io/kiwigrid/k8s-sidecar rancher/mirrored-kiwigrid-k8s-sidecar 1.12.3


### PR DESCRIPTION
#### Pull Request Checklist ####

- [x] Change does not remove any existing Images or Tags in the images-list file
- [x] Change does not remove / overwrite exiting Images or Tags in Rancher DockerHub
- [x] If updating an existing entry, verify the `SOURCE` is still accurate and upstream hasn't been migrated to a new registry or repo (if they've migrated, a new repo request to EIO is needed to comply with the `SOURCE DESTINATION TAG` pattern)
- [x] New entries are in format `SOURCE DESTINATION TAG`
- [x] New entries are added to the correct section of the list (sorted lexicographically)
- [ ] New entries have a repo created in Rancher Dockerhub (where the image will be mirrored to)
- [x] New entries are licensed with Rancher favored licenses - Apache 2 and MIT - or approved licenses - as according to [CNCF approved licenses](https://github.com/cncf/foundation/blob/main/allowed-third-party-license-policy.md).
- [ ] New entries, when used in Rancher or Rancher's provided charts, have their corresponding origin added in Rancher's images [origins](https://github.com/rancher/rancher/blob/release/v2.7/pkg/image/origins.go) file (must be added for all Rancher versions `>= v2.7`).
- [x] Changes to scripting or CI config have been tested to the best of your ability

#### Types of Change ####

Added new image ztunnel.
Added tags for latest Istio releases: 1.23.3 and 1.24.0.

#### Additional Notes ####

The changes are needed to enable Istio ambient profile to be installed.

#### Final Checks after the PR is merged ####
- [ ] Confirm that you can pull the new images and tags from DockerHub