### PR TITLE
Fix `ImageAccumulator` indexing

### DIFF
--- a/tools/internal/config/accumulator.go
+++ b/tools/internal/config/accumulator.go
@@ -4,23 +4,25 @@ import (
 	"slices"
 )
 
-type sourceTargetPair struct {
+type imageIndex struct {
+	DoNotMirror     bool
 	SourceImage     string
 	TargetImageName string
 }
 
 type ImageAccumulator struct {
-	mapping map[sourceTargetPair]*Image
+	mapping map[imageIndex]*Image
 }
 
 func NewImageAccumulator() *ImageAccumulator {
 	return &ImageAccumulator{
-		mapping: map[sourceTargetPair]*Image{},
+		mapping: map[imageIndex]*Image{},
 	}
 }
 
 func (ia *ImageAccumulator) AddImage(newImage *Image) {
-	pair := sourceTargetPair{
+	pair := imageIndex{
+		DoNotMirror:     newImage.DoNotMirror,
 		SourceImage:     newImage.SourceImage,
 		TargetImageName: newImage.TargetImageName(),
 	}

--- a/tools/internal/config/accumulator_test.go
+++ b/tools/internal/config/accumulator_test.go
@@ -1,0 +1,31 @@
+package config
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestImageAccumulator(t *testing.T) {
+	t.Run("AddImage", func(t *testing.T) {
+		t.Run("should not combine identical Images with different DoNotMirror fields", func(t *testing.T) {
+			accumulator := NewImageAccumulator()
+
+			image1, err := NewImage("test-org/test-image", []string{"test1"})
+			assert.NoError(t, err)
+			accumulator.AddImage(image1)
+
+			image2, err := NewImage("test-org/test-image", []string{"test2"})
+			assert.NoError(t, err)
+			image2.DoNotMirror = true
+			accumulator.AddImage(image2)
+
+			imageList := accumulator.Images()
+
+			if !assert.Len(t, imageList, 2) {
+				return
+			}
+			assert.False(t, imageList[0].DoNotMirror)
+			assert.True(t, imageList[1].DoNotMirror)
+		})
+	})
+}


### PR DESCRIPTION
Previously, `ImageAccumulator` indexed only on `SourceImage` and `TargetImageName`. This could lead to problems in cases like the one introduced in https://github.com/rancher/image-mirror/pull/932. This PR adds `DoNotMirror` to the indexed fields.