### PR TITLE
Do not mirror `quay.io/cilium/cilium-etcd-operator` and `quay.io/jetstack/cert-manager-controller`

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1457,7 +1457,8 @@ Images:
   - v1.31.5-1739264036-958bef243c6c66fcfd73ca319f2eb49fff1eb2ae
   - v1.31.5-1741765102-efed3defcc70ab5b263a0fc44c93d316b846a211
   - v1.32.5-1744305768-f9ddca7dcd91f7ca25a505560e655c47d3dec2cf
-- SourceImage: quay.io/cilium/cilium-etcd-operator
+- DoNotMirror: true
+  SourceImage: quay.io/cilium/cilium-etcd-operator
   Tags:
   - v2.0.7
 - SourceImage: quay.io/cilium/clustermesh-apiserver
@@ -1719,7 +1720,8 @@ Images:
   - v0.38.1
   - v0.39.0
   - v0.40.0
-- SourceImage: quay.io/jetstack/cert-manager-controller
+- DoNotMirror: true
+  SourceImage: quay.io/jetstack/cert-manager-controller
   Tags:
   - v0.8.1
 - SourceImage: quay.io/k8scsi/csi-attacher

--- a/regsync.yaml
+++ b/regsync.yaml
@@ -6401,12 +6401,6 @@ sync:
 - source: quay.io/cilium/cilium-envoy:v1.32.5-1744305768-f9ddca7dcd91f7ca25a505560e655c47d3dec2cf
   target: registry.suse.com/rancher/mirrored-cilium-cilium-envoy:v1.32.5-1744305768-f9ddca7dcd91f7ca25a505560e655c47d3dec2cf
   type: image
-- source: quay.io/cilium/cilium-etcd-operator:v2.0.7
-  target: docker.io/rancher/mirrored-cilium-cilium-etcd-operator:v2.0.7
-  type: image
-- source: quay.io/cilium/cilium-etcd-operator:v2.0.7
-  target: registry.suse.com/rancher/mirrored-cilium-cilium-etcd-operator:v2.0.7
-  type: image
 - source: quay.io/cilium/clustermesh-apiserver:v1.12.4
   target: docker.io/rancher/mirrored-cilium-clustermesh-apiserver:v1.12.4
   type: image
@@ -7768,12 +7762,6 @@ sync:
   type: image
 - source: quay.io/coreos/prometheus-operator:v0.40.0
   target: registry.suse.com/rancher/mirrored-coreos-prometheus-operator:v0.40.0
-  type: image
-- source: quay.io/jetstack/cert-manager-controller:v0.8.1
-  target: docker.io/rancher/mirrored-jetstack-cert-manager-controller:v0.8.1
-  type: image
-- source: quay.io/jetstack/cert-manager-controller:v0.8.1
-  target: registry.suse.com/rancher/mirrored-jetstack-cert-manager-controller:v0.8.1
   type: image
 - source: quay.io/k8scsi/csi-attacher:v3.0.0
   target: docker.io/rancher/mirrored-k8scsi-csi-attacher:v3.0.0


### PR DESCRIPTION
I believe that these images are causing the `regsync` mirroring workflow to fail. When I attempt to pull them via `docker pull`, I get an error looking like the following:
```
[DEPRECATION NOTICE] Docker Image Format v1 and Docker Image manifest version 2, schema 1 support is disabled by default and will be removed in an upcoming release. Suggest the author of quay.io/jetstack/cert-manager-controller:v0.8.1 to upgrade the image to the OCI Format or Docker Image manifest v2, schema 2. More information at https://docs.docker.com/go/deprecated-image-specs/
```
This PR omits them from the mirroring process.