### PR TITLE
Fix `HelmLatest` update strategy's treatment of `Images` key

### DIFF
--- a/tools/internal/autoupdate/helmlatest.go
+++ b/tools/internal/autoupdate/helmlatest.go
@@ -97,22 +97,20 @@ func (hl *HelmLatest) GetUpdateImages() ([]*config.Image, error) {
 	// Convert the map to a slice of config.Image objects
 	images := make([]*config.Image, 0, len(imageMap))
 	for sourceImage, tags := range imageMap {
-		foundTargetImageName := ""
+		var foundTargetImageName *string
 		for _, autoupdateImageRef := range hl.Images {
 			if sourceImage == autoupdateImageRef.SourceImage {
-				foundTargetImageName = autoupdateImageRef.TargetImageName
+				foundTargetImageName = &autoupdateImageRef.SourceImage
 				break
 			}
 		}
-		if foundTargetImageName == "" {
+		if foundTargetImageName == nil {
 			return nil, fmt.Errorf("found image %s but it is not present in Images", sourceImage)
 		}
-
-		image, err := config.NewImage(sourceImage, tags, foundTargetImageName, nil)
+		image, err := config.NewImage(sourceImage, tags, *foundTargetImageName, nil)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create image: %w", err)
 		}
-
 		images = append(images, image)
 	}
 


### PR DESCRIPTION
I noticed an error in the autoupdate workflow: https://github.com/rancher/image-mirror/actions/runs/16074545116/job/45366540428

We were treating `foundTargetImageName == ""` as an error case. However, this is also the case when `sourceImage == autoupdateImageRef.SourceImage` but `autoupdateImageRef.TargetImageName` is unset. This PR fixes this by making `foundTargetImageName` a pointer to a string, and treating the `nil` case as unset.