### PR TITLE
Skip mirroring images when target and source image are exactly the same

### DIFF
--- a/regsync.yaml
+++ b/regsync.yaml
@@ -4442,6 +4442,30 @@ sync:
 - source: registry.suse.com/rancher/elemental-operator:1.6.9
   target: docker.io/rancher/mirrored-elemental-operator:1.6.9
   type: image
+- source: registry.suse.com/rancher/elemental-operator:1.4.2
+  target: registry.suse.com/rancher/mirrored-elemental-operator:1.4.2
+  type: image
+- source: registry.suse.com/rancher/elemental-operator:1.4.3
+  target: registry.suse.com/rancher/mirrored-elemental-operator:1.4.3
+  type: image
+- source: registry.suse.com/rancher/elemental-operator:1.5.3
+  target: registry.suse.com/rancher/mirrored-elemental-operator:1.5.3
+  type: image
+- source: registry.suse.com/rancher/elemental-operator:1.5.4
+  target: registry.suse.com/rancher/mirrored-elemental-operator:1.5.4
+  type: image
+- source: registry.suse.com/rancher/elemental-operator:1.6.4
+  target: registry.suse.com/rancher/mirrored-elemental-operator:1.6.4
+  type: image
+- source: registry.suse.com/rancher/elemental-operator:1.6.5
+  target: registry.suse.com/rancher/mirrored-elemental-operator:1.6.5
+  type: image
+- source: registry.suse.com/rancher/elemental-operator:1.6.8
+  target: registry.suse.com/rancher/mirrored-elemental-operator:1.6.8
+  type: image
+- source: registry.suse.com/rancher/elemental-operator:1.6.9
+  target: registry.suse.com/rancher/mirrored-elemental-operator:1.6.9
+  type: image
 - source: registry.suse.com/rancher/seedimage-builder:1.3.4
   target: docker.io/rancher/mirrored-elemental-seedimage-builder:1.3.4
   type: image
@@ -4468,6 +4492,33 @@ sync:
   type: image
 - source: registry.suse.com/rancher/seedimage-builder:1.6.9
   target: docker.io/rancher/mirrored-elemental-seedimage-builder:1.6.9
+  type: image
+- source: registry.suse.com/rancher/seedimage-builder:1.3.4
+  target: registry.suse.com/rancher/mirrored-elemental-seedimage-builder:1.3.4
+  type: image
+- source: registry.suse.com/rancher/seedimage-builder:1.4.2
+  target: registry.suse.com/rancher/mirrored-elemental-seedimage-builder:1.4.2
+  type: image
+- source: registry.suse.com/rancher/seedimage-builder:1.4.3
+  target: registry.suse.com/rancher/mirrored-elemental-seedimage-builder:1.4.3
+  type: image
+- source: registry.suse.com/rancher/seedimage-builder:1.5.3
+  target: registry.suse.com/rancher/mirrored-elemental-seedimage-builder:1.5.3
+  type: image
+- source: registry.suse.com/rancher/seedimage-builder:1.5.4
+  target: registry.suse.com/rancher/mirrored-elemental-seedimage-builder:1.5.4
+  type: image
+- source: registry.suse.com/rancher/seedimage-builder:1.6.4
+  target: registry.suse.com/rancher/mirrored-elemental-seedimage-builder:1.6.4
+  type: image
+- source: registry.suse.com/rancher/seedimage-builder:1.6.5
+  target: registry.suse.com/rancher/mirrored-elemental-seedimage-builder:1.6.5
+  type: image
+- source: registry.suse.com/rancher/seedimage-builder:1.6.8
+  target: registry.suse.com/rancher/mirrored-elemental-seedimage-builder:1.6.8
+  type: image
+- source: registry.suse.com/rancher/seedimage-builder:1.6.9
+  target: registry.suse.com/rancher/mirrored-elemental-seedimage-builder:1.6.9
   type: image
 - source: rpardini/docker-registry-proxy:0.6.1
   target: docker.io/rancher/rpardini-docker-registry-proxy:0.6.1

--- a/tools/main.go
+++ b/tools/main.go
@@ -94,7 +94,8 @@ func generateRegsyncYaml(_ context.Context, _ *cli.Command) error {
 			if !repo.Target {
 				continue
 			}
-			if strings.HasPrefix(image.SourceImage, repo.BaseUrl) {
+			// source and destination images are the same
+			if image.SourceImage == repo.BaseUrl+"/"+image.TargetImageName() {
 				continue
 			}
 			syncEntries, err := convertConfigImageToRegsyncImages(repo, image)


### PR DESCRIPTION
Elemental container images are built directly (via IBS) in registry.suse.com.

In order to not mess-up with "classic" Rancher Prime sync process which cloned `docker.io/rancher/<IMAGE>` to `registry.suse.com/rancher/<IMAGE>`  we used `registry.suse.com/rancher/mirrored-<IMAGE>` as target for elemental images in `images-list` file.

The new process allows decoupling of syncs in docker.io and registry.suse.com. We can start then to have elemental-operator images cloned from registry.suse.com to docker.io and avoid the sync step from docker.io to registry.suse.com.

Still, the current Elemental images in the form "mirrored-elemental-*" are required in registry.suse.com, since those images are targeted by Rancher Prime Elemental chart deployments.

commit #b9cd2aee0944f761d8a620b6ca6580ad480802d3 skips syncing from source to target when the repo is the same: idea is to make it more strict, just skipping the sync when source and target path are identical.

Related to #b9cd2aee0944f761d8a620b6ca6580ad480802d3
