### PR TITLE
add grafana image renderer v4.0.5

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -456,6 +456,7 @@ Images:
   - 3.12.3
   - 3.12.6
   - 3.8.0
+  - v4.0.5
 - SourceImage: idealista/prom2teams
   Tags:
   - 3.2.1

--- a/regsync.yaml
+++ b/regsync.yaml
@@ -1476,6 +1476,9 @@ sync:
 - source: grafana/grafana-image-renderer:3.8.0
   target: docker.io/rancher/mirrored-grafana-grafana-image-renderer:3.8.0
   type: image
+- source: grafana/grafana-image-renderer:v4.0.5
+  target: docker.io/rancher/mirrored-grafana-grafana-image-renderer:v4.0.5
+  type: image
 - source: grafana/grafana-image-renderer:2.0.1
   target: registry.suse.com/rancher/mirrored-grafana-grafana-image-renderer:2.0.1
   type: image
@@ -1502,6 +1505,9 @@ sync:
   type: image
 - source: grafana/grafana-image-renderer:3.8.0
   target: registry.suse.com/rancher/mirrored-grafana-grafana-image-renderer:3.8.0
+  type: image
+- source: grafana/grafana-image-renderer:v4.0.5
+  target: registry.suse.com/rancher/mirrored-grafana-grafana-image-renderer:v4.0.5
   type: image
 - source: idealista/prom2teams:3.2.1
   target: docker.io/rancher/mirrored-idealista-prom2teams:3.2.1


### PR DESCRIPTION
Issue https://github.com/rancher/ob-team-charts/issues/101
#### Pull Request Checklist ####

- [x] If an entire image is being added, a repo has been created for the image in DockerHub under the `rancher` org
- [x] Additions are licensed with Rancher favored licenses - Apache 2 and MIT - or approved licenses - as according to [CNCF approved licenses](https://github.com/cncf/foundation/blob/main/allowed-third-party-license-policy.md).
- [x] Additions, when used in Rancher or Rancher's provided charts, have their corresponding origin added in Rancher's images [origins](https://github.com/rancher/rancher/blob/release/v2.7/pkg/image/origins.go) file (must be added for all Rancher versions `>= v2.7`).
- [x] Any changes to scripting or CI config have been tested to the best of your ability

#### Change Description ####

<!-- Describe what you are doing and why. Link any related issues, pull requests and commit hashes. -->

#### Final Checks after the PR is merged ####

- [ ] Confirm that you can pull the mirrored images and tags from all target locations
