### PR TITLE
Fix order of `regsync` args and modify `PATH` instead of using `./regsync`

### DIFF
--- a/.github/workflows/mirror-images-regsync.yml
+++ b/.github/workflows/mirror-images-regsync.yml
@@ -31,7 +31,8 @@ jobs:
 
       - name: Sync Container Images
         run: |
-          time ./regsync once --config --missing regsync.yaml
+          export PATH=$PATH:$(pwd)
+          time regsync once --missing --config regsync.yaml
         env:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}


### PR DESCRIPTION
This is a follow-up to #885.

Since the workflow ran fine (eventually) from my personal repo, I think that what happened is: I made a series of modifications to the workflow to get it to work, and then when removing them I removed some of the important ones. This PR should get it working :crossed_fingers: 