### PR TITLE
Remove demonstration images from `config.yaml`

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -15,11 +15,6 @@ Images:
   - 3.9.0
   - 3.9.4
   - 3.9.5
-- SourceImage: docker.io/test-org/test-image-2
-  Tags:
-  - v2.3.4
-  - v4.50.6
-  - v40.5.6
 - SourceImage: fluent/fluent-bit
   Tags:
   - windows-2019-3.1.8
@@ -99,10 +94,6 @@ Images:
   - 4.4.0
   - 4.8.0
   - 4.9.1
-- SourceImage: test-org/test-image
-  Tags:
-  - v1.2.3
-  - v2.3.4
 Repositories:
 - BaseUrl: docker.io/rancher
   Password: '{{ env "DOCKER_PASSWORD" }}'

--- a/regsync.yaml
+++ b/regsync.yaml
@@ -78,24 +78,6 @@ sync:
 - source: banzaicloud/logging-operator:3.9.5
   target: registry.suse.com/rancher/mirrored-banzaicloud-logging-operator:3.9.5
   type: image
-- source: docker.io/test-org/test-image-2:v2.3.4
-  target: docker.io/rancher/mirrored-test-org-test-image-2:v2.3.4
-  type: image
-- source: docker.io/test-org/test-image-2:v4.50.6
-  target: docker.io/rancher/mirrored-test-org-test-image-2:v4.50.6
-  type: image
-- source: docker.io/test-org/test-image-2:v40.5.6
-  target: docker.io/rancher/mirrored-test-org-test-image-2:v40.5.6
-  type: image
-- source: docker.io/test-org/test-image-2:v2.3.4
-  target: registry.suse.com/rancher/mirrored-test-org-test-image-2:v2.3.4
-  type: image
-- source: docker.io/test-org/test-image-2:v4.50.6
-  target: registry.suse.com/rancher/mirrored-test-org-test-image-2:v4.50.6
-  type: image
-- source: docker.io/test-org/test-image-2:v40.5.6
-  target: registry.suse.com/rancher/mirrored-test-org-test-image-2:v40.5.6
-  type: image
 - source: fluent/fluent-bit:windows-2019-3.1.8
   target: docker.io/rancher/fluent-bit:windows-2019-3.1.8
   type: image
@@ -461,16 +443,4 @@ sync:
   type: image
 - source: ghcr.io/kube-logging/logging-operator:4.9.1
   target: registry.suse.com/rancher/mirrored-kube-logging-logging-operator:4.9.1
-  type: image
-- source: test-org/test-image:v1.2.3
-  target: docker.io/rancher/mirrored-test-org-test-image:v1.2.3
-  type: image
-- source: test-org/test-image:v2.3.4
-  target: docker.io/rancher/mirrored-test-org-test-image:v2.3.4
-  type: image
-- source: test-org/test-image:v1.2.3
-  target: registry.suse.com/rancher/mirrored-test-org-test-image:v1.2.3
-  type: image
-- source: test-org/test-image:v2.3.4
-  target: registry.suse.com/rancher/mirrored-test-org-test-image:v2.3.4
   type: image


### PR DESCRIPTION
Prior to #876 `config.yaml` was contained demonstration images in order to make the scheme easier to understand for PR reviews. I removed these images in #876, but I think they got added back in a rebase. This PR removes these demonstration images.