### PR TITLE
Reset reqConcurrent to default of `3`

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1176,18 +1176,15 @@ Repositories:
 - BaseUrl: docker.io/rancher
   Password: '{{ env "DOCKER_PASSWORD" }}'
   Registry: docker.io
-  ReqConcurrent: 2
   Target: true
   Username: '{{ env "DOCKER_USERNAME" }}'
 - BaseUrl: dp.apps.rancher.io/containers
   Password: '{{ env "APPCO_PASSWORD" }}'
   Registry: dp.apps.rancher.io
-  ReqConcurrent: 2
   Target: false
   Username: '{{ env "APPCO_USERNAME" }}'
 - BaseUrl: registry.suse.com/rancher
   Password: '{{ env "PRIME_PASSWORD" }}'
   Registry: registry.suse.com
-  ReqConcurrent: 2
   Target: true
   Username: '{{ env "PRIME_USERNAME" }}'

--- a/regsync.yaml
+++ b/regsync.yaml
@@ -4,15 +4,12 @@
 creds:
 - pass: '{{ env "DOCKER_PASSWORD" }}'
   registry: docker.io
-  reqConcurrent: 2
   user: '{{ env "DOCKER_USERNAME" }}'
 - pass: '{{ env "APPCO_PASSWORD" }}'
   registry: dp.apps.rancher.io
-  reqConcurrent: 2
   user: '{{ env "APPCO_USERNAME" }}'
 - pass: '{{ env "PRIME_PASSWORD" }}'
   registry: registry.suse.com
-  reqConcurrent: 2
   user: '{{ env "PRIME_USERNAME" }}'
 defaults:
   userAgent: rancher-image-mirror


### PR DESCRIPTION
In #899 I set `reqConcurrent` for all registries to 2. However, I recently noticed that there is a message in the [`regsync` workflows](https://github.com/rancher/image-mirror/actions/runs/15331647080/job/43139608469):
```
{"host":"docker.io","level":"warning","msg":"Changing reqPerSec settings for registry","new":2,"orig":3,"time":"2025-05-29T19:16:18Z"}
```
I think that the use of `reqPerSec` is actually incorrect here - it should be `reqConcurrent`. What is important is that this caused me to realize that setting `reqConcurrent` to `2` is actually counter-productive, because the default is 3. This PR resets it to the default (but keeps the ability to set it, since we may want to set it in the future.

Docs for `regsync.yaml` are here: https://regclient.org/usage/regsync/