### PR TITLE
add fluent-bit windows images to correct repository

### DIFF
--- a/images-list
+++ b/images-list
@@ -94,6 +94,8 @@ flannel/flannel rancher/mirrored-flannel-flannel v0.26.1
 flannel/flannel-cni-plugin rancher/mirrored-flannel-flannel-cni-plugin v1.2.0
 flannel/flannel-cni-plugin rancher/mirrored-flannel-flannel-cni-plugin v1.5.1-flannel1
 flannel/flannel-cni-plugin rancher/mirrored-flannel-flannel-cni-plugin v1.5.1-flannel2
+fluent/fluent-bit rancher/fluent-bit windows-2019-3.1.8
+fluent/fluent-bit rancher/fluent-bit windows-2022-3.1.8
 fluent/fluent-bit rancher/fluent-fluent-bit 1.5.4
 fluent/fluent-bit rancher/fluent-fluent-bit 1.5.4-debug
 fluent/fluent-bit rancher/fluent-fluent-bit 1.6.1

--- a/images-list
+++ b/images-list
@@ -131,8 +131,6 @@ fluent/fluent-bit rancher/mirrored-fluent-fluent-bit 3.0.4
 fluent/fluent-bit rancher/mirrored-fluent-fluent-bit 3.0.4-debug
 fluent/fluent-bit rancher/mirrored-fluent-fluent-bit 3.1.8
 fluent/fluent-bit rancher/mirrored-fluent-fluent-bit 3.1.8-debug
-fluent/fluent-bit rancher/mirrored-fluent-fluent-bit windows-2019-3.1.8
-fluent/fluent-bit rancher/mirrored-fluent-fluent-bit windows-2022-3.1.8
 gcr.io/cloud-provider-vsphere/cpi/release/manager rancher/mirrored-cloud-provider-vsphere-cpi-release-manager v1.2.1
 gcr.io/cloud-provider-vsphere/cpi/release/manager rancher/mirrored-cloud-provider-vsphere-cpi-release-manager v1.18.0
 gcr.io/cloud-provider-vsphere/cpi/release/manager rancher/mirrored-cloud-provider-vsphere-cpi-release-manager v1.19.0


### PR DESCRIPTION
#### Pull Request Checklist ####

- [x] Change does not remove any existing Images or Tags in the images-list file
- [x] Change does not remove / overwrite exiting Images or Tags in Rancher DockerHub
- [x] If updating an existing entry, verify the `SOURCE` is still accurate and upstream hasn't been migrated to a new regitry or repo (if they've migrated, a new repo request to EIO is needed to comply with the `SOURCE DESTINATION TAG` pattern)
- [x] New entries are in format `SOURCE DESTINATION TAG`
- [x] New entries are added to the correct section of the list (sorted lexicographically)
- [x] New entries have a repo created in Rancher Dockerhub (where the image will be mirrored to)
- [x] New entries are licensed with Rancher favored licenses - Apache 2 and MIT - or approved licenses - as according to [CNCF approved licenses](https://github.com/cncf/foundation/blob/main/allowed-third-party-license-policy.md).
- [x] New entries, when used in Rancher or Rancher's provided charts, have their corresponding origin added in Rancher's images [origins](https://github.com/rancher/rancher/blob/release/v2.7/pkg/image/origins.go) file (must be added for all Rancher versions `>= v2.7`).
- [x] Changes to scripting or CI config have been tested to the best of your ability

#### Types of Change ####

Previous PR mirrored these images to the wrong repo

#### Linked Issues ####

https://github.com/rancher/rancher/issues/47911

#### Additional Notes ####

<!-- Any additional details / test results / etc -->

#### Final Checks after the PR is merged ####
- [ ] Confirm that you can pull the new images and tags from DockerHub
