### PR TITLE
[K8s-1.33]Added Capi v1.10.2

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1001,6 +1001,7 @@ Images:
   TargetImageName: mirrored-nginx-ingress-controller-defaultbackend
 - SourceImage: registry.k8s.io/cluster-api/cluster-api-controller
   Tags:
+  - v1.10.2
   - v1.4.4
   - v1.5.5
   - v1.6.4
@@ -1009,7 +1010,6 @@ Images:
   - v1.8.3
   - v1.9.4
   - v1.9.5
-  - v1.10.2
   TargetImageName: mirrored-cluster-api-controller
 - SourceImage: registry.k8s.io/cpa/cluster-proportional-autoscaler
   Tags:

--- a/config.yaml
+++ b/config.yaml
@@ -1009,6 +1009,7 @@ Images:
   - v1.8.3
   - v1.9.4
   - v1.9.5
+  - v1.10.2
   TargetImageName: mirrored-cluster-api-controller
 - SourceImage: registry.k8s.io/cpa/cluster-proportional-autoscaler
   Tags:

--- a/regsync.yaml
+++ b/regsync.yaml
@@ -3962,6 +3962,9 @@ sync:
 - source: rancher/nginx-ingress-controller-defaultbackend:1.5-rancher2
   target: registry.suse.com/rancher/mirrored-nginx-ingress-controller-defaultbackend:1.5-rancher2
   type: image
+- source: registry.k8s.io/cluster-api/cluster-api-controller:v1.10.2
+  target: docker.io/rancher/mirrored-cluster-api-controller:v1.10.2
+  type: image
 - source: registry.k8s.io/cluster-api/cluster-api-controller:v1.4.4
   target: docker.io/rancher/mirrored-cluster-api-controller:v1.4.4
   type: image
@@ -3987,7 +3990,7 @@ sync:
   target: docker.io/rancher/mirrored-cluster-api-controller:v1.9.5
   type: image
 - source: registry.k8s.io/cluster-api/cluster-api-controller:v1.10.2
-  target: docker.io/rancher/mirrored-cluster-api-controller:v1.10.2
+  target: registry.suse.com/rancher/mirrored-cluster-api-controller:v1.10.2
   type: image
 - source: registry.k8s.io/cluster-api/cluster-api-controller:v1.4.4
   target: registry.suse.com/rancher/mirrored-cluster-api-controller:v1.4.4
@@ -4012,9 +4015,6 @@ sync:
   type: image
 - source: registry.k8s.io/cluster-api/cluster-api-controller:v1.9.5
   target: registry.suse.com/rancher/mirrored-cluster-api-controller:v1.9.5
-  type: image
-- source: registry.k8s.io/cluster-api/cluster-api-controller:v1.10.2
-  target: registry.suse.com/rancher/mirrored-cluster-api-controller:v1.10.2
   type: image
 - source: registry.k8s.io/cpa/cluster-proportional-autoscaler:1.8.3
   target: docker.io/rancher/mirrored-cluster-proportional-autoscaler:1.8.3

--- a/regsync.yaml
+++ b/regsync.yaml
@@ -3986,6 +3986,9 @@ sync:
 - source: registry.k8s.io/cluster-api/cluster-api-controller:v1.9.5
   target: docker.io/rancher/mirrored-cluster-api-controller:v1.9.5
   type: image
+- source: registry.k8s.io/cluster-api/cluster-api-controller:v1.10.2
+  target: docker.io/rancher/mirrored-cluster-api-controller:v1.10.2
+  type: image
 - source: registry.k8s.io/cluster-api/cluster-api-controller:v1.4.4
   target: registry.suse.com/rancher/mirrored-cluster-api-controller:v1.4.4
   type: image
@@ -4009,6 +4012,9 @@ sync:
   type: image
 - source: registry.k8s.io/cluster-api/cluster-api-controller:v1.9.5
   target: registry.suse.com/rancher/mirrored-cluster-api-controller:v1.9.5
+  type: image
+- source: registry.k8s.io/cluster-api/cluster-api-controller:v1.10.2
+  target: registry.suse.com/rancher/mirrored-cluster-api-controller:v1.10.2
   type: image
 - source: registry.k8s.io/cpa/cluster-proportional-autoscaler:1.8.3
   target: docker.io/rancher/mirrored-cluster-proportional-autoscaler:1.8.3


### PR DESCRIPTION
#### Pull Request Checklist ####

- [x] Change does not remove any existing Images or Tags in the images-list file
- [x] Change does not remove / overwrite exiting Images or Tags in Rancher DockerHub
- [x] If updating an existing entry, verify the `SOURCE` is still accurate and upstream hasn't been migrated to a new regitry or repo (if they've migrated, a new repo request to EIO is needed to comply with the `SOURCE DESTINATION TAG` pattern)
- [x] New entries are in format `SOURCE DESTINATION TAG`
- [x] New entries are added to the correct section of the list (sorted lexicographically)
- [x] New entries have a repo created in Rancher Dockerhub (where the image will be mirrored to)
- [x] New entries are licensed with Rancher favored licenses - Apache 2 and MIT - or approved licenses - as according to [CNCF approved licenses](https://github.com/cncf/foundation/blob/main/allowed-third-party-license-policy.md).
- [x] New entries, when used in Rancher or Rancher's provided charts, have their corresponding origin added in Rancher's images [origins](https://github.com/rancher/rancher/blob/release/v2.7/pkg/image/origins.go) file (must be added for all Rancher versions `>= v2.7`).
- [x] Changes to scripting or CI config have been tested to the best of your ability

#### Types of Change ####

<!-- New image, version bump. script update, etc etc -->

#### Linked Issues ####
added capi v1.10.2
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request.  -->

#### Additional Notes ####

<!-- Any additional details / test results / etc -->

#### Final Checks after the PR is merged ####
- [x] Confirm that you can pull the new images and tags from DockerHub
