### PR TITLE
Add github actions workflow for mirroring images using regsync

### DIFF
--- a/.github/workflows/mirror-images-regsync.yml
+++ b/.github/workflows/mirror-images-regsync.yml
@@ -13,8 +13,28 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Read Secrets
+      - name: Check for secrets being set by workflow_dispatch
+        id: check_manual_secrets
+        run: |
+          if [ -n "${{ secrets.DEBUG_DOCKER_USERNAME }}" ]; then
+            echo "manual_secrets=true" >> $GITHUB_OUTPUT
+          elif [ -n "${{ secrets.DEBUG_DOCKER_PASSWORD }}" ]; then
+            echo "manual_secrets=true" >> $GITHUB_OUTPUT
+          elif [ -n "${{ secrets.DEBUG_APPCO_USERNAME }}" ]; then
+            echo "manual_secrets=true" >> $GITHUB_OUTPUT
+          elif [ -n "${{ secrets.DEBUG_APPCO_PASSWORD }}" ]; then
+            echo "manual_secrets=true" >> $GITHUB_OUTPUT
+          elif [ -n "${{ secrets.DEBUG_PRIME_USERNAME }}" ]; then
+            echo "manual_secrets=true" >> $GITHUB_OUTPUT
+          elif [ -n "${{ secrets.DEBUG_PRIME_PASSWORD }}" ]; then
+            echo "manual_secrets=true" >> $GITHUB_OUTPUT
+          else
+            echo "manual_secrets=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Read Secrets (only if not set in workflow_dispatch)
         uses: rancher-eio/read-vault-secrets@main
+        if: ${{ steps.check_manual_secrets.outputs.manual_secrets == 'true' }}
         with:
           secrets: |
             secret/data/github/repo/${{ github.repository }}/dockerhub/rancher/credentials username | DOCKER_USERNAME ;
@@ -33,9 +53,12 @@ jobs:
         run: |
           time regsync once --config --missing regsync.yaml
         env:
-          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-          APPCO_USERNAME: ${{ secrets.APPCO_USERNAME }}
-          APPCO_PASSWORD: ${{ secrets.APPCO_PASSWORD }}
-          PRIME_USERNAME: ${{ secrets.PRIME_USERNAME }}
-          PRIME_PASSWORD: ${{ secrets.PRIME_PASSWORD }}
+          # We use a ternary operator here. See
+          # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/evaluate-expressions-in-workflows-and-actions#example
+          # for more details.
+          DOCKER_USERNAME: ${{ secrets.DEBUG_DOCKER_USERNAME && secrets.DEBUG_DOCKER_USERNAME || secrets.DOCKER_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.DEBUG_DOCKER_PASSWORD && secrets.DEBUG_DOCKER_PASSWORD || secrets.DOCKER_PASSWORD }}
+          APPCO_USERNAME: ${{ secrets.DEBUG_APPCO_USERNAME && secrets.DEBUG_APPCO_USERNAME || secrets.APPCO_USERNAME }}
+          APPCO_PASSWORD: ${{ secrets.DEBUG_APPCO_PASSWORD && secrets.DEBUG_APPCO_PASSWORD || secrets.APPCO_PASSWORD }}
+          PRIME_USERNAME: ${{ secrets.DEBUG_PRIME_USERNAME && secrets.DEBUG_PRIME_USERNAME || secrets.PRIME_USERNAME }}
+          PRIME_PASSWORD: ${{ secrets.DEBUG_PRIME_PASSWORD && secrets.DEBUG_PRIME_PASSWORD || secrets.PRIME_PASSWORD }}

--- a/.github/workflows/mirror-images-regsync.yml
+++ b/.github/workflows/mirror-images-regsync.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Read Secrets (only if not set in workflow_dispatch)
         uses: rancher-eio/read-vault-secrets@main
-        if: ${{ steps.check_manual_secrets.outputs.manual_secrets == 'true' }}
+        if: ${{ steps.check_manual_secrets.outputs.manual_secrets == 'false' }}
         with:
           secrets: |
             secret/data/github/repo/${{ github.repository }}/dockerhub/rancher/credentials username | DOCKER_USERNAME ;

--- a/.github/workflows/mirror-images-regsync.yml
+++ b/.github/workflows/mirror-images-regsync.yml
@@ -1,0 +1,41 @@
+name: Mirror Images Using regsync
+
+on:
+  workflow_dispatch: {}
+
+jobs:
+  mirror-images:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Read Secrets
+        uses: rancher-eio/read-vault-secrets@main
+        with:
+          secrets: |
+            secret/data/github/repo/${{ github.repository }}/dockerhub/rancher/credentials username | DOCKER_USERNAME ;
+            secret/data/github/repo/${{ github.repository }}/dockerhub/rancher/credentials password | DOCKER_PASSWORD ;
+            secret/data/github/repo/${{ github.repository }}/application-collection/credentials username | APPCO_USERNAME ;
+            secret/data/github/repo/${{ github.repository }}/application-collection/credentials password | APPCO_PASSWORD ;
+            secret/data/github/repo/${{ github.repository }}/rancher-prime-registry/credentials username | PRIME_USERNAME ;
+            secret/data/github/repo/${{ github.repository }}/rancher-prime-registry/credentials password | PRIME_PASSWORD
+
+      - name: Install regsync
+        run: |
+          curl --silent --fail --location --output regsync https://github.com/regclient/regclient/releases/download/v0.5.1/regsync-linux-amd64
+          chmod +x regsync
+
+      - name: Sync Container Images
+        run: |
+          time regsync once --config --missing regsync.yaml
+        env:
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+          APPCO_USERNAME: ${{ secrets.APPCO_USERNAME }}
+          APPCO_PASSWORD: ${{ secrets.APPCO_PASSWORD }}
+          PRIME_USERNAME: ${{ secrets.PRIME_USERNAME }}
+          PRIME_PASSWORD: ${{ secrets.PRIME_PASSWORD }}

--- a/.github/workflows/mirror-images-regsync.yml
+++ b/.github/workflows/mirror-images-regsync.yml
@@ -13,28 +13,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Check for secrets being set by workflow_dispatch
-        id: check_manual_secrets
-        run: |
-          if [ -n "${{ secrets.DEBUG_DOCKER_USERNAME }}" ]; then
-            echo "manual_secrets=true" >> $GITHUB_OUTPUT
-          elif [ -n "${{ secrets.DEBUG_DOCKER_PASSWORD }}" ]; then
-            echo "manual_secrets=true" >> $GITHUB_OUTPUT
-          elif [ -n "${{ secrets.DEBUG_APPCO_USERNAME }}" ]; then
-            echo "manual_secrets=true" >> $GITHUB_OUTPUT
-          elif [ -n "${{ secrets.DEBUG_APPCO_PASSWORD }}" ]; then
-            echo "manual_secrets=true" >> $GITHUB_OUTPUT
-          elif [ -n "${{ secrets.DEBUG_PRIME_USERNAME }}" ]; then
-            echo "manual_secrets=true" >> $GITHUB_OUTPUT
-          elif [ -n "${{ secrets.DEBUG_PRIME_PASSWORD }}" ]; then
-            echo "manual_secrets=true" >> $GITHUB_OUTPUT
-          else
-            echo "manual_secrets=false" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Read Secrets (only if not set in workflow_dispatch)
+      - name: Read Secrets
         uses: rancher-eio/read-vault-secrets@main
-        if: ${{ steps.check_manual_secrets.outputs.manual_secrets == 'false' }}
         with:
           secrets: |
             secret/data/github/repo/${{ github.repository }}/dockerhub/rancher/credentials username | DOCKER_USERNAME ;
@@ -53,12 +33,9 @@ jobs:
         run: |
           time regsync once --config --missing regsync.yaml
         env:
-          # We use a ternary operator here. See
-          # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/evaluate-expressions-in-workflows-and-actions#example
-          # for more details.
-          DOCKER_USERNAME: ${{ secrets.DEBUG_DOCKER_USERNAME && secrets.DEBUG_DOCKER_USERNAME || secrets.DOCKER_USERNAME }}
-          DOCKER_PASSWORD: ${{ secrets.DEBUG_DOCKER_PASSWORD && secrets.DEBUG_DOCKER_PASSWORD || secrets.DOCKER_PASSWORD }}
-          APPCO_USERNAME: ${{ secrets.DEBUG_APPCO_USERNAME && secrets.DEBUG_APPCO_USERNAME || secrets.APPCO_USERNAME }}
-          APPCO_PASSWORD: ${{ secrets.DEBUG_APPCO_PASSWORD && secrets.DEBUG_APPCO_PASSWORD || secrets.APPCO_PASSWORD }}
-          PRIME_USERNAME: ${{ secrets.DEBUG_PRIME_USERNAME && secrets.DEBUG_PRIME_USERNAME || secrets.PRIME_USERNAME }}
-          PRIME_PASSWORD: ${{ secrets.DEBUG_PRIME_PASSWORD && secrets.DEBUG_PRIME_PASSWORD || secrets.PRIME_PASSWORD }}
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+          APPCO_USERNAME: ${{ secrets.APPCO_USERNAME }}
+          APPCO_PASSWORD: ${{ secrets.APPCO_PASSWORD }}
+          PRIME_USERNAME: ${{ secrets.PRIME_USERNAME }}
+          PRIME_PASSWORD: ${{ secrets.PRIME_PASSWORD }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,0 +1,33 @@
+name: Pull request checks
+
+on: [pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.23'
+
+      - name: Run unit tests
+        run: |
+          cd tools
+          go test ./...
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.23'
+
+      - name: Run linter
+        uses: golangci/golangci-lint-action@v5
+        with:
+          working-directory: tools
+          args: --timeout=5m

--- a/config.yaml
+++ b/config.yaml
@@ -1,12 +1,18 @@
 Repositories:
-  - EnvVarPrefix: APPCO
-    BaseUrl: dp.apps.rancher.io/containers
-  - EnvVarPrefix: DOCKER
-    BaseUrl: docker.io/rancher
+  - BaseUrl: dp.apps.rancher.io/containers
+    Registry: dp.apps.rancher.io
+    Username: '{{ env "APPCO_USERNAME" }}'
+    Password: '{{ env "APPCO_PASSWORD" }}'
+  - BaseUrl: docker.io/rancher
     Target: true
-  - EnvVarPrefix: PRIME
-    BaseUrl: registry.suse.com/rancher
+    Registry: docker.io
+    Username: '{{ env "DOCKER_USERNAME" }}'
+    Password: '{{ env "DOCKER_PASSWORD" }}'
+  - BaseUrl: registry.suse.com/rancher
     Target: true
+    Registry: registry.suse.com
+    Username: '{{ env "PRIME_USERNAME" }}'
+    Password: '{{ env "PRIME_PASSWORD" }}'
 Images:
   - SourceImage: test-org/test-image
     Tags:

--- a/config.yaml
+++ b/config.yaml
@@ -1,10 +1,10 @@
 Repositories:
-  - EnvVarPrefix: DISTRIBUTION_PLATFORM
+  - EnvVarPrefix: APPCO
     BaseUrl: dp.apps.rancher.io/containers
-  - EnvVarPrefix: DOCKER_HUB
+  - EnvVarPrefix: DOCKER
     BaseUrl: docker.io/rancher
     Target: true
-  - EnvVarPrefix: PRIME_REGISTRY
+  - EnvVarPrefix: PRIME
     BaseUrl: registry.suse.com/rancher
     Target: true
 Images:

--- a/regsync.yaml
+++ b/regsync.yaml
@@ -2,15 +2,15 @@
 # THIS FILE IS AUTO-GENERATED. DO NOT MODIFY IT.
 ##################################################
 creds:
-- pass: '{{ env "DISTRIBUTION_PLATFORM_PASSWORD" }}'
-  registry: '{{ env "DISTRIBUTION_PLATFORM_ENDPOINT" }}'
-  user: '{{ env "DISTRIBUTION_PLATFORM_USERNAME" }}'
-- pass: '{{ env "DOCKER_HUB_PASSWORD" }}'
-  registry: '{{ env "DOCKER_HUB_ENDPOINT" }}'
-  user: '{{ env "DOCKER_HUB_USERNAME" }}'
-- pass: '{{ env "PRIME_REGISTRY_PASSWORD" }}'
-  registry: '{{ env "PRIME_REGISTRY_ENDPOINT" }}'
-  user: '{{ env "PRIME_REGISTRY_USERNAME" }}'
+- pass: '{{ env "APPCO_PASSWORD" }}'
+  registry: '{{ env "APPCO_ENDPOINT" }}'
+  user: '{{ env "APPCO_USERNAME" }}'
+- pass: '{{ env "DOCKER_PASSWORD" }}'
+  registry: '{{ env "DOCKER_ENDPOINT" }}'
+  user: '{{ env "DOCKER_USERNAME" }}'
+- pass: '{{ env "PRIME_PASSWORD" }}'
+  registry: '{{ env "PRIME_ENDPOINT" }}'
+  user: '{{ env "PRIME_USERNAME" }}'
 sync:
 - source: test-org/test-image:v1.2.3
   target: docker.io/rancher/mirrored-test-org-test-image:v1.2.3

--- a/regsync.yaml
+++ b/regsync.yaml
@@ -3,13 +3,13 @@
 ##################################################
 creds:
 - pass: '{{ env "APPCO_PASSWORD" }}'
-  registry: '{{ env "APPCO_ENDPOINT" }}'
+  registry: dp.apps.rancher.io
   user: '{{ env "APPCO_USERNAME" }}'
 - pass: '{{ env "DOCKER_PASSWORD" }}'
-  registry: '{{ env "DOCKER_ENDPOINT" }}'
+  registry: docker.io
   user: '{{ env "DOCKER_USERNAME" }}'
 - pass: '{{ env "PRIME_PASSWORD" }}'
-  registry: '{{ env "PRIME_ENDPOINT" }}'
+  registry: registry.suse.com
   user: '{{ env "PRIME_USERNAME" }}'
 sync:
 - source: test-org/test-image:v1.2.3

--- a/tools/main.go
+++ b/tools/main.go
@@ -55,9 +55,9 @@ func generateRegsyncYaml(ctx *cli.Context) error {
 	}
 	for _, targetRepository := range cfg.Repositories {
 		credEntry := regsync.ConfigCred{
-			Registry: fmt.Sprintf(`{{ env "%s_ENDPOINT" }}`, targetRepository.EnvVarPrefix),
-			User:     fmt.Sprintf(`{{ env "%s_USERNAME" }}`, targetRepository.EnvVarPrefix),
-			Pass:     fmt.Sprintf(`{{ env "%s_PASSWORD" }}`, targetRepository.EnvVarPrefix),
+			Registry: targetRepository.Registry,
+			User:     targetRepository.Username,
+			Pass:     targetRepository.Password,
 		}
 		regsyncYaml.Creds = append(regsyncYaml.Creds, credEntry)
 	}

--- a/tools/main_test.go
+++ b/tools/main_test.go
@@ -58,8 +58,7 @@ func TestGetRegsyncEntries(t *testing.T) {
 				},
 			}
 			inputRepository := config.Repository{
-				EnvVarPrefix: "TEST1",
-				BaseUrl:      "docker.io/test1",
+				BaseUrl: "docker.io/test1",
 			}
 			regsyncEntries, err := convertConfigImageToRegsyncImages(inputRepository, inputImage)
 			if err != nil {

--- a/tools/pkg/config/config.go
+++ b/tools/pkg/config/config.go
@@ -24,10 +24,26 @@ type Image struct {
 }
 
 type Repository struct {
-	BaseUrl      string
-	EnvVarPrefix string
+	// BaseUrl is used exclusively for building the target image ref
+	// for a given image for a repository. For example, a target
+	// image name of "mirrored-rancher-cis-operator" and a BaseUrl
+	// of "docker.io/rancher" produce a target image ref of
+	// "docker.io/rancher/mirrored-rancher-cis-operator".
+	BaseUrl string
 	// Whether the repository should have images mirrored to it.
 	Target bool
+	// Password is what goes into the "pass" field of regsync.yaml
+	// for this repository. For more information please see
+	// https://github.com/regclient/regclient/blob/main/docs/regsync.md
+	Password string
+	// Registry is what goes into the "registry" field of regsync.yaml
+	// for this repository. For more information please see
+	// https://github.com/regclient/regclient/blob/main/docs/regsync.md
+	Registry string
+	// Username is what goes into the "user" field of regsync.yaml
+	// for this repository. For more information please see
+	// https://github.com/regclient/regclient/blob/main/docs/regsync.md
+	Username string
 }
 
 func Parse(fileName string) (Config, error) {


### PR DESCRIPTION
Also:
- Add a workflow for running `golangci-lint` and `go test` on Go code during PR checks.
- Simplify user/password/registry settings in `config.yaml`.

Until we are more confident in these changes, regsync-based mirroring can only be triggered via a `workflow_dispatch` event.