### PR TITLE
Process image lines concurrently, 10 at a time

### DIFF
--- a/scripts/image-mirror.sh
+++ b/scripts/image-mirror.sh
@@ -215,10 +215,20 @@ else
   exit 1
 fi
 
+MAX_POOL_SIZE=10
+CURRENT_POOL_SIZE=0
+
 echo "Reading SOURCE DESTINATION TAG from ${IMAGES_FILE}"
 while IFS= read -r LINE; do
+
+  while [ $CURRENT_POOL_SIZE -ge $MAX_POOL_SIZE ]; do
+    CURRENT_POOL_SIZE=$(jobs | wc -l)
+  done
+
   echo -e "\nLine: ${LINE}"
   if grep -P '^(?!\s*(#|//))\S+\s+\S+\s+\S+' <<< ${LINE}; then
-    mirror_image ${LINE}
+    mirror_image ${LINE} &
   fi
 done < "${IMAGES_FILE}"
+
+wait < <(jobs -p)


### PR DESCRIPTION
#### Pull Request Checklist ####

- [x] Change does not remove any existing Images or Tags in the images-list file
- [x] Change does not remove / overwrite exiting Images or Tags in Rancher DockerHub
- [x] If updating an existing entry, verify the `SOURCE` is still accurate and upstream hasn't been migrated to a new regitry or repo (if they've migrated, a new repo request to EIO is needed to comply with the `SOURCE DESTINATION TAG` pattern)
- [x] New entries are in format `SOURCE DESTINATION TAG`
- [x] New entries are added to the correct section of the list (sorted lexicographically)
- [x] New entries have a repo created in Rancher Dockerhub (where the image will be mirrored to)
- [x] New entries are licensed with Rancher favored licenses - Apache 2 and MIT - or approved licenses - as according to [CNCF approved licenses](https://github.com/cncf/foundation/blob/main/allowed-third-party-license-policy.md).
- [x] New entries, when used in Rancher or Rancher's provided charts, have their corresponding origin added in Rancher's images [origins](https://github.com/rancher/rancher/blob/release/v2.7/pkg/image/origins.go) file (must be added for all Rancher versions `>= v2.7`).
- [x] Changes to scripting or CI config have been tested to the best of your ability

#### Types of Change ####
Instead of sequentially processing each image line (most of which are old versions and no-op), allow 10 concurrent processes to work on a line. This should dramatically improve performance of the script times. 
<!-- New image, version bump. script update, etc etc -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request.  -->

#### Additional Notes ####

<!-- Any additional details / test results / etc -->

#### Final Checks after the PR is merged ####
- [ ] Confirm that you can pull the new images and tags from DockerHub
