### PR TITLE
Add `DoNotMirror` field to `config.Image` and add it to `appscode/kubed`

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -6,7 +6,8 @@ Images:
   - 2.8.9
   - 2.9.0
   - 2.9.14
-- SourceImage: appscode/kubed
+- DoNotMirror: true
+  SourceImage: appscode/kubed
   Tags:
   - v0.13.2
 - SourceImage: banzaicloud/logging-operator

--- a/regsync.yaml
+++ b/regsync.yaml
@@ -45,12 +45,6 @@ sync:
 - source: amazon/aws-cli:2.9.14
   target: registry.suse.com/rancher/mirrored-amazon-aws-cli:2.9.14
   type: image
-- source: appscode/kubed:v0.13.2
-  target: docker.io/rancher/mirrored-appscode-kubed:v0.13.2
-  type: image
-- source: appscode/kubed:v0.13.2
-  target: registry.suse.com/rancher/mirrored-appscode-kubed:v0.13.2
-  type: image
 - source: banzaicloud/logging-operator:3.6.0
   target: docker.io/rancher/banzaicloud-logging-operator:3.6.0
   type: image

--- a/tools/internal/config/config.go
+++ b/tools/internal/config/config.go
@@ -72,7 +72,7 @@ func Parse(fileName string) (Config, error) {
 
 	for _, image := range config.Images {
 		if err := image.setDefaults(); err != nil {
-			return Config{}, fmt.Errorf("failed to set defaults for image %q: %w", image, err)
+			return Config{}, fmt.Errorf("failed to set defaults for image %q: %w", image.SourceImage, err)
 		}
 	}
 

--- a/tools/internal/config/config.go
+++ b/tools/internal/config/config.go
@@ -16,6 +16,9 @@ type Config struct {
 
 // Image should not be instantiated directly. Instead, use NewImage().
 type Image struct {
+	// If true, the Image is not mirrored i.e. it is not added to the
+	// regsync config when the regsync config is generated.
+	DoNotMirror bool `json:",omitempty"`
 	// The source image without any tags.
 	SourceImage            string
 	defaultTargetImageName string

--- a/tools/main.go
+++ b/tools/main.go
@@ -84,6 +84,9 @@ func generateRegsyncYaml(_ context.Context, _ *cli.Command) error {
 		regsyncYaml.Creds = append(regsyncYaml.Creds, credEntry)
 	}
 	for _, image := range cfg.Images {
+		if image.DoNotMirror {
+			continue
+		}
 		for _, repo := range cfg.Repositories {
 			if !repo.Target {
 				continue


### PR DESCRIPTION
Related to https://github.com/rancher/rancher/issues/50159.

`appscode/kubed` is causing the `regsync` mirroring workflow to fail. I think it is a good idea to keep an entry in `config.yaml` for `appscode/kubed` for future reference. So, I am adding the `DoNotMirror` field to `config.Image` so that we can omit an image from `config.yaml` from the generated `regsync.yaml`.