### PR TITLE
Disable mirroring for registry.suse.com/rancher/elemental-operator:1.3.4

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1117,6 +1117,9 @@ Images:
   SourceImage: registry.suse.com/rancher/elemental-operator
   Tags:
   - 1.3.4
+  TargetImageName: mirrored-elemental-operator
+- SourceImage: registry.suse.com/rancher/elemental-operator
+  Tags:
   - 1.4.2
   - 1.4.3
   - 1.5.3

--- a/regsync.yaml
+++ b/regsync.yaml
@@ -4397,6 +4397,27 @@ sync:
 - source: registry.suse.com/bci/bci-micro:15.6.24.2
   target: registry.suse.com/rancher/mirrored-bci-micro:15.6.24.2
   type: image
+- source: registry.suse.com/rancher/elemental-operator:1.4.2
+  target: docker.io/rancher/mirrored-elemental-operator:1.4.2
+  type: image
+- source: registry.suse.com/rancher/elemental-operator:1.4.3
+  target: docker.io/rancher/mirrored-elemental-operator:1.4.3
+  type: image
+- source: registry.suse.com/rancher/elemental-operator:1.5.3
+  target: docker.io/rancher/mirrored-elemental-operator:1.5.3
+  type: image
+- source: registry.suse.com/rancher/elemental-operator:1.5.4
+  target: docker.io/rancher/mirrored-elemental-operator:1.5.4
+  type: image
+- source: registry.suse.com/rancher/elemental-operator:1.6.4
+  target: docker.io/rancher/mirrored-elemental-operator:1.6.4
+  type: image
+- source: registry.suse.com/rancher/elemental-operator:1.6.5
+  target: docker.io/rancher/mirrored-elemental-operator:1.6.5
+  type: image
+- source: registry.suse.com/rancher/elemental-operator:1.6.8
+  target: docker.io/rancher/mirrored-elemental-operator:1.6.8
+  type: image
 - source: registry.suse.com/rancher/seedimage-builder:1.3.4
   target: docker.io/rancher/mirrored-elemental-seedimage-builder:1.3.4
   type: image


### PR DESCRIPTION
This was done in #932, but the change was lost due to a merge.