### PR TITLE
Update Monitoring Images for https://github.com/rancher/ob-team-charts/pull/76

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -373,6 +373,7 @@ Images:
 - SourceImage: ghcr.io/prometheus-community/windows-exporter
   Tags:
   - 0.25.1
+  - 0.29.2
   - 0.30.5
   TargetImageName: mirrored-prometheus-windows-exporter
 - SourceImage: grafana/grafana
@@ -386,6 +387,7 @@ Images:
   - 10.4.9
   - 11.1.0
   - 11.3.0
+  - 11.4.0
   - 11.5.2
   - 6.7.4
   - 7.1.5

--- a/regsync.yaml
+++ b/regsync.yaml
@@ -1106,11 +1106,17 @@ sync:
 - source: ghcr.io/prometheus-community/windows-exporter:0.25.1
   target: docker.io/rancher/mirrored-prometheus-windows-exporter:0.25.1
   type: image
+- source: ghcr.io/prometheus-community/windows-exporter:0.29.2
+  target: docker.io/rancher/mirrored-prometheus-windows-exporter:0.29.2
+  type: image
 - source: ghcr.io/prometheus-community/windows-exporter:0.30.5
   target: docker.io/rancher/mirrored-prometheus-windows-exporter:0.30.5
   type: image
 - source: ghcr.io/prometheus-community/windows-exporter:0.25.1
   target: registry.suse.com/rancher/mirrored-prometheus-windows-exporter:0.25.1
+  type: image
+- source: ghcr.io/prometheus-community/windows-exporter:0.29.2
+  target: registry.suse.com/rancher/mirrored-prometheus-windows-exporter:0.29.2
   type: image
 - source: ghcr.io/prometheus-community/windows-exporter:0.30.5
   target: registry.suse.com/rancher/mirrored-prometheus-windows-exporter:0.30.5
@@ -1138,6 +1144,9 @@ sync:
   type: image
 - source: grafana/grafana:11.3.0
   target: docker.io/rancher/mirrored-grafana-grafana:11.3.0
+  type: image
+- source: grafana/grafana:11.4.0
+  target: docker.io/rancher/mirrored-grafana-grafana:11.4.0
   type: image
 - source: grafana/grafana:11.5.2
   target: docker.io/rancher/mirrored-grafana-grafana:11.5.2
@@ -1177,6 +1186,9 @@ sync:
   type: image
 - source: grafana/grafana:11.3.0
   target: registry.suse.com/rancher/mirrored-grafana-grafana:11.3.0
+  type: image
+- source: grafana/grafana:11.4.0
+  target: registry.suse.com/rancher/mirrored-grafana-grafana:11.4.0
   type: image
 - source: grafana/grafana:11.5.2
   target: registry.suse.com/rancher/mirrored-grafana-grafana:11.5.2


### PR DESCRIPTION

#### Types of Change ####

Add new image tags

#### Linked Issues ####

https://github.com/rancher/ob-team-charts/pull/76

#### Final Checks after the PR is merged ####
- [ ] Confirm that you can pull the new images and tags from DockerHub
