### PR TITLE
Fix image deepcopy targetimagename

### DIFF
--- a/tools/internal/config/image.go
+++ b/tools/internal/config/image.go
@@ -143,13 +143,14 @@ func (image *Image) ToRegsyncImages(repo Repository) ([]regsync.ConfigSync, erro
 
 func (image *Image) DeepCopy() *Image {
 	copiedImage := &Image{
-		DoNotMirror:    image.DoNotMirror,
-		SourceImage:    image.SourceImage,
-		excludeAllTags: image.excludeAllTags,
-		excludedTags:   maps.Clone(image.excludedTags),
-		Tags:           slices.Clone(image.Tags),
+		DoNotMirror:              image.DoNotMirror,
+		SourceImage:              image.SourceImage,
+		defaultTargetImageName:   image.defaultTargetImageName,
+		SpecifiedTargetImageName: image.SpecifiedTargetImageName,
+		excludeAllTags:           image.excludeAllTags,
+		excludedTags:             maps.Clone(image.excludedTags),
+		Tags:                     slices.Clone(image.Tags),
 	}
-	copiedImage.SetTargetImageName(image.TargetImageName())
 	return copiedImage
 }
 

--- a/tools/internal/config/image_test.go
+++ b/tools/internal/config/image_test.go
@@ -108,4 +108,26 @@ func TestImage(t *testing.T) {
 			}
 		})
 	})
+
+	t.Run("DeepCopy", func(t *testing.T) {
+		t.Run("should copy all fields", func(t *testing.T) {
+			original, err := NewImage("test-org/test-image", []string{"v1.0.0", "v2.0.0"})
+			assert.NoError(t, err)
+
+			original.DoNotMirror = []any{"v1.0.0"}
+			original.SetTargetImageName("custom-image-name")
+			err = original.setDefaults()
+			assert.NoError(t, err)
+
+			copy := original.DeepCopy()
+
+			assert.Equal(t, original.DoNotMirror, copy.DoNotMirror)
+			assert.Equal(t, original.SourceImage, copy.SourceImage)
+			assert.Equal(t, original.defaultTargetImageName, copy.defaultTargetImageName)
+			assert.Equal(t, original.SpecifiedTargetImageName, copy.SpecifiedTargetImageName)
+			assert.Equal(t, original.Tags, copy.Tags)
+			assert.Equal(t, original.excludeAllTags, copy.excludeAllTags)
+			assert.Equal(t, original.excludedTags, copy.excludedTags)
+		})
+	})
 }


### PR DESCRIPTION
I introduced another bug due to the combination of #986 and #987. Calling `(*Image).DeepCopy()` resulted in a copy without `defaultTargetImageName` set, which caused `SpecifiedTargetImageName` to be set when `SetTargetImageName()` was called in `DeepCopy()`. This resulted in `TargetImageName` being set for every image in `config.yaml`, as you can see in #989 (I've corrected it now, but if you look in the history you can see it). This PR fixes this problem and introduces a unit test for it.