### PR TITLE
Add auto-update for latest traefik3 image

### DIFF
--- a/retrieve-image-tags/config.json
+++ b/retrieve-image-tags/config.json
@@ -39,6 +39,14 @@
     "versionFilter": "^2\\.[0-9]+\\.[0-9]+$",
     "latest": true
   },
+  "traefik3": {
+    "images": [
+      "library/traefik"
+    ],
+    "versionSource": "registry",
+    "versionFilter": "^3\\.[0-9]+\\.[0-9]+$",
+    "latest": true
+  },
   "sonobuoy": {
     "images": [
       "sonobuoy/sonobuoy"


### PR DESCRIPTION
#### Pull Request Checklist ####

- [x] Change does not remove any existing Images or Tags in the images-list file
- [x] Change does not remove / overwrite exiting Images or Tags in Rancher DockerHub
- [x] If updating an existing entry, verify the `SOURCE` is still accurate and upstream hasn't been migrated to a new regitry or repo (if they've migrated, a new repo request to EIO is needed to comply with the `SOURCE DESTINATION TAG` pattern)
- [x] New entries are in format `SOURCE DESTINATION TAG`
- [x] New entries are added to the correct section of the list (sorted lexicographically)
- [x] New entries have a repo created in Rancher Dockerhub (where the image will be mirrored to)
- [x] New entries are licensed with Rancher favored licenses - Apache 2 and MIT - or approved licenses - as according to [CNCF approved licenses](https://github.com/cncf/foundation/blob/main/allowed-third-party-license-policy.md).
- [x] New entries, when used in Rancher or Rancher's provided charts, have their corresponding origin added in Rancher's images [origins](https://github.com/rancher/rancher/blob/release/v2.7/pkg/image/origins.go) file (must be added for all Rancher versions `>= v2.7`).
- [x] Changes to scripting or CI config have been tested to the best of your ability

#### Types of Change ####

automated version bump

#### Linked Issues ####

* https://github.com/k3s-io/k3s/issues/10526

#### Additional Notes ####


#### Final Checks after the PR is merged ####
- [ ] Confirm that you can pull the new images and tags from DockerHub
