### PR TITLE
Migrate `images-list` to `config.yaml` (S-Z)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1150,6 +1150,10 @@ Images:
   Tags:
   - v1.5.2
   TargetImageName: squareup-ghostunnel
+- SourceImage: thanosio/thanos
+  Tags:
+  - v0.15.0
+  - v0.21.1
 Repositories:
 - BaseUrl: docker.io/rancher
   Password: '{{ env "DOCKER_PASSWORD" }}'

--- a/config.yaml
+++ b/config.yaml
@@ -1154,6 +1154,10 @@ Images:
   Tags:
   - v0.15.0
   - v0.21.1
+- SourceImage: thanosio/thanos
+  Tags:
+  - v0.15.0
+  TargetImageName: thanosio-thanos
 Repositories:
 - BaseUrl: docker.io/rancher
   Password: '{{ env "DOCKER_PASSWORD" }}'

--- a/config.yaml
+++ b/config.yaml
@@ -1146,6 +1146,10 @@ Images:
 - SourceImage: squareup/ghostunnel
   Tags:
   - v1.5.2
+- SourceImage: squareup/ghostunnel
+  Tags:
+  - v1.5.2
+  TargetImageName: squareup-ghostunnel
 Repositories:
 - BaseUrl: docker.io/rancher
   Password: '{{ env "DOCKER_PASSWORD" }}'

--- a/config.yaml
+++ b/config.yaml
@@ -1162,6 +1162,10 @@ Images:
   Tags:
   - v0.7.3
   TargetImageName: kubernetes-external-dns
+- SourceImage: us.gcr.io/k8s-artifacts-prod/external-dns/external-dns
+  Tags:
+  - v0.7.3
+  TargetImageName: mirrored-kubernetes-external-dns
 Repositories:
 - BaseUrl: docker.io/rancher
   Password: '{{ env "DOCKER_PASSWORD" }}'

--- a/config.yaml
+++ b/config.yaml
@@ -1117,9 +1117,6 @@ Images:
   SourceImage: registry.suse.com/rancher/elemental-operator
   Tags:
   - 1.3.4
-  TargetImageName: mirrored-elemental-operator
-- SourceImage: registry.suse.com/rancher/elemental-operator
-  Tags:
   - 1.4.2
   - 1.4.3
   - 1.5.3
@@ -1143,6 +1140,9 @@ Images:
   Tags:
   - 0.6.1
   TargetImageName: rpardini-docker-registry-proxy
+- SourceImage: sigwindowstools/k8s-gmsa-webhook
+  Tags:
+  - v0.3.0
 Repositories:
 - BaseUrl: docker.io/rancher
   Password: '{{ env "DOCKER_PASSWORD" }}'

--- a/config.yaml
+++ b/config.yaml
@@ -1143,6 +1143,9 @@ Images:
 - SourceImage: sigwindowstools/k8s-gmsa-webhook
   Tags:
   - v0.3.0
+- SourceImage: squareup/ghostunnel
+  Tags:
+  - v1.5.2
 Repositories:
 - BaseUrl: docker.io/rancher
   Password: '{{ env "DOCKER_PASSWORD" }}'

--- a/config.yaml
+++ b/config.yaml
@@ -1158,6 +1158,10 @@ Images:
   Tags:
   - v0.15.0
   TargetImageName: thanosio-thanos
+- SourceImage: us.gcr.io/k8s-artifacts-prod/external-dns/external-dns
+  Tags:
+  - v0.7.3
+  TargetImageName: kubernetes-external-dns
 Repositories:
 - BaseUrl: docker.io/rancher
   Password: '{{ env "DOCKER_PASSWORD" }}'

--- a/images-list
+++ b/images-list
@@ -1351,4 +1351,3 @@ sonobuoy/sonobuoy rancher/mirrored-sonobuoy-sonobuoy v0.57.3
 sonobuoy/sonobuoy rancher/sonobuoy-sonobuoy v0.19.0
 tonistiigi/xx rancher/mirrored-tonistiigi-xx 1.3.0
 tonistiigi/xx rancher/mirrored-tonistiigi-xx 1.5.0
-us.gcr.io/k8s-artifacts-prod/external-dns/external-dns rancher/mirrored-kubernetes-external-dns v0.7.3

--- a/images-list
+++ b/images-list
@@ -1351,5 +1351,4 @@ sonobuoy/sonobuoy rancher/mirrored-sonobuoy-sonobuoy v0.57.3
 sonobuoy/sonobuoy rancher/sonobuoy-sonobuoy v0.19.0
 tonistiigi/xx rancher/mirrored-tonistiigi-xx 1.3.0
 tonistiigi/xx rancher/mirrored-tonistiigi-xx 1.5.0
-us.gcr.io/k8s-artifacts-prod/external-dns/external-dns rancher/kubernetes-external-dns v0.7.3
 us.gcr.io/k8s-artifacts-prod/external-dns/external-dns rancher/mirrored-kubernetes-external-dns v0.7.3

--- a/images-list
+++ b/images-list
@@ -1349,8 +1349,6 @@ sonobuoy/sonobuoy rancher/mirrored-sonobuoy-sonobuoy v0.57.1
 sonobuoy/sonobuoy rancher/mirrored-sonobuoy-sonobuoy v0.57.2
 sonobuoy/sonobuoy rancher/mirrored-sonobuoy-sonobuoy v0.57.3
 sonobuoy/sonobuoy rancher/sonobuoy-sonobuoy v0.19.0
-thanosio/thanos rancher/mirrored-thanosio-thanos v0.15.0
-thanosio/thanos rancher/mirrored-thanosio-thanos v0.21.1
 thanosio/thanos rancher/thanosio-thanos v0.15.0
 tonistiigi/xx rancher/mirrored-tonistiigi-xx 1.3.0
 tonistiigi/xx rancher/mirrored-tonistiigi-xx 1.5.0

--- a/images-list
+++ b/images-list
@@ -1349,7 +1349,6 @@ sonobuoy/sonobuoy rancher/mirrored-sonobuoy-sonobuoy v0.57.1
 sonobuoy/sonobuoy rancher/mirrored-sonobuoy-sonobuoy v0.57.2
 sonobuoy/sonobuoy rancher/mirrored-sonobuoy-sonobuoy v0.57.3
 sonobuoy/sonobuoy rancher/sonobuoy-sonobuoy v0.19.0
-squareup/ghostunnel rancher/mirrored-squareup-ghostunnel v1.5.2
 squareup/ghostunnel rancher/squareup-ghostunnel v1.5.2
 thanosio/thanos rancher/mirrored-thanosio-thanos v0.15.0
 thanosio/thanos rancher/mirrored-thanosio-thanos v0.21.1

--- a/images-list
+++ b/images-list
@@ -1335,7 +1335,6 @@ registry.k8s.io/sig-storage/snapshot-controller rancher/mirrored-sig-storage-sna
 registry.k8s.io/sig-storage/snapshot-controller rancher/mirrored-sig-storage-snapshot-controller v6.2.1
 registry.k8s.io/sig-storage/snapshot-controller rancher/mirrored-sig-storage-snapshot-controller v8.1.0
 registry.k8s.io/sig-storage/snapshot-controller rancher/mirrored-sig-storage-snapshot-controller v8.2.0
-sigwindowstools/k8s-gmsa-webhook rancher/mirrored-sigwindowstools-k8s-gmsa-webhook v0.3.0
 sonobuoy/sonobuoy rancher/mirrored-sonobuoy-sonobuoy v0.16.3
 sonobuoy/sonobuoy rancher/mirrored-sonobuoy-sonobuoy v0.19.0
 sonobuoy/sonobuoy rancher/mirrored-sonobuoy-sonobuoy v0.52.0

--- a/images-list
+++ b/images-list
@@ -1349,7 +1349,6 @@ sonobuoy/sonobuoy rancher/mirrored-sonobuoy-sonobuoy v0.57.1
 sonobuoy/sonobuoy rancher/mirrored-sonobuoy-sonobuoy v0.57.2
 sonobuoy/sonobuoy rancher/mirrored-sonobuoy-sonobuoy v0.57.3
 sonobuoy/sonobuoy rancher/sonobuoy-sonobuoy v0.19.0
-squareup/ghostunnel rancher/squareup-ghostunnel v1.5.2
 thanosio/thanos rancher/mirrored-thanosio-thanos v0.15.0
 thanosio/thanos rancher/mirrored-thanosio-thanos v0.21.1
 thanosio/thanos rancher/thanosio-thanos v0.15.0

--- a/images-list
+++ b/images-list
@@ -1349,7 +1349,6 @@ sonobuoy/sonobuoy rancher/mirrored-sonobuoy-sonobuoy v0.57.1
 sonobuoy/sonobuoy rancher/mirrored-sonobuoy-sonobuoy v0.57.2
 sonobuoy/sonobuoy rancher/mirrored-sonobuoy-sonobuoy v0.57.3
 sonobuoy/sonobuoy rancher/sonobuoy-sonobuoy v0.19.0
-thanosio/thanos rancher/thanosio-thanos v0.15.0
 tonistiigi/xx rancher/mirrored-tonistiigi-xx 1.3.0
 tonistiigi/xx rancher/mirrored-tonistiigi-xx 1.5.0
 us.gcr.io/k8s-artifacts-prod/external-dns/external-dns rancher/kubernetes-external-dns v0.7.3

--- a/regsync.yaml
+++ b/regsync.yaml
@@ -4397,27 +4397,6 @@ sync:
 - source: registry.suse.com/bci/bci-micro:15.6.24.2
   target: registry.suse.com/rancher/mirrored-bci-micro:15.6.24.2
   type: image
-- source: registry.suse.com/rancher/elemental-operator:1.4.2
-  target: docker.io/rancher/mirrored-elemental-operator:1.4.2
-  type: image
-- source: registry.suse.com/rancher/elemental-operator:1.4.3
-  target: docker.io/rancher/mirrored-elemental-operator:1.4.3
-  type: image
-- source: registry.suse.com/rancher/elemental-operator:1.5.3
-  target: docker.io/rancher/mirrored-elemental-operator:1.5.3
-  type: image
-- source: registry.suse.com/rancher/elemental-operator:1.5.4
-  target: docker.io/rancher/mirrored-elemental-operator:1.5.4
-  type: image
-- source: registry.suse.com/rancher/elemental-operator:1.6.4
-  target: docker.io/rancher/mirrored-elemental-operator:1.6.4
-  type: image
-- source: registry.suse.com/rancher/elemental-operator:1.6.5
-  target: docker.io/rancher/mirrored-elemental-operator:1.6.5
-  type: image
-- source: registry.suse.com/rancher/elemental-operator:1.6.8
-  target: docker.io/rancher/mirrored-elemental-operator:1.6.8
-  type: image
 - source: registry.suse.com/rancher/seedimage-builder:1.3.4
   target: docker.io/rancher/mirrored-elemental-seedimage-builder:1.3.4
   type: image
@@ -4447,4 +4426,10 @@ sync:
   type: image
 - source: rpardini/docker-registry-proxy:0.6.1
   target: registry.suse.com/rancher/rpardini-docker-registry-proxy:0.6.1
+  type: image
+- source: sigwindowstools/k8s-gmsa-webhook:v0.3.0
+  target: docker.io/rancher/mirrored-sigwindowstools-k8s-gmsa-webhook:v0.3.0
+  type: image
+- source: sigwindowstools/k8s-gmsa-webhook:v0.3.0
+  target: registry.suse.com/rancher/mirrored-sigwindowstools-k8s-gmsa-webhook:v0.3.0
   type: image

--- a/regsync.yaml
+++ b/regsync.yaml
@@ -4439,3 +4439,9 @@ sync:
 - source: squareup/ghostunnel:v1.5.2
   target: registry.suse.com/rancher/mirrored-squareup-ghostunnel:v1.5.2
   type: image
+- source: squareup/ghostunnel:v1.5.2
+  target: docker.io/rancher/squareup-ghostunnel:v1.5.2
+  type: image
+- source: squareup/ghostunnel:v1.5.2
+  target: registry.suse.com/rancher/squareup-ghostunnel:v1.5.2
+  type: image

--- a/regsync.yaml
+++ b/regsync.yaml
@@ -4463,3 +4463,9 @@ sync:
 - source: thanosio/thanos:v0.15.0
   target: registry.suse.com/rancher/thanosio-thanos:v0.15.0
   type: image
+- source: us.gcr.io/k8s-artifacts-prod/external-dns/external-dns:v0.7.3
+  target: docker.io/rancher/kubernetes-external-dns:v0.7.3
+  type: image
+- source: us.gcr.io/k8s-artifacts-prod/external-dns/external-dns:v0.7.3
+  target: registry.suse.com/rancher/kubernetes-external-dns:v0.7.3
+  type: image

--- a/regsync.yaml
+++ b/regsync.yaml
@@ -4457,3 +4457,9 @@ sync:
 - source: thanosio/thanos:v0.21.1
   target: registry.suse.com/rancher/mirrored-thanosio-thanos:v0.21.1
   type: image
+- source: thanosio/thanos:v0.15.0
+  target: docker.io/rancher/thanosio-thanos:v0.15.0
+  type: image
+- source: thanosio/thanos:v0.15.0
+  target: registry.suse.com/rancher/thanosio-thanos:v0.15.0
+  type: image

--- a/regsync.yaml
+++ b/regsync.yaml
@@ -4445,3 +4445,15 @@ sync:
 - source: squareup/ghostunnel:v1.5.2
   target: registry.suse.com/rancher/squareup-ghostunnel:v1.5.2
   type: image
+- source: thanosio/thanos:v0.15.0
+  target: docker.io/rancher/mirrored-thanosio-thanos:v0.15.0
+  type: image
+- source: thanosio/thanos:v0.21.1
+  target: docker.io/rancher/mirrored-thanosio-thanos:v0.21.1
+  type: image
+- source: thanosio/thanos:v0.15.0
+  target: registry.suse.com/rancher/mirrored-thanosio-thanos:v0.15.0
+  type: image
+- source: thanosio/thanos:v0.21.1
+  target: registry.suse.com/rancher/mirrored-thanosio-thanos:v0.21.1
+  type: image

--- a/regsync.yaml
+++ b/regsync.yaml
@@ -4469,3 +4469,9 @@ sync:
 - source: us.gcr.io/k8s-artifacts-prod/external-dns/external-dns:v0.7.3
   target: registry.suse.com/rancher/kubernetes-external-dns:v0.7.3
   type: image
+- source: us.gcr.io/k8s-artifacts-prod/external-dns/external-dns:v0.7.3
+  target: docker.io/rancher/mirrored-kubernetes-external-dns:v0.7.3
+  type: image
+- source: us.gcr.io/k8s-artifacts-prod/external-dns/external-dns:v0.7.3
+  target: registry.suse.com/rancher/mirrored-kubernetes-external-dns:v0.7.3
+  type: image

--- a/regsync.yaml
+++ b/regsync.yaml
@@ -4433,3 +4433,9 @@ sync:
 - source: sigwindowstools/k8s-gmsa-webhook:v0.3.0
   target: registry.suse.com/rancher/mirrored-sigwindowstools-k8s-gmsa-webhook:v0.3.0
   type: image
+- source: squareup/ghostunnel:v1.5.2
+  target: docker.io/rancher/mirrored-squareup-ghostunnel:v1.5.2
+  type: image
+- source: squareup/ghostunnel:v1.5.2
+  target: registry.suse.com/rancher/mirrored-squareup-ghostunnel:v1.5.2
+  type: image


### PR DESCRIPTION
This issue is part of https://github.com/rancher/rancher/issues/49870.

It migrates entries from `images-list` with source images starting with letters S-Z that are not mentioned in `retrieve-image-tags/config.json`.