### PR TITLE
Mirror application collection redis

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -90,6 +90,9 @@ Images:
   Tags:
   - v0.7.0
   - v0.8.3
+- SourceImage: dp.apps.rancher.io/containers/redis
+  Tags:
+  - 8.0.3-2.1
 - SourceImage: flannel/flannel
   Tags:
   - v0.21.2

--- a/regsync.yaml
+++ b/regsync.yaml
@@ -363,6 +363,12 @@ sync:
 - source: directxman12/k8s-prometheus-adapter-amd64:v0.8.3
   target: registry.suse.com/rancher/mirrored-directxman12-k8s-prometheus-adapter-amd64:v0.8.3
   type: image
+- source: dp.apps.rancher.io/containers/redis:8.0.3-2.1
+  target: docker.io/rancher/appco-redis:8.0.3-2.1
+  type: image
+- source: dp.apps.rancher.io/containers/redis:8.0.3-2.1
+  target: registry.suse.com/rancher/appco-redis:8.0.3-2.1
+  type: image
 - source: flannel/flannel:v0.21.2
   target: docker.io/rancher/mirrored-flannel-flannel:v0.21.2
   type: image


### PR DESCRIPTION
We already have mirror of redis on docker hub.
But we should use more secure one.

#### Pull Request Checklist ####

- [x] If an entire image is being added, a repo has been created for the image in DockerHub under the `rancher` org
- [x] Additions are licensed with Rancher favored licenses - Apache 2 and MIT - or approved licenses - as according to [CNCF approved licenses](https://github.com/cncf/foundation/blob/main/allowed-third-party-license-policy.md). -> This is `AGPLv3`.
- [x] Additions, when used in Rancher or Rancher's provided charts, have their corresponding origin added in Rancher's images [origins](https://github.com/rancher/rancher/blob/release/v2.7/pkg/image/origins.go) file (must be added for all Rancher versions `>= v2.7`).
- [x] Any changes to scripting or CI config have been tested to the best of your ability

#### Change Description ####
This PR request mirroring of `redis` image in application collection. We already have mirror of `redis` on docker hub. But we should use more secure one.

#### Final Checks after the PR is merged ####

- [ ] Confirm that you can pull the mirrored images and tags from all target locations
