### PR TITLE
Do not mirror `ghcr.io/epinio/epinio-unpacker:1.0`

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -384,7 +384,9 @@ Images:
   - v1.5.1-0.0.3
   - v1.8.1-0.0.1
   - v1.9.0-0.0.3
-- SourceImage: ghcr.io/epinio/epinio-unpacker
+- DoNotMirror:
+  - "1.0"
+  SourceImage: ghcr.io/epinio/epinio-unpacker
   Tags:
   - "1.0"
   - v1.10.0

--- a/regsync.yaml
+++ b/regsync.yaml
@@ -1793,9 +1793,6 @@ sync:
 - source: ghcr.io/epinio/epinio-ui:v1.9.0-0.0.3
   target: stgregistry.suse.com/rancher/mirrored-epinio-epinio-ui:v1.9.0-0.0.3
   type: image
-- source: ghcr.io/epinio/epinio-unpacker:1.0
-  target: docker.io/rancher/mirrored-epinio-epinio-unpacker:1.0
-  type: image
 - source: ghcr.io/epinio/epinio-unpacker:v1.10.0
   target: docker.io/rancher/mirrored-epinio-epinio-unpacker:v1.10.0
   type: image
@@ -1811,9 +1808,6 @@ sync:
 - source: ghcr.io/epinio/epinio-unpacker:v1.9.0
   target: docker.io/rancher/mirrored-epinio-epinio-unpacker:v1.9.0
   type: image
-- source: ghcr.io/epinio/epinio-unpacker:1.0
-  target: registry.suse.com/rancher/mirrored-epinio-epinio-unpacker:1.0
-  type: image
 - source: ghcr.io/epinio/epinio-unpacker:v1.10.0
   target: registry.suse.com/rancher/mirrored-epinio-epinio-unpacker:v1.10.0
   type: image
@@ -1828,9 +1822,6 @@ sync:
   type: image
 - source: ghcr.io/epinio/epinio-unpacker:v1.9.0
   target: registry.suse.com/rancher/mirrored-epinio-epinio-unpacker:v1.9.0
-  type: image
-- source: ghcr.io/epinio/epinio-unpacker:1.0
-  target: stgregistry.suse.com/rancher/mirrored-epinio-epinio-unpacker:1.0
   type: image
 - source: ghcr.io/epinio/epinio-unpacker:v1.10.0
   target: stgregistry.suse.com/rancher/mirrored-epinio-epinio-unpacker:v1.10.0


### PR DESCRIPTION
The image mirroring workflow is breaking: https://github.com/rancher/image-mirror/actions/runs/17300557776/job/49110255071

I believe the culprit is `ghcr.io/epinio/epinio-unpacker:1.0`. This PR prevents image-mirror from mirroring it.