### PR TITLE
Do not mirror registry.suse.com/rancher/elemental-operator:1.3.4

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1113,9 +1113,13 @@ Images:
   - 15.6.19.1
   - 15.6.24.2
   TargetImageName: mirrored-bci-micro
-- SourceImage: registry.suse.com/rancher/elemental-operator
+- DoNotMirror: true
+  SourceImage: registry.suse.com/rancher/elemental-operator
   Tags:
   - 1.3.4
+  TargetImageName: mirrored-elemental-operator
+- SourceImage: registry.suse.com/rancher/elemental-operator
+  Tags:
   - 1.4.2
   - 1.4.3
   - 1.5.3

--- a/regsync.yaml
+++ b/regsync.yaml
@@ -4397,9 +4397,6 @@ sync:
 - source: registry.suse.com/bci/bci-micro:15.6.24.2
   target: registry.suse.com/rancher/mirrored-bci-micro:15.6.24.2
   type: image
-- source: registry.suse.com/rancher/elemental-operator:1.3.4
-  target: docker.io/rancher/mirrored-elemental-operator:1.3.4
-  type: image
 - source: registry.suse.com/rancher/elemental-operator:1.4.2
   target: docker.io/rancher/mirrored-elemental-operator:1.4.2
   type: image


### PR DESCRIPTION
Part of https://github.com/rancher/rancher/issues/49870.

This PR disables mirroring for `registry.suse.com/rancher/elemental-operator:1.3.4`. For whatever reason, this tag (and only this tag; I tested the others using `docker pull`) of this image is not present on `registry.suse.com/rancher`. This should get the `regsync` mirroring workflow green again.