### PR TITLE
bump prometheus-operator to 0.79.2

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -2428,6 +2428,7 @@ Images:
   - v0.75.1
   - v0.77.2
   - v0.79.0
+  - v0.79.2
   - v0.80.1
 - SourceImage: quay.io/prometheus-operator/prometheus-operator
   Tags:
@@ -2445,6 +2446,7 @@ Images:
   - v0.75.1
   - v0.77.2
   - v0.79.0
+  - v0.79.2
   - v0.80.1
 - SourceImage: quay.io/prometheus/alertmanager
   Tags:

--- a/regsync.yaml
+++ b/regsync.yaml
@@ -17006,6 +17006,9 @@ sync:
 - source: quay.io/prometheus-operator/prometheus-config-reloader:v0.79.0
   target: docker.io/rancher/mirrored-prometheus-operator-prometheus-config-reloader:v0.79.0
   type: image
+- source: quay.io/prometheus-operator/prometheus-config-reloader:v0.79.2
+  target: docker.io/rancher/mirrored-prometheus-operator-prometheus-config-reloader:v0.79.2
+  type: image
 - source: quay.io/prometheus-operator/prometheus-config-reloader:v0.80.1
   target: docker.io/rancher/mirrored-prometheus-operator-prometheus-config-reloader:v0.80.1
   type: image
@@ -17039,6 +17042,9 @@ sync:
 - source: quay.io/prometheus-operator/prometheus-config-reloader:v0.79.0
   target: registry.suse.com/rancher/mirrored-prometheus-operator-prometheus-config-reloader:v0.79.0
   type: image
+- source: quay.io/prometheus-operator/prometheus-config-reloader:v0.79.2
+  target: registry.suse.com/rancher/mirrored-prometheus-operator-prometheus-config-reloader:v0.79.2
+  type: image
 - source: quay.io/prometheus-operator/prometheus-config-reloader:v0.80.1
   target: registry.suse.com/rancher/mirrored-prometheus-operator-prometheus-config-reloader:v0.80.1
   type: image
@@ -17071,6 +17077,9 @@ sync:
   type: image
 - source: quay.io/prometheus-operator/prometheus-config-reloader:v0.79.0
   target: stgregistry.suse.com/rancher/mirrored-prometheus-operator-prometheus-config-reloader:v0.79.0
+  type: image
+- source: quay.io/prometheus-operator/prometheus-config-reloader:v0.79.2
+  target: stgregistry.suse.com/rancher/mirrored-prometheus-operator-prometheus-config-reloader:v0.79.2
   type: image
 - source: quay.io/prometheus-operator/prometheus-config-reloader:v0.80.1
   target: stgregistry.suse.com/rancher/mirrored-prometheus-operator-prometheus-config-reloader:v0.80.1
@@ -17114,6 +17123,9 @@ sync:
 - source: quay.io/prometheus-operator/prometheus-operator:v0.79.0
   target: docker.io/rancher/mirrored-prometheus-operator-prometheus-operator:v0.79.0
   type: image
+- source: quay.io/prometheus-operator/prometheus-operator:v0.79.2
+  target: docker.io/rancher/mirrored-prometheus-operator-prometheus-operator:v0.79.2
+  type: image
 - source: quay.io/prometheus-operator/prometheus-operator:v0.80.1
   target: docker.io/rancher/mirrored-prometheus-operator-prometheus-operator:v0.80.1
   type: image
@@ -17147,6 +17159,9 @@ sync:
 - source: quay.io/prometheus-operator/prometheus-operator:v0.79.0
   target: registry.suse.com/rancher/mirrored-prometheus-operator-prometheus-operator:v0.79.0
   type: image
+- source: quay.io/prometheus-operator/prometheus-operator:v0.79.2
+  target: registry.suse.com/rancher/mirrored-prometheus-operator-prometheus-operator:v0.79.2
+  type: image
 - source: quay.io/prometheus-operator/prometheus-operator:v0.80.1
   target: registry.suse.com/rancher/mirrored-prometheus-operator-prometheus-operator:v0.80.1
   type: image
@@ -17179,6 +17194,9 @@ sync:
   type: image
 - source: quay.io/prometheus-operator/prometheus-operator:v0.79.0
   target: stgregistry.suse.com/rancher/mirrored-prometheus-operator-prometheus-operator:v0.79.0
+  type: image
+- source: quay.io/prometheus-operator/prometheus-operator:v0.79.2
+  target: stgregistry.suse.com/rancher/mirrored-prometheus-operator-prometheus-operator:v0.79.2
   type: image
 - source: quay.io/prometheus-operator/prometheus-operator:v0.80.1
   target: stgregistry.suse.com/rancher/mirrored-prometheus-operator-prometheus-operator:v0.80.1


### PR DESCRIPTION
#### Pull Request Checklist ####

- [ ] If an entire image is being added, a repo has been created for the image in DockerHub under the `rancher` org
- [ ] Additions are licensed with Rancher favored licenses - Apache 2 and MIT - or approved licenses - as according to [CNCF approved licenses](https://github.com/cncf/foundation/blob/main/allowed-third-party-license-policy.md).
- [ ] Additions, when used in Rancher or Rancher's provided charts, have their corresponding origin added in Rancher's images [origins](https://github.com/rancher/rancher/blob/release/v2.7/pkg/image/origins.go) file (must be added for all Rancher versions `>= v2.7`).
- [ ] Any changes to scripting or CI config have been tested to the best of your ability

#### Change Description ####

<!-- Describe what you are doing and why. Link any related issues, pull requests and commit hashes. -->
Fixes# https://github.com/rancher/image-mirror/issues/1097

#### Final Checks after the PR is merged ####

- [ ] Confirm that you can pull the mirrored images and tags from all target locations
