### PR TITLE
[K8s-1.34]Added Capi v1.11.1

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -2602,6 +2602,7 @@ Images:
 - SourceImage: registry.k8s.io/cluster-api/cluster-api-controller
   Tags:
   - v1.10.2
+  - v1.11.1
   - v1.4.4
   - v1.5.5
   - v1.6.4

--- a/regsync.yaml
+++ b/regsync.yaml
@@ -18185,6 +18185,9 @@ sync:
 - source: registry.k8s.io/cluster-api/cluster-api-controller:v1.10.2
   target: docker.io/rancher/mirrored-cluster-api-controller:v1.10.2
   type: image
+- source: registry.k8s.io/cluster-api/cluster-api-controller:v1.11.1
+  target: docker.io/rancher/mirrored-cluster-api-controller:v1.11.1
+  type: image
 - source: registry.k8s.io/cluster-api/cluster-api-controller:v1.4.4
   target: docker.io/rancher/mirrored-cluster-api-controller:v1.4.4
   type: image
@@ -18212,6 +18215,9 @@ sync:
 - source: registry.k8s.io/cluster-api/cluster-api-controller:v1.10.2
   target: registry.suse.com/rancher/mirrored-cluster-api-controller:v1.10.2
   type: image
+- source: registry.k8s.io/cluster-api/cluster-api-controller:v1.11.1
+  target: registry.suse.com/rancher/mirrored-cluster-api-controller:v1.11.1
+  type: image
 - source: registry.k8s.io/cluster-api/cluster-api-controller:v1.4.4
   target: registry.suse.com/rancher/mirrored-cluster-api-controller:v1.4.4
   type: image
@@ -18238,6 +18244,9 @@ sync:
   type: image
 - source: registry.k8s.io/cluster-api/cluster-api-controller:v1.10.2
   target: stgregistry.suse.com/rancher/mirrored-cluster-api-controller:v1.10.2
+  type: image
+- source: registry.k8s.io/cluster-api/cluster-api-controller:v1.11.1
+  target: stgregistry.suse.com/rancher/mirrored-cluster-api-controller:v1.11.1
   type: image
 - source: registry.k8s.io/cluster-api/cluster-api-controller:v1.4.4
   target: stgregistry.suse.com/rancher/mirrored-cluster-api-controller:v1.4.4


### PR DESCRIPTION
#### Pull Request Checklist ####

- [x] If an entire image is being added, a repo has been created for the image in DockerHub under the `rancher` org
- [x] Additions are licensed with Rancher favored licenses - Apache 2 and MIT - or approved licenses - as according to [CNCF approved licenses](https://github.com/cncf/foundation/blob/main/allowed-third-party-license-policy.md).
- [x] Additions, when used in Rancher or Rancher's provided charts, have their corresponding origin added in Rancher's images [origins](https://github.com/rancher/rancher/blob/release/v2.7/pkg/image/origins.go) file (must be added for all Rancher versions `>= v2.7`).
- [x] Any changes to scripting or CI config have been tested to the best of your ability

#### Change Description ####

<!-- Describe what you are doing and why. Link any related issues, pull requests and commit hashes. -->

#### Final Checks after the PR is merged ####

- [x] Confirm that you can pull the mirrored images and tags from all target locations
