### PR TITLE
metrics-server: Add missing `TargetImageName` to autoupdate.yaml

### DIFF
--- a/autoupdate.yaml
+++ b/autoupdate.yaml
@@ -165,6 +165,7 @@
 - GithubRelease:
     Images:
     - SourceImage: registry.k8s.io/metrics-server/metrics-server
+      TargetImageName: mirrored-metrics-server
     LatestOnly: true
     Owner: kubernetes-sigs
     Repository: metrics-server


### PR DESCRIPTION
fixup for 52250a0648884e4ff08933b877ff0f7a482f17ff

resolves: https://github.com/rancher/image-mirror/pull/1059#discussion_r2261668302