### PR TITLE
Correct missing `regsync.yaml` entries due to race condition

### DIFF
--- a/regsync.yaml
+++ b/regsync.yaml
@@ -4421,6 +4421,30 @@ sync:
 - source: registry.suse.com/rancher/seedimage-builder:1.6.8
   target: docker.io/rancher/mirrored-elemental-seedimage-builder:1.6.8
   type: image
+- source: registry.suse.com/rancher/seedimage-builder:1.3.4
+  target: registry.suse.com/rancher/mirrored-elemental-seedimage-builder:1.3.4
+  type: image
+- source: registry.suse.com/rancher/seedimage-builder:1.4.2
+  target: registry.suse.com/rancher/mirrored-elemental-seedimage-builder:1.4.2
+  type: image
+- source: registry.suse.com/rancher/seedimage-builder:1.4.3
+  target: registry.suse.com/rancher/mirrored-elemental-seedimage-builder:1.4.3
+  type: image
+- source: registry.suse.com/rancher/seedimage-builder:1.5.3
+  target: registry.suse.com/rancher/mirrored-elemental-seedimage-builder:1.5.3
+  type: image
+- source: registry.suse.com/rancher/seedimage-builder:1.5.4
+  target: registry.suse.com/rancher/mirrored-elemental-seedimage-builder:1.5.4
+  type: image
+- source: registry.suse.com/rancher/seedimage-builder:1.6.4
+  target: registry.suse.com/rancher/mirrored-elemental-seedimage-builder:1.6.4
+  type: image
+- source: registry.suse.com/rancher/seedimage-builder:1.6.5
+  target: registry.suse.com/rancher/mirrored-elemental-seedimage-builder:1.6.5
+  type: image
+- source: registry.suse.com/rancher/seedimage-builder:1.6.8
+  target: registry.suse.com/rancher/mirrored-elemental-seedimage-builder:1.6.8
+  type: image
 - source: rpardini/docker-registry-proxy:0.6.1
   target: docker.io/rancher/rpardini-docker-registry-proxy:0.6.1
   type: image


### PR DESCRIPTION
CI is failing due to the `regsync-yaml-synced` step of the pull request workflow. I think this happened due to a race condition when merging PRs. This PR fixes this.