### PR TITLE
Parallelize `regsync` mirroring

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,12 @@ This section roughly correlates to the `creds` section of `regsync.yaml`.
 
 | Field | Required | Description |
 | ------------- | ------------- |------------- |
-| `EnvVarPrefix` | yes | The prefix added to the environment variables used to set username, password and registry in `regsync.yaml`.
 | `BaseUrl` | yes | The base URL for the repository. Appending `/` plus an image name should be a valid image reference.
+| `Password` | yes | The password to use when authenticating against the registry. See [the regsync documentation](https://regclient.org/usage/regsync/) for more details.
+| `Registry` | yes | The registry URL. See [the regsync documentation](https://regclient.org/usage/regsync/) for more details.
+| `ReqConcurrent` | no | The number of concurrent requests that are made to this registry. See [the regsync documentation](https://regclient.org/usage/regsync/) for more details.
 | `Target` | no | When `true`, denotes a target repository. This means that all images will be mirrored to this repository.
+| `Username` | yes | The username to use when authenticating against the registry. See [the regsync documentation](https://regclient.org/usage/regsync/) for more details.
 
 
 #### `Images`

--- a/config.yaml
+++ b/config.yaml
@@ -98,15 +98,18 @@ Repositories:
 - BaseUrl: docker.io/rancher
   Password: '{{ env "DOCKER_PASSWORD" }}'
   Registry: docker.io
+  ReqConcurrent: 2
   Target: true
   Username: '{{ env "DOCKER_USERNAME" }}'
 - BaseUrl: dp.apps.rancher.io/containers
   Password: '{{ env "APPCO_PASSWORD" }}'
   Registry: dp.apps.rancher.io
+  ReqConcurrent: 2
   Target: false
   Username: '{{ env "APPCO_USERNAME" }}'
 - BaseUrl: registry.suse.com/rancher
   Password: '{{ env "PRIME_PASSWORD" }}'
   Registry: registry.suse.com
+  ReqConcurrent: 2
   Target: true
   Username: '{{ env "PRIME_USERNAME" }}'

--- a/regsync.yaml
+++ b/regsync.yaml
@@ -4,12 +4,15 @@
 creds:
 - pass: '{{ env "DOCKER_PASSWORD" }}'
   registry: docker.io
+  reqConcurrent: 2
   user: '{{ env "DOCKER_USERNAME" }}'
 - pass: '{{ env "APPCO_PASSWORD" }}'
   registry: dp.apps.rancher.io
+  reqConcurrent: 2
   user: '{{ env "APPCO_USERNAME" }}'
 - pass: '{{ env "PRIME_PASSWORD" }}'
   registry: registry.suse.com
+  reqConcurrent: 2
   user: '{{ env "PRIME_USERNAME" }}'
 sync:
 - source: banzaicloud/logging-operator:3.6.0

--- a/tools/internal/config/config.go
+++ b/tools/internal/config/config.go
@@ -46,6 +46,10 @@ type Repository struct {
 	// for this repository. For more information please see
 	// https://github.com/regclient/regclient/blob/main/docs/regsync.md
 	Registry string
+	// ReqConcurrent is what goes into the "reqConcurrent" field of
+	// regsync.yaml for this repository. For more information please see
+	// https://github.com/regclient/regclient/blob/main/docs/regsync.md
+	ReqConcurrent int
 	// Username is what goes into the "user" field of regsync.yaml
 	// for this repository. For more information please see
 	// https://github.com/regclient/regclient/blob/main/docs/regsync.md

--- a/tools/internal/regsync/config.go
+++ b/tools/internal/regsync/config.go
@@ -27,9 +27,10 @@ type Config struct {
 // ConfigCred specifies the details for a registry that container images may
 // be pulled from or pushed to.
 type ConfigCred struct {
-	Registry string `json:"registry"`
-	User     string `json:"user"`
-	Pass     string `json:"pass"`
+	Registry      string `json:"registry"`
+	User          string `json:"user"`
+	Pass          string `json:"pass"`
+	ReqConcurrent int    `json:"reqConcurrent,omitempty"`
 }
 
 // ConfigSync defines a source/target repository to sync.

--- a/tools/main.go
+++ b/tools/main.go
@@ -76,9 +76,10 @@ func generateRegsyncYaml(_ context.Context, _ *cli.Command) error {
 	}
 	for _, targetRepository := range cfg.Repositories {
 		credEntry := regsync.ConfigCred{
-			Registry: targetRepository.Registry,
-			User:     targetRepository.Username,
-			Pass:     targetRepository.Password,
+			Pass:          targetRepository.Password,
+			Registry:      targetRepository.Registry,
+			ReqConcurrent: targetRepository.ReqConcurrent,
+			User:          targetRepository.Username,
 		}
 		regsyncYaml.Creds = append(regsyncYaml.Creds, credEntry)
 	}


### PR DESCRIPTION
The idea here is to give us an option (speeding up mirroring) other than increasing the timeout when we start hitting the default 6 minute timeout on github actions jobs. This PR adds the necessary field (`ReqConcurrent`) to `config.yaml` so that it can be configured in `regsync.yaml`.

For the documentation for `creds.reqConcurrent` please see https://regclient.org/usage/regsync/.