### PR TITLE
Add "./" to regsync call so that regsync can be found

### DIFF
--- a/.github/workflows/mirror-images-regsync.yml
+++ b/.github/workflows/mirror-images-regsync.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Sync Container Images
         run: |
-          time regsync once --config --missing regsync.yaml
+          time ./regsync once --config --missing regsync.yaml
         env:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}


### PR DESCRIPTION
It looks like the regsync call in the regsync mirroring workflow needs to be
```
time ./regsync once --config --missing regsync.yaml
```
not
```
time regsync once --config --missing regsync.yaml
```
Otherwise, the shell cannot find `regsync`.

This is weird, because I did test this workflow from my personal repo when I initially developed it. Maybe this line got changed in a rebase? Anyhow, this PR fixes the problem.