### PR TITLE
Add calico envoy ratelimit image

### DIFF
--- a/autoupdate.yaml
+++ b/autoupdate.yaml
@@ -6,6 +6,7 @@
     - SourceImage: quay.io/calico/ctl
     - SourceImage: quay.io/calico/envoy-gateway
     - SourceImage: quay.io/calico/envoy-proxy
+    - SourceImage: quay.io/calico/envoy-ratelimit
     - SourceImage: quay.io/calico/goldmane
     - SourceImage: quay.io/calico/kube-controllers
     - SourceImage: quay.io/calico/node

--- a/config.yaml
+++ b/config.yaml
@@ -1697,6 +1697,12 @@ Images:
   - v3.30.1
   - v3.30.2
   - v3.30.3
+- SourceImage: quay.io/calico/envoy-ratelimit
+  Tags:
+  - v3.30.0
+  - v3.30.1
+  - v3.30.2
+  - v3.30.3
 - SourceImage: quay.io/calico/goldmane
   Tags:
   - v3.30.0

--- a/regsync.yaml
+++ b/regsync.yaml
@@ -11450,6 +11450,42 @@ sync:
 - source: quay.io/calico/envoy-proxy:v3.30.3
   target: stgregistry.suse.com/rancher/mirrored-calico-envoy-proxy:v3.30.3
   type: image
+- source: quay.io/calico/envoy-ratelimit:v3.30.0
+  target: docker.io/rancher/mirrored-calico-envoy-ratelimit:v3.30.0
+  type: image
+- source: quay.io/calico/envoy-ratelimit:v3.30.1
+  target: docker.io/rancher/mirrored-calico-envoy-ratelimit:v3.30.1
+  type: image
+- source: quay.io/calico/envoy-ratelimit:v3.30.2
+  target: docker.io/rancher/mirrored-calico-envoy-ratelimit:v3.30.2
+  type: image
+- source: quay.io/calico/envoy-ratelimit:v3.30.3
+  target: docker.io/rancher/mirrored-calico-envoy-ratelimit:v3.30.3
+  type: image
+- source: quay.io/calico/envoy-ratelimit:v3.30.0
+  target: registry.suse.com/rancher/mirrored-calico-envoy-ratelimit:v3.30.0
+  type: image
+- source: quay.io/calico/envoy-ratelimit:v3.30.1
+  target: registry.suse.com/rancher/mirrored-calico-envoy-ratelimit:v3.30.1
+  type: image
+- source: quay.io/calico/envoy-ratelimit:v3.30.2
+  target: registry.suse.com/rancher/mirrored-calico-envoy-ratelimit:v3.30.2
+  type: image
+- source: quay.io/calico/envoy-ratelimit:v3.30.3
+  target: registry.suse.com/rancher/mirrored-calico-envoy-ratelimit:v3.30.3
+  type: image
+- source: quay.io/calico/envoy-ratelimit:v3.30.0
+  target: stgregistry.suse.com/rancher/mirrored-calico-envoy-ratelimit:v3.30.0
+  type: image
+- source: quay.io/calico/envoy-ratelimit:v3.30.1
+  target: stgregistry.suse.com/rancher/mirrored-calico-envoy-ratelimit:v3.30.1
+  type: image
+- source: quay.io/calico/envoy-ratelimit:v3.30.2
+  target: stgregistry.suse.com/rancher/mirrored-calico-envoy-ratelimit:v3.30.2
+  type: image
+- source: quay.io/calico/envoy-ratelimit:v3.30.3
+  target: stgregistry.suse.com/rancher/mirrored-calico-envoy-ratelimit:v3.30.3
+  type: image
 - source: quay.io/calico/goldmane:v3.30.0
   target: docker.io/rancher/mirrored-calico-goldmane:v3.30.0
   type: image


### PR DESCRIPTION
#### Pull Request Checklist ####

- [x] If an entire image is being added, a repo has been created for the image in DockerHub under the `rancher` org
- [X] Additions are licensed with Rancher favored licenses - Apache 2 and MIT - or approved licenses - as according to [CNCF approved licenses](https://github.com/cncf/foundation/blob/main/allowed-third-party-license-policy.md).
- [X] Additions, when used in Rancher or Rancher's provided charts, have their corresponding origin added in Rancher's images [origins](https://github.com/rancher/rancher/blob/release/v2.7/pkg/image/origins.go) file (must be added for all Rancher versions `>= v2.7`).
- [X] Any changes to scripting or CI config have been tested to the best of your ability

#### Change Description ####

Add calico envoy ratelimit image
Issue: https://github.com/rancher/rke2/issues/8979

#### Final Checks after the PR is merged ####

- [ ] Confirm that you can pull the mirrored images and tags from all target locations
