### PR TITLE
Introduce code to automate migration of `images-list` and `images-list-daily`

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,25 +1,26 @@
-Repositories:
-  - BaseUrl: dp.apps.rancher.io/containers
-    Registry: dp.apps.rancher.io
-    Username: '{{ env "APPCO_USERNAME" }}'
-    Password: '{{ env "APPCO_PASSWORD" }}'
-  - BaseUrl: docker.io/rancher
-    Target: true
-    Registry: docker.io
-    Username: '{{ env "DOCKER_USERNAME" }}'
-    Password: '{{ env "DOCKER_PASSWORD" }}'
-  - BaseUrl: registry.suse.com/rancher
-    Target: true
-    Registry: registry.suse.com
-    Username: '{{ env "PRIME_USERNAME" }}'
-    Password: '{{ env "PRIME_PASSWORD" }}'
 Images:
-  - SourceImage: test-org/test-image
-    Tags:
-      - v1.2.3
-      - v2.3.4
-  - SourceImage: docker.io/test-org/test-image-2
-    Tags:
-      - v2.3.4
-      - v4.50.6
-      - v40.5.6
+- SourceImage: docker.io/test-org/test-image-2
+  Tags:
+  - v2.3.4
+  - v4.50.6
+  - v40.5.6
+- SourceImage: test-org/test-image
+  Tags:
+  - v1.2.3
+  - v2.3.4
+Repositories:
+- BaseUrl: docker.io/rancher
+  Password: '{{ env "DOCKER_PASSWORD" }}'
+  Registry: docker.io
+  Target: true
+  Username: '{{ env "DOCKER_USERNAME" }}'
+- BaseUrl: dp.apps.rancher.io/containers
+  Password: '{{ env "APPCO_PASSWORD" }}'
+  Registry: dp.apps.rancher.io
+  Target: false
+  Username: '{{ env "APPCO_USERNAME" }}'
+- BaseUrl: registry.suse.com/rancher
+  Password: '{{ env "PRIME_PASSWORD" }}'
+  Registry: registry.suse.com
+  Target: true
+  Username: '{{ env "PRIME_USERNAME" }}'

--- a/regsync.yaml
+++ b/regsync.yaml
@@ -2,28 +2,16 @@
 # THIS FILE IS AUTO-GENERATED. DO NOT MODIFY IT.
 ##################################################
 creds:
-- pass: '{{ env "APPCO_PASSWORD" }}'
-  registry: dp.apps.rancher.io
-  user: '{{ env "APPCO_USERNAME" }}'
 - pass: '{{ env "DOCKER_PASSWORD" }}'
   registry: docker.io
   user: '{{ env "DOCKER_USERNAME" }}'
+- pass: '{{ env "APPCO_PASSWORD" }}'
+  registry: dp.apps.rancher.io
+  user: '{{ env "APPCO_USERNAME" }}'
 - pass: '{{ env "PRIME_PASSWORD" }}'
   registry: registry.suse.com
   user: '{{ env "PRIME_USERNAME" }}'
 sync:
-- source: test-org/test-image:v1.2.3
-  target: docker.io/rancher/mirrored-test-org-test-image:v1.2.3
-  type: image
-- source: test-org/test-image:v2.3.4
-  target: docker.io/rancher/mirrored-test-org-test-image:v2.3.4
-  type: image
-- source: test-org/test-image:v1.2.3
-  target: registry.suse.com/rancher/mirrored-test-org-test-image:v1.2.3
-  type: image
-- source: test-org/test-image:v2.3.4
-  target: registry.suse.com/rancher/mirrored-test-org-test-image:v2.3.4
-  type: image
 - source: docker.io/test-org/test-image-2:v2.3.4
   target: docker.io/rancher/mirrored-test-org-test-image-2:v2.3.4
   type: image
@@ -41,4 +29,16 @@ sync:
   type: image
 - source: docker.io/test-org/test-image-2:v40.5.6
   target: registry.suse.com/rancher/mirrored-test-org-test-image-2:v40.5.6
+  type: image
+- source: test-org/test-image:v1.2.3
+  target: docker.io/rancher/mirrored-test-org-test-image:v1.2.3
+  type: image
+- source: test-org/test-image:v2.3.4
+  target: docker.io/rancher/mirrored-test-org-test-image:v2.3.4
+  type: image
+- source: test-org/test-image:v1.2.3
+  target: registry.suse.com/rancher/mirrored-test-org-test-image:v1.2.3
+  type: image
+- source: test-org/test-image:v2.3.4
+  target: registry.suse.com/rancher/mirrored-test-org-test-image:v2.3.4
   type: image

--- a/tools/.golangci.yaml
+++ b/tools/.golangci.yaml
@@ -1,0 +1,7 @@
+version: "2"
+linters:
+  exclusions:
+    rules:
+      - linters:
+          - errcheck
+        source: "defer fd.Close()"

--- a/tools/main.go
+++ b/tools/main.go
@@ -34,6 +34,11 @@ func main() {
 		},
 		Commands: []*cli.Command{
 			{
+				Name:   "format",
+				Usage:  "Enforce formatting on certain files",
+				Action: formatFiles,
+			},
+			{
 				Name:   "generate-regsync",
 				Usage:  "Generate regsync.yaml",
 				Action: generateRegsyncYaml,
@@ -189,4 +194,15 @@ func convertImageListEntryToImage(imageListEntry legacy.ImagesListEntry) (*confi
 	image.SetTargetImageName(targetImageName)
 
 	return image, nil
+}
+
+func formatFiles(_ context.Context, _ *cli.Command) error {
+	configJson, err := config.Parse(configYamlPath)
+	if err != nil {
+		return fmt.Errorf("failed to parse config: %w", err)
+	}
+	if err := config.Write(configYamlPath, configJson); err != nil {
+		return fmt.Errorf("failed to write config: %w", err)
+	}
+	return nil
 }

--- a/tools/main.go
+++ b/tools/main.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"strings"
 
 	"github.com/rancher/image-mirror/pkg/config"
 	"github.com/rancher/image-mirror/pkg/regsync"
@@ -86,22 +85,11 @@ func generateRegsyncYaml(_ context.Context, _ *cli.Command) error {
 // convertConfigImageToRegsyncImages converts image into one ConfigSync (i.e. an
 // image for regsync to sync) for each tag present in image. repo provides the
 // target repository for each ConfigSync.
-func convertConfigImageToRegsyncImages(repo config.Repository, image config.Image) ([]regsync.ConfigSync, error) {
-	targetImageName := image.TargetImageName
-	if targetImageName == "" {
-		parts := strings.Split(image.SourceImage, "/")
-		if len(parts) < 2 {
-			return nil, fmt.Errorf("source image split into %d parts (>=2 parts expected)", len(parts))
-		}
-		repoName := parts[len(parts)-2]
-		imageName := parts[len(parts)-1]
-		targetImageName = "mirrored-" + repoName + "-" + imageName
-	}
-
+func convertConfigImageToRegsyncImages(repo config.Repository, image *config.Image) ([]regsync.ConfigSync, error) {
 	entries := make([]regsync.ConfigSync, 0, len(image.Tags))
 	for _, tag := range image.Tags {
 		sourceImage := image.SourceImage + ":" + tag
-		targetImage := repo.BaseUrl + "/" + targetImageName + ":" + tag
+		targetImage := repo.BaseUrl + "/" + image.TargetImageName() + ":" + tag
 		entry := regsync.ConfigSync{
 			Source: sourceImage,
 			Target: targetImage,

--- a/tools/main.go
+++ b/tools/main.go
@@ -121,7 +121,7 @@ func migrateImagesList(_ context.Context, cmd *cli.Command) error {
 	}
 	accumulator := config.NewImageAccumulator()
 	for _, existingImage := range configYaml.Images {
-		accumulator.AddImage(*existingImage)
+		accumulator.AddImage(existingImage)
 	}
 
 	legacyImages, err := legacy.ParseImagesList(imagesListPath)
@@ -143,7 +143,7 @@ func migrateImagesList(_ context.Context, cmd *cli.Command) error {
 		if err != nil {
 			return fmt.Errorf("failed to convert %q: %w", legacyImage, err)
 		}
-		accumulator.AddImage(*newImage)
+		accumulator.AddImage(newImage)
 	}
 
 	// set config.Images to accumulated images and write config

--- a/tools/main_test.go
+++ b/tools/main_test.go
@@ -10,14 +10,14 @@ import (
 
 func TestGetRegsyncEntries(t *testing.T) {
 	type TestCase struct {
-		Name            string
-		TargetImageName string
-		ExpectedEntries []regsync.ConfigSync
+		Name                     string
+		SpecifiedTargetImageName string
+		ExpectedEntries          []regsync.ConfigSync
 	}
 	for _, testCase := range []TestCase{
 		{
-			Name:            "should use default image name when TargetImageName is not set",
-			TargetImageName: "",
+			Name:                     "should use default image name when TargetImageName is not set",
+			SpecifiedTargetImageName: "",
 			ExpectedEntries: []regsync.ConfigSync{
 				{
 					Source: "test-org/test-image:v1.2.3",
@@ -32,8 +32,8 @@ func TestGetRegsyncEntries(t *testing.T) {
 			},
 		},
 		{
-			Name:            "should use TargetImageName when it is set",
-			TargetImageName: "other-org-test-image",
+			Name:                     "should use TargetImageName when it is set",
+			SpecifiedTargetImageName: "other-org-test-image",
 			ExpectedEntries: []regsync.ConfigSync{
 				{
 					Source: "test-org/test-image:v1.2.3",
@@ -49,14 +49,17 @@ func TestGetRegsyncEntries(t *testing.T) {
 		},
 	} {
 		t.Run(testCase.Name, func(t *testing.T) {
-			inputImage := config.Image{
-				SourceImage:     "test-org/test-image",
-				TargetImageName: testCase.TargetImageName,
+			inputImage := &config.Image{
+				SourceImage: "test-org/test-image",
 				Tags: []string{
 					"v1.2.3",
 					"v2.3.4",
 				},
 			}
+			if err := inputImage.SetDefaults(); err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+			inputImage.SetTargetImageName(testCase.SpecifiedTargetImageName)
 			inputRepository := config.Repository{
 				BaseUrl: "docker.io/test1",
 			}

--- a/tools/main_test.go
+++ b/tools/main_test.go
@@ -49,14 +49,11 @@ func TestGetRegsyncEntries(t *testing.T) {
 		},
 	} {
 		t.Run(testCase.Name, func(t *testing.T) {
-			inputImage := &config.Image{
-				SourceImage: "test-org/test-image",
-				Tags: []string{
-					"v1.2.3",
-					"v2.3.4",
-				},
-			}
-			if err := inputImage.SetDefaults(); err != nil {
+			inputImage, err := config.NewImage("test-org/test-image", []string{
+				"v1.2.3",
+				"v2.3.4",
+			})
+			if err != nil {
 				t.Fatalf("unexpected error: %s", err)
 			}
 			inputImage.SetTargetImageName(testCase.SpecifiedTargetImageName)

--- a/tools/pkg/config/accumulator.go
+++ b/tools/pkg/config/accumulator.go
@@ -10,16 +10,16 @@ type sourceTargetPair struct {
 }
 
 type ImageAccumulator struct {
-	mapping map[sourceTargetPair]Image
+	mapping map[sourceTargetPair]*Image
 }
 
 func NewImageAccumulator() *ImageAccumulator {
 	return &ImageAccumulator{
-		mapping: map[sourceTargetPair]Image{},
+		mapping: map[sourceTargetPair]*Image{},
 	}
 }
 
-func (ia *ImageAccumulator) AddImage(newImage Image) {
+func (ia *ImageAccumulator) AddImage(newImage *Image) {
 	pair := sourceTargetPair{
 		SourceImage:     newImage.SourceImage,
 		TargetImageName: newImage.TargetImageName(),
@@ -40,7 +40,7 @@ func (ia *ImageAccumulator) AddImage(newImage Image) {
 func (ia *ImageAccumulator) Images() []*Image {
 	images := make([]*Image, 0, len(ia.mapping))
 	for _, image := range ia.mapping {
-		images = append(images, &image)
+		images = append(images, image)
 	}
 	return images
 }

--- a/tools/pkg/config/accumulator.go
+++ b/tools/pkg/config/accumulator.go
@@ -1,0 +1,46 @@
+package config
+
+import (
+	"slices"
+)
+
+type sourceTargetPair struct {
+	SourceImage     string
+	TargetImageName string
+}
+
+type ImageAccumulator struct {
+	mapping map[sourceTargetPair]Image
+}
+
+func NewImageAccumulator() *ImageAccumulator {
+	return &ImageAccumulator{
+		mapping: map[sourceTargetPair]Image{},
+	}
+}
+
+func (ia *ImageAccumulator) AddImage(newImage Image) {
+	pair := sourceTargetPair{
+		SourceImage:     newImage.SourceImage,
+		TargetImageName: newImage.TargetImageName(),
+	}
+	existingImage, ok := ia.mapping[pair]
+	if !ok {
+		ia.mapping[pair] = newImage
+	} else {
+		for _, newTag := range newImage.Tags {
+			if !slices.Contains(existingImage.Tags, newTag) {
+				existingImage.Tags = append(existingImage.Tags, newTag)
+			}
+		}
+		ia.mapping[pair] = existingImage
+	}
+}
+
+func (ia *ImageAccumulator) Images() []*Image {
+	images := make([]*Image, 0, len(ia.mapping))
+	for _, image := range ia.mapping {
+		images = append(images, &image)
+	}
+	return images
+}

--- a/tools/pkg/config/config.go
+++ b/tools/pkg/config/config.go
@@ -3,22 +3,26 @@ package config
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"sigs.k8s.io/yaml"
 )
 
 type Config struct {
-	Images       []Image
+	Images       []*Image
 	Repositories []Repository
 }
 
 type Image struct {
-	// The source image without any tags. For example: rancher/rancher
-	// or ghcr.io/banzaicloud/fluentd.
-	SourceImage string
-	// Used to specify the desired name of the image on the target. If it
-	// is not specified, defaults to mirrored-<repoName>-<imageName>.
-	TargetImageName string
+	// The source image without any tags.
+	SourceImage            string
+	defaultTargetImageName string
+	// Used to specify the desired name of the target image if it differs
+	// from default. This field would be private if it was convenient for
+	// marshalling to JSON/YAML, but it is not. This field should not be
+	// accessed directly - instead, use the TargetImageName() and
+	// SetTargetImageName() methods.
+	SpecifiedTargetImageName string `json:"TargetImageName,omitempty"`
 	// The tags that we want to mirror.
 	Tags []string
 }
@@ -57,5 +61,37 @@ func Parse(fileName string) (Config, error) {
 		return Config{}, fmt.Errorf("failed to unmarshal as JSON: %w", err)
 	}
 
+	for _, image := range config.Images {
+		if err := image.SetDefaults(); err != nil {
+			return Config{}, fmt.Errorf("failed to set defaults for image %q: %w", image, err)
+		}
+	}
+
 	return config, nil
+}
+
+func (image *Image) SetDefaults() error {
+	parts := strings.Split(image.SourceImage, "/")
+	if len(parts) < 2 {
+		return fmt.Errorf("source image split into %d parts (>=2 parts expected)", len(parts))
+	}
+	repoName := parts[len(parts)-2]
+	imageName := parts[len(parts)-1]
+	image.defaultTargetImageName = "mirrored-" + repoName + "-" + imageName
+	return nil
+}
+
+func (image Image) TargetImageName() string {
+	if image.SpecifiedTargetImageName != "" {
+		return image.SpecifiedTargetImageName
+	}
+	return image.defaultTargetImageName
+}
+
+func (image *Image) SetTargetImageName(value string) {
+	if value == image.defaultTargetImageName {
+		image.SpecifiedTargetImageName = ""
+	} else {
+		image.SpecifiedTargetImageName = value
+	}
 }

--- a/tools/pkg/config/config.go
+++ b/tools/pkg/config/config.go
@@ -70,6 +70,19 @@ func Parse(fileName string) (Config, error) {
 	return config, nil
 }
 
+func Write(fileName string, config Config) error {
+	contents, err := yaml.Marshal(config)
+	if err != nil {
+		return fmt.Errorf("failed to unmarshal as JSON: %w", err)
+	}
+
+	if err := os.WriteFile(fileName, contents, 0o644); err != nil {
+		return fmt.Errorf("failed to write: %w", err)
+	}
+
+	return nil
+}
+
 func (image *Image) SetDefaults() error {
 	parts := strings.Split(image.SourceImage, "/")
 	if len(parts) < 2 {

--- a/tools/pkg/config/config.go
+++ b/tools/pkg/config/config.go
@@ -131,7 +131,7 @@ func (image *Image) setDefaults() error {
 	return nil
 }
 
-func (image Image) TargetImageName() string {
+func (image *Image) TargetImageName() string {
 	if image.SpecifiedTargetImageName != "" {
 		return image.SpecifiedTargetImageName
 	}

--- a/tools/pkg/config/config.go
+++ b/tools/pkg/config/config.go
@@ -14,6 +14,7 @@ type Config struct {
 	Repositories []Repository
 }
 
+// Image should not be instantiated directly. Instead, use NewImage().
 type Image struct {
 	// The source image without any tags.
 	SourceImage            string
@@ -63,7 +64,7 @@ func Parse(fileName string) (Config, error) {
 	}
 
 	for _, image := range config.Images {
-		if err := image.SetDefaults(); err != nil {
+		if err := image.setDefaults(); err != nil {
 			return Config{}, fmt.Errorf("failed to set defaults for image %q: %w", image, err)
 		}
 	}
@@ -105,11 +106,21 @@ func compareRepositories(a, b Repository) int {
 	return strings.Compare(a.BaseUrl, b.BaseUrl)
 }
 
+func NewImage(sourceImage string, tags []string) (*Image, error) {
+	image := &Image{
+		SourceImage: sourceImage,
+		Tags:        tags,
+	}
+	if err := image.setDefaults(); err != nil {
+		return nil, err
+	}
+	return image, nil
+}
 func (image *Image) Sort() {
 	slices.Sort(image.Tags)
 }
 
-func (image *Image) SetDefaults() error {
+func (image *Image) setDefaults() error {
 	parts := strings.Split(image.SourceImage, "/")
 	if len(parts) < 2 {
 		return fmt.Errorf("source image split into %d parts (>=2 parts expected)", len(parts))

--- a/tools/pkg/config/config_test.go
+++ b/tools/pkg/config/config_test.go
@@ -1,0 +1,56 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestImage(t *testing.T) {
+	t.Run("TargetImageName", func(t *testing.T) {
+		t.Run("should return default when targetImageName is not set", func(t *testing.T) {
+			image := Image{
+				SpecifiedTargetImageName: "",
+				defaultTargetImageName:   "default",
+			}
+			assert.Equal(t, "default", image.TargetImageName())
+		})
+
+		t.Run("should return targetImageName when targetImageName is set", func(t *testing.T) {
+			image := Image{
+				SpecifiedTargetImageName: "non-default",
+				defaultTargetImageName:   "default",
+			}
+			assert.Equal(t, "non-default", image.TargetImageName())
+		})
+	})
+
+	t.Run("SetTargetImageName", func(t *testing.T) {
+		t.Run(`should set targetImageName to "" when passed value matches default`, func(t *testing.T) {
+			image := Image{
+				SpecifiedTargetImageName: "non-default",
+				defaultTargetImageName:   "default",
+			}
+			image.SetTargetImageName("default")
+			assert.Equal(t, "", image.SpecifiedTargetImageName)
+		})
+
+		t.Run(`should set targetImageName to "" when passed value is ""`, func(t *testing.T) {
+			image := Image{
+				SpecifiedTargetImageName: "non-default",
+				defaultTargetImageName:   "default",
+			}
+			image.SetTargetImageName("")
+			assert.Equal(t, "", image.SpecifiedTargetImageName)
+		})
+
+		t.Run(`should set targetImageName to value when passed value does not match default`, func(t *testing.T) {
+			image := Image{
+				SpecifiedTargetImageName: "non-default",
+				defaultTargetImageName:   "default",
+			}
+			image.SetTargetImageName("another-not-default")
+			assert.Equal(t, "another-not-default", image.TargetImageName())
+		})
+	})
+}

--- a/tools/pkg/legacy/config.go
+++ b/tools/pkg/legacy/config.go
@@ -1,0 +1,34 @@
+package legacy
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+)
+
+type Config map[string]ConfigEntry
+
+type ConfigEntry struct {
+	HelmCharts        map[string]interface{}
+	ImageDenyList     []string
+	Images            []string
+	ImagesFilePath    string
+	Latest            bool
+	VersionConstraint string
+	VersionFilter     string
+	VersionSource     string
+}
+
+func ParseConfig(fileName string) (Config, error) {
+	contents, err := os.ReadFile(fileName)
+	if err != nil {
+		return Config{}, fmt.Errorf("failed to read: %w", err)
+	}
+
+	config := Config{}
+	if err := json.Unmarshal(contents, &config); err != nil {
+		return Config{}, fmt.Errorf("failed to unmarshal as JSON: %w", err)
+	}
+
+	return config, nil
+}

--- a/tools/pkg/legacy/config.go
+++ b/tools/pkg/legacy/config.go
@@ -32,3 +32,16 @@ func ParseConfig(fileName string) (Config, error) {
 
 	return config, nil
 }
+
+// Returns true if any of the entries' Images fields contains
+// the passed image.
+func (c Config) Contains(image string) bool {
+	for _, configEntry := range c {
+		for _, configImage := range configEntry.Images {
+			if configImage == image {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/tools/pkg/legacy/list.go
+++ b/tools/pkg/legacy/list.go
@@ -7,9 +7,9 @@ import (
 )
 
 type ImagesListEntry struct {
-	Source      string
-	Destination string
-	Tag         string
+	Source string
+	Target string
+	Tag    string
 }
 
 func ParseImagesList(fileName string) ([]ImagesListEntry, error) {
@@ -29,9 +29,9 @@ func ParseImagesList(fileName string) ([]ImagesListEntry, error) {
 			return nil, fmt.Errorf("line %q does not have 3 elements", line)
 		}
 		imagesListEntry := ImagesListEntry{
-			Source:      elements[0],
-			Destination: elements[1],
-			Tag:         elements[2],
+			Source: elements[0],
+			Target: elements[1],
+			Tag:    elements[2],
 		}
 		imagesList = append(imagesList, imagesListEntry)
 	}

--- a/tools/pkg/legacy/list.go
+++ b/tools/pkg/legacy/list.go
@@ -1,0 +1,40 @@
+package legacy
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+type ImagesListEntry struct {
+	Source      string
+	Destination string
+	Tag         string
+}
+
+func ParseImagesList(fileName string) ([]ImagesListEntry, error) {
+	contents, err := os.ReadFile(fileName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read: %s", err)
+	}
+
+	lines := strings.Split(string(contents), "\n")
+	imagesList := make([]ImagesListEntry, 0, len(lines))
+	for _, line := range lines {
+		if strings.HasPrefix(line, "#") || line == "" {
+			continue
+		}
+		elements := strings.Split(line, " ")
+		if len(elements) != 3 {
+			return nil, fmt.Errorf("line %q does not have 3 elements", line)
+		}
+		imagesListEntry := ImagesListEntry{
+			Source:      elements[0],
+			Destination: elements[1],
+			Tag:         elements[2],
+		}
+		imagesList = append(imagesList, imagesListEntry)
+	}
+
+	return imagesList, nil
+}

--- a/tools/pkg/legacy/list.go
+++ b/tools/pkg/legacy/list.go
@@ -12,21 +12,26 @@ type ImagesListEntry struct {
 	Tag    string
 }
 
-func ParseImagesList(fileName string) ([]ImagesListEntry, error) {
+func ParseImagesList(fileName string) (string, []ImagesListEntry, error) {
+	comment := ""
 	contents, err := os.ReadFile(fileName)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read: %s", err)
+		return "", nil, fmt.Errorf("failed to read: %s", err)
 	}
 
 	lines := strings.Split(string(contents), "\n")
 	imagesList := make([]ImagesListEntry, 0, len(lines))
 	for _, line := range lines {
-		if strings.HasPrefix(line, "#") || line == "" {
+		if line == "" {
+			continue
+		}
+		if strings.HasPrefix(line, "#") {
+			comment = comment + line + "\n"
 			continue
 		}
 		elements := strings.Split(line, " ")
 		if len(elements) != 3 {
-			return nil, fmt.Errorf("line %q does not have 3 elements", line)
+			return "", nil, fmt.Errorf("line %q does not have 3 elements", line)
 		}
 		imagesListEntry := ImagesListEntry{
 			Source: elements[0],
@@ -36,5 +41,26 @@ func ParseImagesList(fileName string) ([]ImagesListEntry, error) {
 		imagesList = append(imagesList, imagesListEntry)
 	}
 
-	return imagesList, nil
+	return comment, imagesList, nil
+}
+
+func WriteImagesList(fileName string, comment string, imagesList []ImagesListEntry) error {
+	fd, err := os.Create(fileName)
+	if err != nil {
+		return fmt.Errorf("failed to open file: %w", err)
+	}
+	defer fd.Close()
+
+	if _, err := fmt.Fprint(fd, comment); err != nil {
+		return fmt.Errorf("failed to write comment: %w", err)
+	}
+
+	for _, imagesListEntry := range imagesList {
+		line := fmt.Sprintf("%s %s %s", imagesListEntry.Source, imagesListEntry.Target, imagesListEntry.Tag)
+		if _, err := fmt.Fprintln(fd, line); err != nil {
+			return fmt.Errorf("failed to write line %q: %w", line, err)
+		}
+	}
+
+	return nil
 }


### PR DESCRIPTION
This PR is the first step towards https://github.com/rancher/rancher/issues/49869. It automates the process of migrating lines from `images-list` and `images-list-daily` to `config.yaml`.

This was an old branch that I wrote a month or two ago. At that time, my intent was to migrate all of the images in one go. However, it has become clear that we need to take a more granular approach. I've added a couple of commits onto the branch in order to facilitate this; `bin/image-mirror-tools migrate-images-list` now requires the source and target image (as specified in `images-list`) to be passed as arguments. Sorry for the confusion this may create when reviewing this PR.