### PR TITLE
Allow specifying `TargetImageName` in `GithubLatestRelease` images

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,8 +82,16 @@ repository and applies it to the specified images.
 | ------------- | ------------- |------------- |
 | `Owner` | yes | The GitHub repository owner/organization.
 | `Repository` | yes | The GitHub repository name.
-| `Images` | yes | A list of images to be updated with the latest release tag. Each image will get the same tag as the GitHub release.
+| `Images` | yes | See [GithubLatestReleaseImage](#githublatestreleaseimage).
 
+#### `GithubLatestReleaseImage`
+
+A list of images to be updated with the latest release tag. Each image will get the same tag as the GitHub release.
+
+| Field | Required | Description |
+| ------------- | ------------- |------------- |
+| `SourceImage` | yes | The GitHub repository name.
+| `TargetImageName` | no | The TargetImageName of the image in `config.yaml` that you want to update.
 
 ## Old Documentation
 
@@ -287,7 +295,7 @@ See example configuration for `helm-latest:helm-repo-fqdn`:
       "kubewarden-defaults": {}
     }
   },
-  "neuvector": {                                                                                                                                                                                                                                                                                                             
+  "neuvector": {
     "versionSource": "helm-latest:https://neuvector.github.io/neuvector-helm",
     "helmCharts": {
       "core": {}
@@ -353,7 +361,7 @@ See example configuration for `helm-directory`:
 
 If you want to manually test your configuration changes to check if the correct tags are found, you can use the following commands depending on your available runtime:
 
-##### Docker 
+##### Docker
 
 ```
 docker run -v $PWD:/code -w /code/retrieve-image-tags python:3.10-alpine sh -c "apk -qU add helm && pip install --disable-pip-version-check --root-user-action=ignore -qr requirements.txt && python retrieve-image-tags.py"
@@ -410,7 +418,7 @@ You can use the [Add tag to existing image](https://github.com/rancher/image-mir
 Example inputs:
 
 ```
-Images: quay.io/cilium/cilium,quay.io/cilium/operator-aws,quay.io/cilium/operator-azure,quay.io/cilium/operator-generic 
+Images: quay.io/cilium/cilium,quay.io/cilium/operator-aws,quay.io/cilium/operator-azure,quay.io/cilium/operator-generic
 Tags: v1.12.1
 ```
 

--- a/autoupdate.yaml
+++ b/autoupdate.yaml
@@ -1,79 +1,81 @@
 - GithubLatestRelease:
     Images:
-    - registry.k8s.io/sig-storage/csi-attacher
+    - SourceImage: registry.k8s.io/sig-storage/csi-attacher
     Owner: kubernetes-csi
     Repository: external-attacher
   Name: csi-attacher
 - GithubLatestRelease:
     Images:
-    - registry.k8s.io/sig-storage/csi-node-driver-registrar
+    - SourceImage: registry.k8s.io/sig-storage/csi-node-driver-registrar
     Owner: kubernetes-csi
     Repository: node-driver-registrar
   Name: csi-driver-registrar
 - GithubLatestRelease:
     Images:
-    - registry.k8s.io/sig-storage/csi-provisioner
+    - SourceImage: registry.k8s.io/sig-storage/csi-provisioner
     Owner: kubernetes-csi
     Repository: external-provisioner
   Name: csi-provisioner
 - GithubLatestRelease:
     Images:
-    - registry.k8s.io/sig-storage/csi-resizer
+    - SourceImage: registry.k8s.io/sig-storage/csi-resizer
     Owner: kubernetes-csi
     Repository: external-resizer
   Name: csi-resizer
 - GithubLatestRelease:
     Images:
-    - registry.k8s.io/sig-storage/csi-snapshotter
+    - SourceImage: registry.k8s.io/sig-storage/csi-snapshotter
     Owner: kubernetes-csi
     Repository: external-snapshotter
   Name: csi-snapshotter
 - GithubLatestRelease:
     Images:
-    - flannel/flannel
+    - SourceImage: flannel/flannel
     Owner: flannel-io
     Repository: flannel
   Name: flannel
 - GithubLatestRelease:
     Images:
-    - flannel/flannel-cni-plugin
+    - SourceImage: flannel/flannel-cni-plugin
     Owner: flannel-io
     Repository: cni-plugin
   Name: flannel-cni-plugin
 - GithubLatestRelease:
     Images:
-    - ghcr.io/kube-vip/kube-vip-iptables
+    - SourceImage: ghcr.io/kube-vip/kube-vip-iptables
     Owner: kube-vip
     Repository: kube-vip
   Name: kube-vip-iptables
 - GithubLatestRelease:
     Images:
-    - idealista/prom2teams
+    - SourceImage: idealista/prom2teams
     Owner: idealista
     Repository: prom2teams
   Name: prom2teams
 - GithubLatestRelease:
     Images:
-    - registry.k8s.io/sig-storage/snapshot-controller
+    - SourceImage: registry.k8s.io/sig-storage/snapshot-controller
     Owner: kubernetes-csi
     Repository: external-snapshotter
   Name: snapshot-controller
 - GithubLatestRelease:
     Images:
-    - sonobuoy/sonobuoy
+    - SourceImage: sonobuoy/sonobuoy
     Owner: vmware-tanzu
     Repository: sonobuoy
   Name: sonobuoy
 - GithubLatestRelease:
     Images:
-    - registry.k8s.io/sig-storage/livenessprobe
+    - SourceImage: registry.k8s.io/sig-storage/livenessprobe
     Owner: kubernetes-csi
     Repository: livenessprobe
   Name: storage-livenessprobe
 - GithubLatestRelease:
     Images:
-    - registry.k8s.io/csi-vsphere/driver
-    - registry.k8s.io/csi-vsphere/syncer
+    - SourceImage: registry.k8s.io/csi-vsphere/driver
+      TargetImageName: mirrored-cloud-provider-vsphere-csi-release-driver
+    - SourceImage: registry.k8s.io/csi-vsphere/syncer
+      TargetImageName: mirrored-cloud-provider-vsphere-csi-release-syncer
     Owner: kubernetes-sigs
     Repository: vsphere-csi-driver
   Name: vsphere-csi

--- a/tools/internal/autoupdate/config_test.go
+++ b/tools/internal/autoupdate/config_test.go
@@ -23,7 +23,7 @@ func TestConfigEntry(t *testing.T) {
 					GithubLatestRelease: &GithubLatestRelease{
 						Owner:      "test-owner",
 						Repository: "test-repo",
-						Images:     []string{"rancher/rancher"},
+						Images:     []GithubLatestReleaseImage{{SourceImage: "rancher/rancher"}},
 					},
 				},
 				ExpectedError: "",
@@ -35,7 +35,7 @@ func TestConfigEntry(t *testing.T) {
 					GithubLatestRelease: &GithubLatestRelease{
 						Owner:      "test-owner",
 						Repository: "test-repo",
-						Images:     []string{"rancher/rancher"},
+						Images:     []GithubLatestReleaseImage{{SourceImage: "rancher/rancher"}},
 					},
 				},
 				ExpectedError: "must specify Name",

--- a/tools/internal/autoupdate/githublatestrelease.go
+++ b/tools/internal/autoupdate/githublatestrelease.go
@@ -17,7 +17,12 @@ import (
 type GithubLatestRelease struct {
 	Owner      string
 	Repository string
-	Images     []string
+	Images     []GithubLatestReleaseImage
+}
+
+type GithubLatestReleaseImage struct {
+	SourceImage     string
+	TargetImageName string `json:",omitempty"`
 }
 
 func (glr *GithubLatestRelease) GetUpdateImages() ([]*config.Image, error) {
@@ -30,10 +35,11 @@ func (glr *GithubLatestRelease) GetUpdateImages() ([]*config.Image, error) {
 
 	images := make([]*config.Image, 0, len(glr.Images))
 	for _, sourceImage := range glr.Images {
-		image, err := config.NewImage(sourceImage, []string{latestTag})
+		image, err := config.NewImage(sourceImage.SourceImage, []string{latestTag})
 		if err != nil {
 			return nil, fmt.Errorf("failed to construct image from source image %q and tag %q: %w", sourceImage, latestTag, err)
 		}
+		image.SetTargetImageName(sourceImage.TargetImageName)
 		images = append(images, image)
 	}
 

--- a/tools/internal/autoupdate/githublatestrelease_test.go
+++ b/tools/internal/autoupdate/githublatestrelease_test.go
@@ -19,7 +19,7 @@ func TestGithubLatestRelease(t *testing.T) {
 				GithubLatestRelease: &GithubLatestRelease{
 					Owner:      "test-owner",
 					Repository: "test-repo",
-					Images:     []string{"rancher/rancher"},
+					Images:     []GithubLatestReleaseImage{{SourceImage: "rancher/rancher"}},
 				},
 				ExpectedError: "",
 			},
@@ -27,7 +27,7 @@ func TestGithubLatestRelease(t *testing.T) {
 				Message: "should return error for empty Owner",
 				GithubLatestRelease: &GithubLatestRelease{
 					Repository: "test-repo",
-					Images:     []string{"rancher/rancher"},
+					Images:     []GithubLatestReleaseImage{{SourceImage: "rancher/rancher"}},
 				},
 				ExpectedError: "must specify Owner",
 			},
@@ -35,7 +35,7 @@ func TestGithubLatestRelease(t *testing.T) {
 				Message: "should return error for empty Repository",
 				GithubLatestRelease: &GithubLatestRelease{
 					Owner:  "test-owner",
-					Images: []string{"rancher/rancher"},
+					Images: []GithubLatestReleaseImage{{SourceImage: "rancher/rancher"}},
 				},
 				ExpectedError: "must specify Repository",
 			},
@@ -52,7 +52,7 @@ func TestGithubLatestRelease(t *testing.T) {
 				GithubLatestRelease: &GithubLatestRelease{
 					Owner:      "test-owner",
 					Repository: "test-repo",
-					Images:     []string{},
+					Images:     []GithubLatestReleaseImage{},
 				},
 				ExpectedError: "must specify at least one element for Images",
 			},


### PR DESCRIPTION
Fixes https://github.com/rancher/rancher/issues/50781.

Basically, whenever we are referring to an image in `config.yaml`, we must index on *both* `SourceImage` and `TargetImageName`. This will be a pattern in every autoupdate strategy.