### PR TITLE
New image tags for logging fluent-bit image

### DIFF
--- a/images-list
+++ b/images-list
@@ -132,6 +132,8 @@ fluent/fluent-bit rancher/mirrored-fluent-fluent-bit 3.0.4
 fluent/fluent-bit rancher/mirrored-fluent-fluent-bit 3.0.4-debug
 fluent/fluent-bit rancher/mirrored-fluent-fluent-bit 3.1.8
 fluent/fluent-bit rancher/mirrored-fluent-fluent-bit 3.1.8-debug
+fluent/fluent-bit rancher/mirrored-fluent-fluent-bit 3.2.4
+fluent/fluent-bit rancher/mirrored-fluent-fluent-bit 3.2.4-debug
 gcr.io/cloud-provider-vsphere/cpi/release/manager rancher/mirrored-cloud-provider-vsphere-cpi-release-manager v1.2.1
 gcr.io/cloud-provider-vsphere/cpi/release/manager rancher/mirrored-cloud-provider-vsphere-cpi-release-manager v1.18.0
 gcr.io/cloud-provider-vsphere/cpi/release/manager rancher/mirrored-cloud-provider-vsphere-cpi-release-manager v1.19.0


### PR DESCRIPTION
#### Pull Request Checklist ####

- [x] Change does not remove any existing Images or Tags in the images-list file
- [x] Change does not remove / overwrite exiting Images or Tags in Rancher DockerHub
- [x] If updating an existing entry, verify the `SOURCE` is still accurate and upstream hasn't been migrated to a new registry or repo (if they've migrated, a new repo request to EIO is needed to comply with the `SOURCE DESTINATION TAG` pattern)
- [x] New entries are in format `SOURCE DESTINATION TAG`
- [x] New entries are added to the correct section of the list (sorted lexicographically)
- [x] New entries have a repo created in Rancher Dockerhub (where the image will be mirrored to)
- [x] New entries are licensed with Rancher favored licenses - Apache 2 and MIT - or approved licenses - as according to [CNCF approved licenses](https://github.com/cncf/foundation/blob/main/allowed-third-party-license-policy.md).
- [ ] New entries, when used in Rancher or Rancher's provided charts, have their corresponding origin added in Rancher's images [origins](https://github.com/rancher/rancher/blob/release/v2.7/pkg/image/origins.go) file (must be added for all Rancher versions `>= v2.7`).
- [x] Changes to scripting or CI config have been tested to the best of your ability

#### Types of Change ####

New Image tag added for fluent/fluent-bit image

#### Linked Issues ####

https://github.com/rancherlabs/image-scanning/issues/4095 

#### Additional Notes ####

#### Final Checks after the PR is merged ####
- [ ] Confirm that you can pull the new images and tags from DockerHub
