### PR TITLE
Add new Calico image versions to images-list

### DIFF
--- a/images-list
+++ b/images-list
@@ -1110,6 +1110,7 @@ quay.io/calico/apiserver rancher/mirrored-calico-apiserver v3.29.0
 quay.io/calico/apiserver rancher/mirrored-calico-apiserver v3.29.1
 quay.io/calico/apiserver rancher/mirrored-calico-apiserver v3.29.2
 quay.io/calico/apiserver rancher/mirrored-calico-apiserver v3.29.3
+quay.io/calico/apiserver rancher/mirrored-calico-apiserver v3.29.4
 quay.io/calico/cni rancher/calico-cni v3.16.5
 quay.io/calico/cni rancher/calico-cni v3.16.6
 quay.io/calico/cni rancher/calico-cni v3.17.1
@@ -1154,6 +1155,7 @@ quay.io/calico/cni rancher/mirrored-calico-cni v3.29.0
 quay.io/calico/cni rancher/mirrored-calico-cni v3.29.1
 quay.io/calico/cni rancher/mirrored-calico-cni v3.29.2
 quay.io/calico/cni rancher/mirrored-calico-cni v3.29.3
+quay.io/calico/cni rancher/mirrored-calico-cni v3.29.4
 quay.io/calico/csi rancher/mirrored-calico-csi v3.27.0
 quay.io/calico/csi rancher/mirrored-calico-csi v3.27.2
 quay.io/calico/csi rancher/mirrored-calico-csi v3.27.3
@@ -1165,6 +1167,7 @@ quay.io/calico/csi rancher/mirrored-calico-csi v3.29.0
 quay.io/calico/csi rancher/mirrored-calico-csi v3.29.1
 quay.io/calico/csi rancher/mirrored-calico-csi v3.29.2
 quay.io/calico/csi rancher/mirrored-calico-csi v3.29.3
+quay.io/calico/csi rancher/mirrored-calico-csi v3.29.4
 quay.io/calico/ctl rancher/calico-ctl v3.16.5
 quay.io/calico/ctl rancher/calico-ctl v3.16.6
 quay.io/calico/ctl rancher/calico-ctl v3.17.1
@@ -1211,6 +1214,7 @@ quay.io/calico/ctl rancher/mirrored-calico-ctl v3.29.0
 quay.io/calico/ctl rancher/mirrored-calico-ctl v3.29.1
 quay.io/calico/ctl rancher/mirrored-calico-ctl v3.29.2
 quay.io/calico/ctl rancher/mirrored-calico-ctl v3.29.3
+quay.io/calico/ctl rancher/mirrored-calico-ctl v3.29.4
 quay.io/calico/kube-controllers rancher/calico-kube-controllers v3.16.5
 quay.io/calico/kube-controllers rancher/calico-kube-controllers v3.16.6
 quay.io/calico/kube-controllers rancher/calico-kube-controllers v3.17.1
@@ -1255,6 +1259,7 @@ quay.io/calico/kube-controllers rancher/mirrored-calico-kube-controllers v3.29.0
 quay.io/calico/kube-controllers rancher/mirrored-calico-kube-controllers v3.29.1
 quay.io/calico/kube-controllers rancher/mirrored-calico-kube-controllers v3.29.2
 quay.io/calico/kube-controllers rancher/mirrored-calico-kube-controllers v3.29.3
+quay.io/calico/kube-controllers rancher/mirrored-calico-kube-controllers v3.29.4
 quay.io/calico/node rancher/calico-node v3.16.5
 quay.io/calico/node rancher/calico-node v3.16.6
 quay.io/calico/node rancher/calico-node v3.17.1
@@ -1299,6 +1304,7 @@ quay.io/calico/node rancher/mirrored-calico-node v3.29.0
 quay.io/calico/node rancher/mirrored-calico-node v3.29.1
 quay.io/calico/node rancher/mirrored-calico-node v3.29.2
 quay.io/calico/node rancher/mirrored-calico-node v3.29.3
+quay.io/calico/node rancher/mirrored-calico-node v3.29.4
 quay.io/calico/node-driver-registrar rancher/mirrored-calico-node-driver-registrar v3.27.0
 quay.io/calico/node-driver-registrar rancher/mirrored-calico-node-driver-registrar v3.27.2
 quay.io/calico/node-driver-registrar rancher/mirrored-calico-node-driver-registrar v3.27.3
@@ -1310,6 +1316,7 @@ quay.io/calico/node-driver-registrar rancher/mirrored-calico-node-driver-registr
 quay.io/calico/node-driver-registrar rancher/mirrored-calico-node-driver-registrar v3.29.1
 quay.io/calico/node-driver-registrar rancher/mirrored-calico-node-driver-registrar v3.29.2
 quay.io/calico/node-driver-registrar rancher/mirrored-calico-node-driver-registrar v3.29.3
+quay.io/calico/node-driver-registrar rancher/mirrored-calico-node-driver-registrar v3.29.4
 quay.io/calico/pod2daemon-flexvol rancher/calico-pod2daemon-flexvol v3.16.5
 quay.io/calico/pod2daemon-flexvol rancher/calico-pod2daemon-flexvol v3.16.6
 quay.io/calico/pod2daemon-flexvol rancher/calico-pod2daemon-flexvol v3.17.1
@@ -1354,6 +1361,7 @@ quay.io/calico/pod2daemon-flexvol rancher/mirrored-calico-pod2daemon-flexvol v3.
 quay.io/calico/pod2daemon-flexvol rancher/mirrored-calico-pod2daemon-flexvol v3.29.1
 quay.io/calico/pod2daemon-flexvol rancher/mirrored-calico-pod2daemon-flexvol v3.29.2
 quay.io/calico/pod2daemon-flexvol rancher/mirrored-calico-pod2daemon-flexvol v3.29.3
+quay.io/calico/pod2daemon-flexvol rancher/mirrored-calico-pod2daemon-flexvol v3.29.4
 quay.io/calico/typha rancher/mirrored-calico-typha v3.18.1
 quay.io/calico/typha rancher/mirrored-calico-typha v3.19.1
 quay.io/calico/typha rancher/mirrored-calico-typha v3.19.2


### PR DESCRIPTION
#### Pull Request Checklist ####

- [x] Change does not remove any existing Images or Tags in the images-list file
- [x] Change does not remove / overwrite exiting Images or Tags in Rancher DockerHub
- [ ] If updating an existing entry, verify the `SOURCE` is still accurate and upstream hasn't been migrated to a new regitry or repo (if they've migrated, a new repo request to EIO is needed to comply with the `SOURCE DESTINATION TAG` pattern)
- [x] New entries are in format `SOURCE DESTINATION TAG`
- [x] New entries are added to the correct section of the list (sorted lexicographically)
- [x] New entries have a repo created in Rancher Dockerhub (where the image will be mirrored to)
- [ ] New entries are licensed with Rancher favored licenses - Apache 2 and MIT - or approved licenses - as according to [CNCF approved licenses](https://github.com/cncf/foundation/blob/main/allowed-third-party-license-policy.md).
- [ ] New entries, when used in Rancher or Rancher's provided charts, have their corresponding origin added in Rancher's images [origins](https://github.com/rancher/rancher/blob/release/v2.7/pkg/image/origins.go) file (must be added for all Rancher versions `>= v2.7`).
- [ ] Changes to scripting or CI config have been tested to the best of your ability

#### Types of Change ####

<!-- New image, version bump. script update, etc etc -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request.  -->

#### Additional Notes ####

<!-- Any additional details / test results / etc -->

#### Final Checks after the PR is merged ####
- [ ] Confirm that you can pull the new images and tags from DockerHub
