### PR TITLE
Mirror dp.apps.rancher.io/containers/k8s-sidecar:1.30.7-11.3

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -90,6 +90,9 @@ Images:
   Tags:
   - v0.7.0
   - v0.8.3
+- SourceImage: dp.apps.rancher.io/containers/k8s-sidecar
+  Tags:
+  - 1.30.7-11.3
 - SourceImage: dp.apps.rancher.io/containers/redis
   Tags:
   - 8.0.3-2.1

--- a/regsync.yaml
+++ b/regsync.yaml
@@ -363,6 +363,12 @@ sync:
 - source: directxman12/k8s-prometheus-adapter-amd64:v0.8.3
   target: registry.suse.com/rancher/mirrored-directxman12-k8s-prometheus-adapter-amd64:v0.8.3
   type: image
+- source: dp.apps.rancher.io/containers/k8s-sidecar:1.30.7-11.3
+  target: docker.io/rancher/appco-k8s-sidecar:1.30.7-11.3
+  type: image
+- source: dp.apps.rancher.io/containers/k8s-sidecar:1.30.7-11.3
+  target: registry.suse.com/rancher/appco-k8s-sidecar:1.30.7-11.3
+  type: image
 - source: dp.apps.rancher.io/containers/redis:8.0.3-2.1
   target: docker.io/rancher/appco-redis:8.0.3-2.1
   type: image


### PR DESCRIPTION
#### Pull Request Checklist ####

- [x] If an entire image is being added, a repo has been created for the image in DockerHub under the `rancher` org
- [x] Additions are licensed with Rancher favored licenses - Apache 2 and MIT - or approved licenses - as according to [CNCF approved licenses](https://github.com/cncf/foundation/blob/main/allowed-third-party-license-policy.md).
- [x] Additions, when used in Rancher or Rancher's provided charts, have their corresponding origin added in Rancher's images [origins](https://github.com/rancher/rancher/blob/release/v2.7/pkg/image/origins.go) file (must be added for all Rancher versions `>= v2.7`).
- [x] Any changes to scripting or CI config have been tested to the best of your ability

#### Change Description ####

Request for EIO to create dockerhub repo: https://github.com/rancherlabs/eio/issues/3533

This is part of https://github.com/rancher/rancher/issues/51341.

#### Final Checks after the PR is merged ####

- [ ] Confirm that you can pull the mirrored images and tags from all target locations
