### PR TITLE
Add new gMSA webhook tag v0.13.0

### DIFF
--- a/images-list
+++ b/images-list
@@ -1935,6 +1935,7 @@ registry.k8s.io/dns/k8s-dns-sidecar rancher/mirrored-k8s-dns-sidecar 1.22.28
 registry.k8s.io/dns/k8s-dns-sidecar rancher/mirrored-k8s-dns-sidecar 1.23.0
 registry.k8s.io/git-sync/git-sync rancher/mirrored-git-sync v3.5.0
 registry.k8s.io/gmsa-webhook/k8s-gmsa-webhook rancher/mirrored-gmsa-webhook-k8s-gmsa-webhook v0.7.0
+registry.k8s.io/gmsa-webhook/k8s-gmsa-webhook rancher/mirrored-gmsa-webhook-k8s-gmsa-webhook v0.13.0
 registry.k8s.io/ingress-nginx/kube-webhook-certgen rancher/mirrored-ingress-nginx-kube-webhook-certgen v1.0
 registry.k8s.io/ingress-nginx/kube-webhook-certgen rancher/mirrored-ingress-nginx-kube-webhook-certgen v1.1.1
 registry.k8s.io/ingress-nginx/kube-webhook-certgen rancher/mirrored-ingress-nginx-kube-webhook-certgen v1.3.0


### PR DESCRIPTION
#### Pull Request Checklist ####

- [x] Change does not remove any existing Images or Tags in the images-list file
- [x] Change does not remove / overwrite exiting Images or Tags in Rancher DockerHub
- [x] If updating an existing entry, verify the `SOURCE` is still accurate and upstream hasn't been migrated to a new regitry or repo (if they've migrated, a new repo request to EIO is needed to comply with the `SOURCE DESTINATION TAG` pattern)
- [x] New entries are in format `SOURCE DESTINATION TAG`
- [x] New entries are added to the correct section of the list (sorted lexicographically)
- [x] New entries have a repo created in Rancher Dockerhub (where the image will be mirrored to)
   + https://hub.docker.com/r/rancher/mirrored-gmsa-webhook-k8s-gmsa-webhook/tags
- [x] New entries are licensed with Rancher favored licenses - Apache 2 and MIT - or approved licenses - as according to [CNCF approved licenses](https://github.com/cncf/foundation/blob/main/allowed-third-party-license-policy.md).
- [x] New entries, when used in Rancher or Rancher's provided charts, have their corresponding origin added in Rancher's images [origins](https://github.com/rancher/rancher/blob/release/v2.7/pkg/image/origins.go) file (must be added for all Rancher versions `>= v2.7`).
     + The charts which use this image are not included with Rancher by default. When / if the gmsa charts are pulled into rancher/charts PRs will be raised to appropriately include the origins.
- [x] Changes to scripting or CI config have been tested to the best of your ability

#### Types of Change ####

Sync new upstream version.

#### Linked Issues ####
https://github.com/rancher/rancher/issues/50063

#### Additional Notes ####

#### Final Checks after the PR is merged ####
- [ ] Confirm that you can pull the new images and tags from DockerHub
