### PR TITLE
Add cilium-certgen v0.2.4 and autoupdate configuration

### DIFF
--- a/autoupdate.yaml
+++ b/autoupdate.yaml
@@ -50,6 +50,7 @@
     - ghcr.io/spiffe/spire-agent
     - ghcr.io/spiffe/spire-server
     Images:
+    - SourceImage: quay.io/cilium/certgen
     - SourceImage: quay.io/cilium/cilium
     - SourceImage: quay.io/cilium/cilium-envoy
     - SourceImage: quay.io/cilium/operator-generic

--- a/config.yaml
+++ b/config.yaml
@@ -1929,6 +1929,7 @@ Images:
   - v0.1.9
   - v0.2.0
   - v0.2.1
+  - v0.2.4
 - SourceImage: quay.io/cilium/cilium
   Tags:
   - v1.10.4

--- a/regsync.yaml
+++ b/regsync.yaml
@@ -13271,6 +13271,9 @@ sync:
 - source: quay.io/cilium/certgen:v0.2.1
   target: docker.io/rancher/mirrored-cilium-certgen:v0.2.1
   type: image
+- source: quay.io/cilium/certgen:v0.2.4
+  target: docker.io/rancher/mirrored-cilium-certgen:v0.2.4
+  type: image
 - source: quay.io/cilium/certgen:v0.1.11
   target: registry.suse.com/rancher/mirrored-cilium-certgen:v0.1.11
   type: image
@@ -13292,6 +13295,9 @@ sync:
 - source: quay.io/cilium/certgen:v0.2.1
   target: registry.suse.com/rancher/mirrored-cilium-certgen:v0.2.1
   type: image
+- source: quay.io/cilium/certgen:v0.2.4
+  target: registry.suse.com/rancher/mirrored-cilium-certgen:v0.2.4
+  type: image
 - source: quay.io/cilium/certgen:v0.1.11
   target: stgregistry.suse.com/rancher/mirrored-cilium-certgen:v0.1.11
   type: image
@@ -13312,6 +13318,9 @@ sync:
   type: image
 - source: quay.io/cilium/certgen:v0.2.1
   target: stgregistry.suse.com/rancher/mirrored-cilium-certgen:v0.2.1
+  type: image
+- source: quay.io/cilium/certgen:v0.2.4
+  target: stgregistry.suse.com/rancher/mirrored-cilium-certgen:v0.2.4
   type: image
 - source: quay.io/cilium/cilium:v1.10.4
   target: docker.io/rancher/mirrored-cilium-cilium:v1.10.4


### PR DESCRIPTION
#### Pull Request Checklist ####

- [ ] If an entire image is being added, a repo has been created for the image in DockerHub under the `rancher` org
- [ ] Additions are licensed with Rancher favored licenses - Apache 2 and MIT - or approved licenses - as according to [CNCF approved licenses](https://github.com/cncf/foundation/blob/main/allowed-third-party-license-policy.md).
- [ ] Additions, when used in Rancher or Rancher's provided charts, have their corresponding origin added in Rancher's images [origins](https://github.com/rancher/rancher/blob/release/v2.7/pkg/image/origins.go) file (must be added for all Rancher versions `>= v2.7`).
- [ ] Any changes to scripting or CI config have been tested to the best of your ability

#### Change Description ####

<!-- Describe what you are doing and why. Link any related issues, pull requests and commit hashes. -->

#### Final Checks after the PR is merged ####

- [ ] Confirm that you can pull the mirrored images and tags from all target locations
