### PR TITLE
Make test deterministic

### DIFF
--- a/tools/internal/config/accumulator_test.go
+++ b/tools/internal/config/accumulator_test.go
@@ -1,8 +1,9 @@
 package config
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestImageAccumulator(t *testing.T) {
@@ -24,8 +25,13 @@ func TestImageAccumulator(t *testing.T) {
 			if !assert.Len(t, imageList, 2) {
 				return
 			}
-			assert.False(t, imageList[0].DoNotMirror)
-			assert.True(t, imageList[1].DoNotMirror)
+			if imageList[0].Tags[0] == "test1" {
+				assert.False(t, imageList[0].DoNotMirror)
+				assert.True(t, imageList[1].DoNotMirror)
+			} else {
+				assert.True(t, imageList[0].DoNotMirror)
+				assert.False(t, imageList[1].DoNotMirror)
+			}
 		})
 
 		t.Run("should correctly accumulate multiple images", func(t *testing.T) {


### PR DESCRIPTION


#### Pull Request Checklist ####

- [x ] Changes to scripting or CI config have been tested to the best of your ability

#### Types of Change ####
Fix sporadic unit test failure, as in https://github.com/rancher/image-mirror/actions/runs/15631022751/job/44035182148?pr=962

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request.  -->

#### Additional Notes ####
Since accumulator.Images() returns a slice of Image(s) picking them from a map, the order of the resulting images is not deterministic (maps element order is unreliable).

This may cause sporadic failures of the unit test.

Do the assertions depending on the actual order of the returned images.

