### PR TITLE
Do not use `autoupdate.yaml` `Reviewers` field to request pull request reviews

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ entry specifies a strategy for finding tags of images to potentially add to
 | `GithubRelease` | no | See [`GithubRelease`](#githubrelease).
 | `HelmLatest`    | no | See [`HelmLatest`](#helmlatest).
 | `Registry`      | no | See [`Registry`](#registry).
-| `Reviewers`     | no | A list of GitHub users or teams to request review from on created pull requests. Teams should be in the format `org/team-slug`.
+| `Reviewers`     | yes | A list of GitHub users or teams that own the autoupdate entry. Teams should be in the format `org/team-slug`.
 
 #### `GithubRelease`
 

--- a/tools/internal/autoupdate/config.go
+++ b/tools/internal/autoupdate/config.go
@@ -289,34 +289,7 @@ func (entry ConfigEntry) CreateImageUpdatePullRequest(ctx context.Context, opts 
 
 	fmt.Printf("%s: created pull request: %s\n", entry.Name, pullRequest.GetHTMLURL())
 
-	if len(entry.Reviewers) > 0 {
-		reviewersRequest := newReviewersRequest(entry.Reviewers)
-		_, _, err := opts.GithubClient.PullRequests.RequestReviewers(requestContext, opts.GithubOwner, opts.GithubRepo, pullRequest.GetNumber(), reviewersRequest)
-		if err != nil {
-			fmt.Printf("warning: failed to request reviewers for PR %s: %v\n", pullRequest.GetHTMLURL(), err)
-		}
-	}
-
 	return nil
-}
-
-func newReviewersRequest(entryReviewers []string) github.ReviewersRequest {
-	reviewers := github.ReviewersRequest{
-		Reviewers: make([]string, 0),
-		TeamReviewers: make([]string, 0),
-	}
-
-	for _, entryReviewer := range entryReviewers {
-		// We have already validated that each reviewer has either one or two parts
-		parts := strings.Split(entryReviewer, "/")
-		if len(parts) == 1 {
-			reviewers.Reviewers = append(reviewers.Reviewers, parts[0])
-		} else if len(parts) == 2 {
-			reviewers.TeamReviewers = append(reviewers.TeamReviewers, parts[1])
-		}
-	}
-
-	return reviewers
 }
 
 // hashImageSet computes a human-readable hash from a passed

--- a/tools/internal/autoupdate/config_test.go
+++ b/tools/internal/autoupdate/config_test.go
@@ -3,7 +3,6 @@ package autoupdate
 import (
 	"testing"
 
-	"github.com/google/go-github/v73/github"
 	"github.com/rancher/image-mirror/internal/config"
 
 	"github.com/stretchr/testify/assert"
@@ -258,48 +257,4 @@ func TestGetBranchHash(t *testing.T) {
 
 		assert.NotEqual(t, hash1, hash2)
 	})
-}
-
-func TestNewReviewersRequest(t *testing.T) {
-	type testCase struct {
-		Name      string
-		Reviewers []string
-		Expected  github.ReviewersRequest
-	}
-	testCases := []testCase{
-		{
-			Name:      "should correctly parse users and teams",
-			Reviewers: []string{"user1", "my-org/team-one", "user2", "another-org/team-two"},
-			Expected: github.ReviewersRequest{
-				Reviewers:     []string{"user1", "user2"},
-				TeamReviewers: []string{"team-one", "team-two"},
-			},
-		},
-		{
-			Name:      "should handle only users",
-			Reviewers: []string{"user1", "user2"},
-			Expected: github.ReviewersRequest{
-				Reviewers: []string{"user1", "user2"},
-			},
-		},
-		{
-			Name:      "should handle only teams",
-			Reviewers: []string{"my-org/team-one", "another-org/team-two"},
-			Expected: github.ReviewersRequest{
-				TeamReviewers: []string{"team-one", "team-two"},
-			},
-		},
-		{
-			Name:      "should handle empty list",
-			Reviewers: []string{},
-			Expected:  github.ReviewersRequest{},
-		},
-	}
-	for _, tc := range testCases {
-		t.Run(tc.Name, func(t *testing.T) {
-			req := newReviewersRequest(tc.Reviewers)
-			assert.ElementsMatch(t, tc.Expected.Reviewers, req.Reviewers)
-			assert.ElementsMatch(t, tc.Expected.TeamReviewers, req.TeamReviewers)
-		})
-	}
 }


### PR DESCRIPTION
Closes https://github.com/rancher/rancher/issues/51069.

See the linked issue for more information. We are keeping the `Reviewers` field (and the requirement to define it) because it says which teams own any given `autoupdate.yaml` entry.