### PR TITLE
Use `appco-` prefix for default target image name when source image comes from appco

### DIFF
--- a/tools/internal/config/config.go
+++ b/tools/internal/config/config.go
@@ -125,9 +125,15 @@ func (image *Image) setDefaults() error {
 	if len(parts) < 2 {
 		return fmt.Errorf("source image split into %d parts (>=2 parts expected)", len(parts))
 	}
-	repoName := parts[len(parts)-2]
-	imageName := parts[len(parts)-1]
-	image.defaultTargetImageName = "mirrored-" + repoName + "-" + imageName
+
+	if parts[0] == "dp.apps.rancher.io" {
+		imageName := parts[len(parts)-1]
+		image.defaultTargetImageName = "appco-" + imageName
+	} else {
+		repoName := parts[len(parts)-2]
+		imageName := parts[len(parts)-1]
+		image.defaultTargetImageName = "mirrored-" + repoName + "-" + imageName
+	}
 	return nil
 }
 

--- a/tools/internal/config/config.go
+++ b/tools/internal/config/config.go
@@ -127,6 +127,10 @@ func (image *Image) setDefaults() error {
 	}
 
 	if parts[0] == "dp.apps.rancher.io" {
+		// AppCo images have only one significant part in their reference.
+		// For example, in dp.apps.rancher.io/containers/openjdk,
+		// dp.apps.rancher.io/containers is the repository and openjdk is
+		// the significant part.
 		imageName := parts[len(parts)-1]
 		image.defaultTargetImageName = "appco-" + imageName
 	} else {


### PR DESCRIPTION
This PR introduces a new naming scheme for images that come from the appco. I think this is a good idea for two reasons:

1. Appco images have only one significant part in their reference. For example, in `dp.apps.rancher.io/containers/openjdk` `dp.apps.rancher.io` is the host, `containers` is the repository, and `openjdk` is the artifact name. This differs from images from docker hub and ghcr.io, where the last two parts of the URL (org and image name) are significant.
2. It is helpful to distinguish between images that come from "just anywhere" and images that come from the appco.

For example, the entry in `config.yaml`:
```yaml
- SourceImage: dp.apps.rancher.io/containers/openjdk
  Tags:
  - 21.0.7-build6
```
now produces, in `regsync.yaml`:
```yaml
- source: dp.apps.rancher.io/containers/openjdk:21.0.7-build6
  target: docker.io/rancher/appco-openjdk:21.0.7-build6
  type: image
- source: dp.apps.rancher.io/containers/openjdk:21.0.7-build6
  target: registry.suse.com/rancher/appco-openjdk:21.0.7-build6
  type: image
```
Without this PR, it would have been:
```yaml
- source: dp.apps.rancher.io/containers/openjdk:21.0.7-build6
  target: docker.io/rancher/mirrored-containers-openjdk:21.0.7-build6
  type: image
- source: dp.apps.rancher.io/containers/openjdk:21.0.7-build6
  target: registry.suse.com/rancher/mirrored-containers-openjdk:21.0.7-build6
  type: image
```
which could be confused with an image from docker hub or elsewhere.