### PR TITLE
Bump new kube-vip version v0.9.1. v0.9.2 v1.0.0

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -420,6 +420,9 @@ Images:
   - v0.8.8
   - v0.8.9
   - v0.9.0
+  - v0.9.1
+  - v0.9.2
+  - v1.0.0
 - SourceImage: ghcr.io/prometheus-community/windows-exporter
   Tags:
   - 0.25.1

--- a/regsync.yaml
+++ b/regsync.yaml
@@ -1961,6 +1961,15 @@ sync:
 - source: ghcr.io/kube-vip/kube-vip-iptables:v0.9.0
   target: docker.io/rancher/mirrored-kube-vip-kube-vip-iptables:v0.9.0
   type: image
+- source: ghcr.io/kube-vip/kube-vip-iptables:v0.9.1
+  target: docker.io/rancher/mirrored-kube-vip-kube-vip-iptables:v0.9.1
+  type: image
+- source: ghcr.io/kube-vip/kube-vip-iptables:v0.9.2
+  target: docker.io/rancher/mirrored-kube-vip-kube-vip-iptables:v0.9.2
+  type: image
+- source: ghcr.io/kube-vip/kube-vip-iptables:v1.0.0
+  target: docker.io/rancher/mirrored-kube-vip-kube-vip-iptables:v1.0.0
+  type: image
 - source: ghcr.io/kube-vip/kube-vip-iptables:v0.6.0
   target: registry.suse.com/rancher/mirrored-kube-vip-kube-vip-iptables:v0.6.0
   type: image
@@ -1985,6 +1994,15 @@ sync:
 - source: ghcr.io/kube-vip/kube-vip-iptables:v0.9.0
   target: registry.suse.com/rancher/mirrored-kube-vip-kube-vip-iptables:v0.9.0
   type: image
+- source: ghcr.io/kube-vip/kube-vip-iptables:v0.9.1
+  target: registry.suse.com/rancher/mirrored-kube-vip-kube-vip-iptables:v0.9.1
+  type: image
+- source: ghcr.io/kube-vip/kube-vip-iptables:v0.9.2
+  target: registry.suse.com/rancher/mirrored-kube-vip-kube-vip-iptables:v0.9.2
+  type: image
+- source: ghcr.io/kube-vip/kube-vip-iptables:v1.0.0
+  target: registry.suse.com/rancher/mirrored-kube-vip-kube-vip-iptables:v1.0.0
+  type: image
 - source: ghcr.io/kube-vip/kube-vip-iptables:v0.6.0
   target: stgregistry.suse.com/rancher/mirrored-kube-vip-kube-vip-iptables:v0.6.0
   type: image
@@ -2008,6 +2026,15 @@ sync:
   type: image
 - source: ghcr.io/kube-vip/kube-vip-iptables:v0.9.0
   target: stgregistry.suse.com/rancher/mirrored-kube-vip-kube-vip-iptables:v0.9.0
+  type: image
+- source: ghcr.io/kube-vip/kube-vip-iptables:v0.9.1
+  target: stgregistry.suse.com/rancher/mirrored-kube-vip-kube-vip-iptables:v0.9.1
+  type: image
+- source: ghcr.io/kube-vip/kube-vip-iptables:v0.9.2
+  target: stgregistry.suse.com/rancher/mirrored-kube-vip-kube-vip-iptables:v0.9.2
+  type: image
+- source: ghcr.io/kube-vip/kube-vip-iptables:v1.0.0
+  target: stgregistry.suse.com/rancher/mirrored-kube-vip-kube-vip-iptables:v1.0.0
   type: image
 - source: ghcr.io/prometheus-community/windows-exporter:0.25.1
   target: docker.io/rancher/mirrored-prometheus-windows-exporter:0.25.1


### PR DESCRIPTION
#### Pull Request Checklist ####

- [x] If an entire image is being added, a repo has been created for the image in DockerHub under the `rancher` org
- [x] Additions are licensed with Rancher favored licenses - Apache 2 and MIT - or approved licenses - as according to [CNCF approved licenses](https://github.com/cncf/foundation/blob/main/allowed-third-party-license-policy.md).
- [x] Additions, when used in Rancher or Rancher's provided charts, have their corresponding origin added in Rancher's images [origins](https://github.com/rancher/rancher/blob/release/v2.7/pkg/image/origins.go) file (must be added for all Rancher versions `>= v2.7`).
- [x] Any changes to scripting or CI config have been tested to the best of your ability


Harvester issue: https://github.com/harvester/harvester/issues/5670
PR: https://github.com/harvester/charts/pull/404

#### Change Description ####

<!-- Describe what you are doing and why. Link any related issues, pull requests and commit hashes. -->

To replace those pending/out-dated PRs:
https://github.com/rancher/image-mirror/pull/988
https://github.com/rancher/image-mirror/pull/1053
https://github.com/rancher/image-mirror/pull/976


#### Final Checks after the PR is merged ####

- [x] Confirm that you can pull the mirrored images and tags from all target locations

local test:
```
docker pull ghcr.io/kube-vip/kube-vip-iptables:v0.9.1
ghcr.io/kube-vip/kube-vip-iptables:v0.9.1:                                        resolved       |++++++++++++++++++++++++++++++++++++++| 
index-sha256:cfa7a20d1e35e2b9f72051e5616854611125d75c83809bc50f7847e00c8e0bb1:    exists         |++++++++++++++++++++++++++++++++++++++| 
manifest-sha256:a7dcdcd782d9c44b9817c1d5795c704ffb7e887e6c1c6a593163613a1d175956: exists         |++++++++++++++++++++++++++++++++++++++| 
config-sha256:8f38f31d3e786fe18260031f001f3ba695d9414abf1755477520f14a4eeb97b7:   exists         |++++++++++++++++++++++++++++++++++++++| 
elapsed: 0.8 s                                                                    total:   0.0 B (0.0 B/s)                                         
harv41:/home/rancher # docker pull ghcr.io/kube-vip/kube-vip-iptables:v0.9.2
ghcr.io/kube-vip/kube-vip-iptables:v0.9.2:                                        resolved       |++++++++++++++++++++++++++++++++++++++| 
index-sha256:ac836ebc3b4f99a4e7cf46e584b41b9708fdda3f71b490726b4098725eca48cd:    done           |++++++++++++++++++++++++++++++++++++++| 
manifest-sha256:c2d772d1092a1efec30b5b9a6eaf63f037c3a4da0b1d7acc9eae262685d197b7: done           |++++++++++++++++++++++++++++++++++++++| 
config-sha256:5cfd17d597882bc44a9f33007ae89c47489efd2edb266aff7deac84f0c75be40:   done           |++++++++++++++++++++++++++++++++++++++| 
layer-sha256:83a5ecb0cf8b9001b1228340b2d9c2080a5e2c5c3782ca793bb82d57d25107e7:    done           |++++++++++++++++++++++++++++++++++++++| 
layer-sha256:9a8d429f3dff4c5b776ec0bb4d265b2bb924dfd0aaa9f80676ce05d2564a9602:    done           |++++++++++++++++++++++++++++++++++++++| 
elapsed: 3.7 s                                                                    total:  19.6 M (5.3 MiB/s)                                       
harv41:/home/rancher # docker pull ghcr.io/kube-vip/kube-vip-iptables:v1.0.0
ghcr.io/kube-vip/kube-vip-iptables:v1.0.0:                                        resolved       |++++++++++++++++++++++++++++++++++++++| 
index-sha256:2ab08a3645ce5d9bc17b5ae7ca2fd7da3eda01da17731fb9e50b83ff2af366dc:    done           |++++++++++++++++++++++++++++++++++++++| 
manifest-sha256:9177462cfe397b310d114676db83be48eb16eb96d8d1ea7bbbc4888e2c64dadd: done           |++++++++++++++++++++++++++++++++++++++| 
config-sha256:8909f3d36044965d8853a24f02d99c9bb62a82cbb36cebf0f8421cd5261e7a4c:   done           |++++++++++++++++++++++++++++++++++++++| 
layer-sha256:8d5bc70153a0e25d613a85c7e0738cfe282a56d6a886d5404896dd641e45748a:    done           |++++++++++++++++++++++++++++++++++++++| 
layer-sha256:9824c27679d3b27c5e1cb00a73adb6f4f8d556994111c12db3c5d61a0c843df8:    done           |++++++++++++++++++++++++++++++++++++++| 
layer-sha256:9799d29e292beadcdcfde365bf6439b0afb3c5f2cde54a2dd4bb283f954f36aa:    done           |++++++++++++++++++++++++++++++++++++++| 
elapsed: 2.8 s                                                                    total:  20.9 M (7.5 MiB/s)       
```