### PR TITLE
Stop autoupdate workflow including previous pr changes

### DIFF
--- a/tools/internal/autoupdate/config.go
+++ b/tools/internal/autoupdate/config.go
@@ -28,7 +28,7 @@ type ConfigEntry struct {
 
 type AutoUpdateOptions struct {
 	BaseBranch   string
-	ConfigYaml   config.Config
+	ConfigYaml   *config.Config
 	DryRun       bool
 	GithubOwner  string
 	GithubRepo   string

--- a/tools/internal/config/config.go
+++ b/tools/internal/config/config.go
@@ -47,27 +47,27 @@ type Repository struct {
 	Username string
 }
 
-func Parse(fileName string) (Config, error) {
+func Parse(fileName string) (*Config, error) {
 	contents, err := os.ReadFile(fileName)
 	if err != nil {
-		return Config{}, fmt.Errorf("failed to read: %w", err)
+		return nil, fmt.Errorf("failed to read: %w", err)
 	}
 
-	config := Config{}
+	config := &Config{}
 	if err := yaml.Unmarshal(contents, &config); err != nil {
-		return Config{}, fmt.Errorf("failed to unmarshal as JSON: %w", err)
+		return nil, fmt.Errorf("failed to unmarshal as JSON: %w", err)
 	}
 
 	for _, image := range config.Images {
 		if err := image.setDefaults(); err != nil {
-			return Config{}, fmt.Errorf("failed to set defaults for image %q: %w", image.SourceImage, err)
+			return nil, fmt.Errorf("failed to set defaults for image %q: %w", image.SourceImage, err)
 		}
 	}
 
 	return config, nil
 }
 
-func Write(fileName string, config Config) error {
+func Write(fileName string, config *Config) error {
 	config.Sort()
 
 	contents, err := yaml.Marshal(config)

--- a/tools/internal/config/config.go
+++ b/tools/internal/config/config.go
@@ -127,6 +127,17 @@ func (config *Config) ToRegsyncConfig() (regsync.Config, error) {
 	return regsyncYaml, nil
 }
 
+func (config *Config) DeepCopy() *Config {
+	copiedConfig := &Config{
+		Images:       make([]*Image, 0, len(config.Images)),
+		Repositories: slices.Clone(config.Repositories),
+	}
+	for _, image := range config.Images {
+		copiedConfig.Images = append(copiedConfig.Images, image.DeepCopy())
+	}
+	return copiedConfig
+}
+
 func compareRepositories(a, b Repository) int {
 	return strings.Compare(a.BaseUrl, b.BaseUrl)
 }

--- a/tools/internal/config/image.go
+++ b/tools/internal/config/image.go
@@ -3,6 +3,7 @@ package config
 import (
 	"errors"
 	"fmt"
+	"maps"
 	"slices"
 	"strings"
 
@@ -138,6 +139,18 @@ func (image *Image) ToRegsyncImages(repo Repository) ([]regsync.ConfigSync, erro
 	}
 
 	return entries, nil
+}
+
+func (image *Image) DeepCopy() *Image {
+	copiedImage := &Image{
+		DoNotMirror:    image.DoNotMirror,
+		SourceImage:    image.SourceImage,
+		excludeAllTags: image.excludeAllTags,
+		excludedTags:   maps.Clone(image.excludedTags),
+		Tags:           slices.Clone(image.Tags),
+	}
+	copiedImage.SetTargetImageName(image.TargetImageName())
+	return copiedImage
 }
 
 func CompareImages(a, b *Image) int {

--- a/tools/main.go
+++ b/tools/main.go
@@ -237,19 +237,20 @@ func autoUpdate(ctx context.Context, _ *cli.Command) error {
 	githubOwner := parts[0]
 	githubRepo := parts[1]
 
-	autoUpdateOptions := autoupdate.AutoUpdateOptions{
-		BaseBranch:   "master",
-		ConfigYaml:   configYaml,
-		DryRun:       dryRun,
-		GithubOwner:  githubOwner,
-		GithubRepo:   githubRepo,
-		GithubClient: ghClient,
-	}
 	errorPresent := false
 	for _, autoUpdateEntry := range autoUpdateEntries {
 		if entryName != "" && autoUpdateEntry.Name != entryName {
 			fmt.Printf("%s: skipped\n", autoUpdateEntry.Name)
 			continue
+		}
+
+		autoUpdateOptions := autoupdate.AutoUpdateOptions{
+			BaseBranch:   "master",
+			ConfigYaml:   configYaml.DeepCopy(),
+			DryRun:       dryRun,
+			GithubOwner:  githubOwner,
+			GithubRepo:   githubRepo,
+			GithubClient: ghClient,
 		}
 		if err := autoUpdateEntry.Run(ctx, autoUpdateOptions); err != nil {
 			fmt.Printf("%s: error: %s\n", autoUpdateEntry.Name, err)


### PR DESCRIPTION
Related to https://github.com/rancher/rancher/issues/50768.

Here is the cause of the problem: the `Tags` slice of a given image was being modified. Because we were reusing the same `config.yaml` variable across different `autoupdate.ConfigEntry.Run()` calls, the changes for one run would persist for the next call. This means that each PR would have the changes from every PR that was created before it for a given workflow run.

The solution is to deep copy the `config.yaml` variable before every `autoupdate.ConfigEntry.Run()` call, and use the copy.