### PR TITLE
Fix incorrect setting of `TargetImageName` in `HelmLatest` autoupdate strategy

### DIFF
--- a/tools/internal/autoupdate/helmlatest.go
+++ b/tools/internal/autoupdate/helmlatest.go
@@ -100,7 +100,7 @@ func (hl *HelmLatest) GetUpdateImages() ([]*config.Image, error) {
 		var foundTargetImageName *string
 		for _, autoupdateImageRef := range hl.Images {
 			if sourceImage == autoupdateImageRef.SourceImage {
-				foundTargetImageName = &autoupdateImageRef.SourceImage
+				foundTargetImageName = &autoupdateImageRef.TargetImageName
 				break
 			}
 		}


### PR DESCRIPTION
There is a typo in the `HelmLatest` code that sets `TargetImageName` to the value of `SourceImage` for any new versions. We can see this in the following PRs:
- https://github.com/rancher/image-mirror/pull/1007
- https://github.com/rancher/image-mirror/pull/1008
This PR sets `TargetImageName` properly.