### PR TITLE
Add metrics-server v0.8.0

### DIFF
--- a/autoupdate.yaml
+++ b/autoupdate.yaml
@@ -164,6 +164,15 @@
   - rancher/k3s-networking
 - GithubRelease:
     Images:
+    - SourceImage: registry.k8s.io/metrics-server/metrics-server
+    LatestOnly: true
+    Owner: kubernetes-sigs
+    Repository: metrics-server
+  Name: metrics-server
+  Reviewers:
+  - rancher/k3s
+- GithubRelease:
+    Images:
     - SourceImage: idealista/prom2teams
     LatestOnly: true
     Owner: idealista

--- a/config.yaml
+++ b/config.yaml
@@ -2658,6 +2658,7 @@ Images:
   - v0.7.0
   - v0.7.1
   - v0.7.2
+  - v0.8.0
   TargetImageName: mirrored-metrics-server
 - SourceImage: registry.k8s.io/pause
   Tags:

--- a/regsync.yaml
+++ b/regsync.yaml
@@ -12303,6 +12303,9 @@ sync:
 - source: registry.k8s.io/metrics-server/metrics-server:v0.7.2
   target: docker.io/rancher/mirrored-metrics-server:v0.7.2
   type: image
+- source: registry.k8s.io/metrics-server/metrics-server:v0.8.0
+  target: docker.io/rancher/mirrored-metrics-server:v0.8.0
+  type: image
 - source: registry.k8s.io/metrics-server/metrics-server:v0.4.1
   target: registry.suse.com/rancher/mirrored-metrics-server:v0.4.1
   type: image
@@ -12338,6 +12341,9 @@ sync:
   type: image
 - source: registry.k8s.io/metrics-server/metrics-server:v0.7.2
   target: registry.suse.com/rancher/mirrored-metrics-server:v0.7.2
+  type: image
+- source: registry.k8s.io/metrics-server/metrics-server:v0.8.0
+  target: registry.suse.com/rancher/mirrored-metrics-server:v0.8.0
   type: image
 - source: registry.k8s.io/pause:3.10
   target: docker.io/rancher/mirrored-pause:3.10


### PR DESCRIPTION
#### Pull Request Checklist ####

- [x] If an entire image is being added, a repo has been created for the image in DockerHub under the `rancher` org
- [ ] Additions are licensed with Rancher favored licenses - Apache 2 and MIT - or approved licenses - as according to [CNCF approved licenses](https://github.com/cncf/foundation/blob/main/allowed-third-party-license-policy.md).
- [ ] Additions, when used in Rancher or Rancher's provided charts, have their corresponding origin added in Rancher's images [origins](https://github.com/rancher/rancher/blob/release/v2.7/pkg/image/origins.go) file (must be added for all Rancher versions `>= v2.7`).
- [ ] Any changes to scripting or CI config have been tested to the best of your ability

#### Change Description ####

<!-- Describe what you are doing and why. Link any related issues, pull requests and commit hashes. -->

#### Final Checks after the PR is merged ####

- [ ] Confirm that you can pull the mirrored images and tags from all target locations
