### PR TITLE
Adding Elemental 1.6.9 images

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1127,6 +1127,7 @@ Images:
   - 1.6.4
   - 1.6.5
   - 1.6.8
+  - 1.6.9
   TargetImageName: mirrored-elemental-operator
 - SourceImage: registry.suse.com/rancher/seedimage-builder
   Tags:
@@ -1138,6 +1139,7 @@ Images:
   - 1.6.4
   - 1.6.5
   - 1.6.8
+  - 1.6.9
   TargetImageName: mirrored-elemental-seedimage-builder
 - SourceImage: rpardini/docker-registry-proxy
   Tags:

--- a/regsync.yaml
+++ b/regsync.yaml
@@ -4418,6 +4418,9 @@ sync:
 - source: registry.suse.com/rancher/elemental-operator:1.6.8
   target: docker.io/rancher/mirrored-elemental-operator:1.6.8
   type: image
+- source: registry.suse.com/rancher/elemental-operator:1.6.9
+  target: docker.io/rancher/mirrored-elemental-operator:1.6.9
+  type: image
 - source: registry.suse.com/rancher/seedimage-builder:1.3.4
   target: docker.io/rancher/mirrored-elemental-seedimage-builder:1.3.4
   type: image
@@ -4441,6 +4444,9 @@ sync:
   type: image
 - source: registry.suse.com/rancher/seedimage-builder:1.6.8
   target: docker.io/rancher/mirrored-elemental-seedimage-builder:1.6.8
+  type: image
+- source: registry.suse.com/rancher/seedimage-builder:1.6.9
+  target: docker.io/rancher/mirrored-elemental-seedimage-builder:1.6.9
   type: image
 - source: rpardini/docker-registry-proxy:0.6.1
   target: docker.io/rancher/rpardini-docker-registry-proxy:0.6.1


### PR DESCRIPTION
registry.suse.com/rancher/elemental-operator:1.6.9
registry.suse.com/rancher/seedimage-builder:1.6.9

#### Pull Request Checklist ####

- [x] Change does not remove any existing Images or Tags in the images-list file
- [x] Change does not remove / overwrite exiting Images or Tags in Rancher DockerHub
- [x] If updating an existing entry, verify the `SOURCE` is still accurate and upstream hasn't been migrated to a new regitry or repo (if they've migrated, a new repo request to EIO is needed to comply with the `SOURCE DESTINATION TAG` pattern)
- [x] New entries are in format `SOURCE DESTINATION TAG`
- [x] New entries are added to the correct section of the list (sorted lexicographically)
- [x] New entries have a repo created in Rancher Dockerhub (where the image will be mirrored to)
- [x] New entries are licensed with Rancher favored licenses - Apache 2 and MIT - or approved licenses - as according to [CNCF approved licenses](https://github.com/cncf/foundation/blob/main/allowed-third-party-license-policy.md).
- [x] New entries, when used in Rancher or Rancher's provided charts, have their corresponding origin added in Rancher's images [origins](https://github.com/rancher/rancher/blob/release/v2.7/pkg/image/origins.go) file (must be added for all Rancher versions `>= v2.7`).
- [x] Changes to scripting or CI config have been tested to the best of your ability

#### Types of Change ####

<!-- New image, version bump. script update, etc etc -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request.  -->

#### Additional Notes ####

<!-- Any additional details / test results / etc -->

#### Final Checks after the PR is merged ####
- [ ] Confirm that you can pull the new images and tags from DockerHub
