### PR TITLE
feat: add official opentelemetry collector releases

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -413,6 +413,27 @@ Images:
   - v0.8.8
   - v0.8.9
   - v0.9.0
+- SourceImage: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector
+  Tags:
+  - 0.129.1
+  TargetImageName: opentelemetry-collector
+- SourceImage: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib
+  Tags:
+  - 0.129.1
+  TargetImageName: opentelemetry-collector-contrib
+- SourceImage: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-k8s
+  Tags:
+  - 0.129.1
+  TargetImageName: opentelemetry-collector-k8s
+- SourceImage: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-opampsupervisor
+  Tags:
+  - 0.128.0
+  - 0.130.0
+  TargetImageName: opentelemetry-collector-opampsupervisor
+- SourceImage: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-otlp
+  Tags:
+  - 0.129.1
+  TargetImageName: opentelemetry-collector-otlp
 - SourceImage: ghcr.io/prometheus-community/windows-exporter
   Tags:
   - 0.25.1

--- a/regsync.yaml
+++ b/regsync.yaml
@@ -1323,6 +1323,42 @@ sync:
 - source: ghcr.io/kube-vip/kube-vip-iptables:v0.9.0
   target: registry.suse.com/rancher/mirrored-kube-vip-kube-vip-iptables:v0.9.0
   type: image
+- source: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:0.129.1
+  target: docker.io/rancher/opentelemetry-collector:0.129.1
+  type: image
+- source: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:0.129.1
+  target: registry.suse.com/rancher/opentelemetry-collector:0.129.1
+  type: image
+- source: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.129.1
+  target: docker.io/rancher/opentelemetry-collector-contrib:0.129.1
+  type: image
+- source: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.129.1
+  target: registry.suse.com/rancher/opentelemetry-collector-contrib:0.129.1
+  type: image
+- source: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-k8s:0.129.1
+  target: docker.io/rancher/opentelemetry-collector-k8s:0.129.1
+  type: image
+- source: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-k8s:0.129.1
+  target: registry.suse.com/rancher/opentelemetry-collector-k8s:0.129.1
+  type: image
+- source: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-opampsupervisor:0.128.0
+  target: docker.io/rancher/opentelemetry-collector-opampsupervisor:0.128.0
+  type: image
+- source: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-opampsupervisor:0.130.0
+  target: docker.io/rancher/opentelemetry-collector-opampsupervisor:0.130.0
+  type: image
+- source: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-opampsupervisor:0.128.0
+  target: registry.suse.com/rancher/opentelemetry-collector-opampsupervisor:0.128.0
+  type: image
+- source: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-opampsupervisor:0.130.0
+  target: registry.suse.com/rancher/opentelemetry-collector-opampsupervisor:0.130.0
+  type: image
+- source: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-otlp:0.129.1
+  target: docker.io/rancher/opentelemetry-collector-otlp:0.129.1
+  type: image
+- source: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-otlp:0.129.1
+  target: registry.suse.com/rancher/opentelemetry-collector-otlp:0.129.1
+  type: image
 - source: ghcr.io/prometheus-community/windows-exporter:0.25.1
   target: docker.io/rancher/mirrored-prometheus-windows-exporter:0.25.1
   type: image


### PR DESCRIPTION
#### Pull Request Checklist ####

- [ ] If an entire image is being added, a repo has been created for the image in DockerHub under the `rancher` org
- [ ] Additions are licensed with Rancher favored licenses - Apache 2 and MIT - or approved licenses - as according to [CNCF approved licenses](https://github.com/cncf/foundation/blob/main/allowed-third-party-license-policy.md).
- [ ] Additions, when used in Rancher or Rancher's provided charts, have their corresponding origin added in Rancher's images [origins](https://github.com/rancher/rancher/blob/release/v2.7/pkg/image/origins.go) file (must be added for all Rancher versions `>= v2.7`).
- [ ] Any changes to scripting or CI config have been tested to the best of your ability

#### Change Description ####

<!-- Describe what you are doing and why. Link any related issues, pull requests and commit hashes. -->

#### Final Checks after the PR is merged ####

- [ ] Confirm that you can pull the mirrored images and tags from all target locations
