### PR TITLE
add new kube-rbac-proxy and prometheus-operator-admission-webhook

### DIFF
--- a/images-list
+++ b/images-list
@@ -244,6 +244,7 @@ gcr.io/kubebuilder/kube-rbac-proxy rancher/kube-rbac-proxy v0.5.0
 gcr.io/kubebuilder/kube-rbac-proxy rancher/mirrored-kube-rbac-proxy v0.5.0
 gcr.io/kubebuilder/kube-rbac-proxy rancher/mirrored-kube-rbac-proxy v0.14.0
 gcr.io/kubebuilder/kube-rbac-proxy rancher/mirrored-kube-rbac-proxy v0.15.0
+gcr.io/kubebuilder/kube-rbac-proxy rancher/mirrored-kube-rbac-proxy v0.18.2
 ghcr.io/banzaicloud/fluentd rancher/mirrored-banzaicloud-fluentd v1.12.4-alpine-1
 ghcr.io/banzaicloud/fluentd rancher/mirrored-banzaicloud-fluentd v1.13.3-alpine-1
 ghcr.io/banzaicloud/fluentd rancher/mirrored-banzaicloud-fluentd v1.13.3-alpine-11
@@ -1749,6 +1750,7 @@ quay.io/minio/minio rancher/mirrored-minio-minio RELEASE.2022-03-24T00-43-44Z
 quay.io/prometheus-operator/admission-webhook rancher/mirrored-prometheus-operator-admission-webhook v0.72.0
 quay.io/prometheus-operator/admission-webhook rancher/mirrored-prometheus-operator-admission-webhook v0.75.1
 quay.io/prometheus-operator/admission-webhook rancher/mirrored-prometheus-operator-admission-webhook v0.77.2
+quay.io/prometheus-operator/admission-webhook rancher/mirrored-prometheus-operator-admission-webhook v0.79.0
 quay.io/prometheus-operator/prometheus-config-reloader rancher/coreos-prometheus-config-reloader v0.43.0
 quay.io/prometheus-operator/prometheus-config-reloader rancher/mirrored-prometheus-operator-prometheus-config-reloader v0.46.0
 quay.io/prometheus-operator/prometheus-config-reloader rancher/mirrored-prometheus-operator-prometheus-config-reloader v0.48.0

--- a/images-list
+++ b/images-list
@@ -244,7 +244,6 @@ gcr.io/kubebuilder/kube-rbac-proxy rancher/kube-rbac-proxy v0.5.0
 gcr.io/kubebuilder/kube-rbac-proxy rancher/mirrored-kube-rbac-proxy v0.5.0
 gcr.io/kubebuilder/kube-rbac-proxy rancher/mirrored-kube-rbac-proxy v0.14.0
 gcr.io/kubebuilder/kube-rbac-proxy rancher/mirrored-kube-rbac-proxy v0.15.0
-gcr.io/kubebuilder/kube-rbac-proxy rancher/mirrored-kube-rbac-proxy v0.18.2
 ghcr.io/banzaicloud/fluentd rancher/mirrored-banzaicloud-fluentd v1.12.4-alpine-1
 ghcr.io/banzaicloud/fluentd rancher/mirrored-banzaicloud-fluentd v1.13.3-alpine-1
 ghcr.io/banzaicloud/fluentd rancher/mirrored-banzaicloud-fluentd v1.13.3-alpine-11
@@ -1101,6 +1100,7 @@ prom/prometheus rancher/mirrored-prom-prometheus v2.12.0
 prom/prometheus rancher/prom-prometheus v2.18.2
 pstauffer/curl rancher/mirrored-pstauffer-curl v1.0.3
 quay.io/brancz/kube-rbac-proxy rancher/mirrored-brancz-kube-rbac-proxy v0.18.0
+quay.io/brancz/kube-rbac-proxy rancher/mirrored-brancz-kube-rbac-proxy v0.18.2
 quay.io/calico/apiserver rancher/mirrored-calico-apiserver v3.20.1
 quay.io/calico/apiserver rancher/mirrored-calico-apiserver v3.20.2
 quay.io/calico/apiserver rancher/mirrored-calico-apiserver v3.21.2


### PR DESCRIPTION
#### Pull Request Checklist ####

- [x] Change does not remove any existing Images or Tags in the images-list file
- [x] Change does not remove / overwrite exiting Images or Tags in Rancher DockerHub
- [x] If updating an existing entry, verify the `SOURCE` is still accurate and upstream hasn't been migrated to a new regitry or repo (if they've migrated, a new repo request to EIO is needed to comply with the `SOURCE DESTINATION TAG` pattern)
- [x] New entries are in format `SOURCE DESTINATION TAG`
- [x] New entries are added to the correct section of the list (sorted lexicographically)
- [x] New entries have a repo created in Rancher Dockerhub (where the image will be mirrored to)
- [x] New entries are licensed with Rancher favored licenses - Apache 2 and MIT - or approved licenses - as according to [CNCF approved licenses](https://github.com/cncf/foundation/blob/main/allowed-third-party-license-policy.md).
- [x] New entries, when used in Rancher or Rancher's provided charts, have their corresponding origin added in Rancher's images [origins](https://github.com/rancher/rancher/blob/release/v2.7/pkg/image/origins.go) file (must be added for all Rancher versions `>= v2.7`).
- [n/a] Changes to scripting or CI config have been tested to the best of your ability

#### Types of Change ####
Version Bumps for new charts

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request.  -->

#### Additional Notes ####

<!-- Any additional details / test results / etc -->

#### Final Checks after the PR is merged ####
- [ ] Confirm that you can pull the new images and tags from DockerHub
