### PR TITLE
Do not try pulling new image tags if they are from the application collection

### DIFF
--- a/tools/main.go
+++ b/tools/main.go
@@ -334,6 +334,14 @@ func validateNewTagsPullable(errs *[]error, newConfigYaml *config.Config) {
 			*errs = append(*errs, wrappedErr)
 			continue
 		}
+		// Workflows that are triggered by pull requests from forks (i.e.
+		// every human-created PR in this repo) cannot get the ID token that
+		// is needed to get secrets from EIO's setup. Pulling images from
+		// the application collection requires one of these secrets. So,
+		// we do not try pulling the image if it is from the appco.
+		if strings.HasPrefix(newTagImage.SourceImage, "dp.apps.rancher.io") {
+			continue
+		}
 		for _, newTag := range newTagImage.Tags {
 			_, err := oras.Copy(context.Background(), repo, newTag, store, newTag, oras.DefaultCopyOptions)
 			if err != nil {


### PR DESCRIPTION
https://github.com/rancher/image-mirror/pull/1046 is failing the PR check that runs `image-mirror-tools validate`. This check is failing because it involves pulling an image from the application collection, which requires authentication.

Ideally we would update `image-mirror-tools validate` and the `pull-request.yml` workflow to provide authentication to the application collection, but this requires secrets to be fetched via `rancher-eio/read-vault-secrets`. And that requires `id-token: write` permissions, which cannot be granted to workflows triggered by pull requests from forks for security reasons: https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#workflows-in-forked-repositories.

Instead, this pull request disables the image pulling check for any images that come from the application collection.