### PR TITLE
feat: add Longhorn 1.9.2 images

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -893,6 +893,7 @@ Images:
   - v1.8.1
   - v1.8.2
   - v1.9.1
+  - v1.9.2
   - v1_20210422
   - v1_20210422_patch1
   - v2_20210820
@@ -1033,6 +1034,7 @@ Images:
   - v1.8.1
   - v1.8.2
   - v1.9.1
+  - v1.9.2
 - SourceImage: longhornio/longhorn-engine
   Tags:
   - v1.0.2
@@ -1089,6 +1091,7 @@ Images:
   - v1.8.1
   - v1.8.2
   - v1.9.1
+  - v1.9.2
 - SourceImage: longhornio/longhorn-instance-manager
   Tags:
   - v1_20200514
@@ -1126,6 +1129,7 @@ Images:
   - v1.8.1
   - v1.8.2
   - v1.9.1
+  - v1.9.2
   - v1_20201216
   - v1_20210621
   - v1_20210731
@@ -1193,6 +1197,7 @@ Images:
   - v1.8.1
   - v1.8.2
   - v1.9.1
+  - v1.9.2
 - SourceImage: longhornio/longhorn-share-manager
   Tags:
   - v1_20201204
@@ -1230,6 +1235,7 @@ Images:
   - v1.8.1
   - v1.8.2
   - v1.9.1
+  - v1.9.2
   - v1_20201204
   - v1_20210416
   - v1_20210416_patch1
@@ -1298,6 +1304,7 @@ Images:
   - v1.8.1
   - v1.8.2
   - v1.9.1
+  - v1.9.2
 - SourceImage: longhornio/openshift-origin-oauth-proxy
   Tags:
   - "4.14"
@@ -1322,6 +1329,7 @@ Images:
   - v0.0.52
   - v0.0.56
   - v0.0.61
+  - v0.0.69
 - SourceImage: messagebird/sachet
   Tags:
   - 0.2.3

--- a/regsync.yaml
+++ b/regsync.yaml
@@ -5210,6 +5210,9 @@ sync:
 - source: longhornio/backing-image-manager:v1.9.1
   target: docker.io/rancher/mirrored-longhornio-backing-image-manager:v1.9.1
   type: image
+- source: longhornio/backing-image-manager:v1.9.2
+  target: docker.io/rancher/mirrored-longhornio-backing-image-manager:v1.9.2
+  type: image
 - source: longhornio/backing-image-manager:v1_20210422
   target: docker.io/rancher/mirrored-longhornio-backing-image-manager:v1_20210422
   type: image
@@ -5306,6 +5309,9 @@ sync:
 - source: longhornio/backing-image-manager:v1.9.1
   target: registry.suse.com/rancher/mirrored-longhornio-backing-image-manager:v1.9.1
   type: image
+- source: longhornio/backing-image-manager:v1.9.2
+  target: registry.suse.com/rancher/mirrored-longhornio-backing-image-manager:v1.9.2
+  type: image
 - source: longhornio/backing-image-manager:v1_20210422
   target: registry.suse.com/rancher/mirrored-longhornio-backing-image-manager:v1_20210422
   type: image
@@ -5401,6 +5407,9 @@ sync:
   type: image
 - source: longhornio/backing-image-manager:v1.9.1
   target: stgregistry.suse.com/rancher/mirrored-longhornio-backing-image-manager:v1.9.1
+  type: image
+- source: longhornio/backing-image-manager:v1.9.2
+  target: stgregistry.suse.com/rancher/mirrored-longhornio-backing-image-manager:v1.9.2
   type: image
 - source: longhornio/backing-image-manager:v1_20210422
   target: stgregistry.suse.com/rancher/mirrored-longhornio-backing-image-manager:v1_20210422
@@ -6305,6 +6314,9 @@ sync:
 - source: longhornio/longhorn-cli:v1.9.1
   target: docker.io/rancher/mirrored-longhornio-longhorn-cli:v1.9.1
   type: image
+- source: longhornio/longhorn-cli:v1.9.2
+  target: docker.io/rancher/mirrored-longhornio-longhorn-cli:v1.9.2
+  type: image
 - source: longhornio/longhorn-cli:v1.7.0
   target: registry.suse.com/rancher/mirrored-longhornio-longhorn-cli:v1.7.0
   type: image
@@ -6326,6 +6338,9 @@ sync:
 - source: longhornio/longhorn-cli:v1.9.1
   target: registry.suse.com/rancher/mirrored-longhornio-longhorn-cli:v1.9.1
   type: image
+- source: longhornio/longhorn-cli:v1.9.2
+  target: registry.suse.com/rancher/mirrored-longhornio-longhorn-cli:v1.9.2
+  type: image
 - source: longhornio/longhorn-cli:v1.7.0
   target: stgregistry.suse.com/rancher/mirrored-longhornio-longhorn-cli:v1.7.0
   type: image
@@ -6346,6 +6361,9 @@ sync:
   type: image
 - source: longhornio/longhorn-cli:v1.9.1
   target: stgregistry.suse.com/rancher/mirrored-longhornio-longhorn-cli:v1.9.1
+  type: image
+- source: longhornio/longhorn-cli:v1.9.2
+  target: stgregistry.suse.com/rancher/mirrored-longhornio-longhorn-cli:v1.9.2
   type: image
 - source: longhornio/longhorn-engine:v1.0.2
   target: docker.io/rancher/longhornio-longhorn-engine:v1.0.2
@@ -6578,6 +6596,9 @@ sync:
 - source: longhornio/longhorn-engine:v1.9.1
   target: docker.io/rancher/mirrored-longhornio-longhorn-engine:v1.9.1
   type: image
+- source: longhornio/longhorn-engine:v1.9.2
+  target: docker.io/rancher/mirrored-longhornio-longhorn-engine:v1.9.2
+  type: image
 - source: longhornio/longhorn-engine:v1.1.0
   target: registry.suse.com/rancher/mirrored-longhornio-longhorn-engine:v1.1.0
   type: image
@@ -6692,6 +6713,9 @@ sync:
 - source: longhornio/longhorn-engine:v1.9.1
   target: registry.suse.com/rancher/mirrored-longhornio-longhorn-engine:v1.9.1
   type: image
+- source: longhornio/longhorn-engine:v1.9.2
+  target: registry.suse.com/rancher/mirrored-longhornio-longhorn-engine:v1.9.2
+  type: image
 - source: longhornio/longhorn-engine:v1.1.0
   target: stgregistry.suse.com/rancher/mirrored-longhornio-longhorn-engine:v1.1.0
   type: image
@@ -6805,6 +6829,9 @@ sync:
   type: image
 - source: longhornio/longhorn-engine:v1.9.1
   target: stgregistry.suse.com/rancher/mirrored-longhornio-longhorn-engine:v1.9.1
+  type: image
+- source: longhornio/longhorn-engine:v1.9.2
+  target: stgregistry.suse.com/rancher/mirrored-longhornio-longhorn-engine:v1.9.2
   type: image
 - source: longhornio/longhorn-instance-manager:v1_20200514
   target: docker.io/rancher/longhornio-longhorn-instance-manager:v1_20200514
@@ -6956,6 +6983,9 @@ sync:
 - source: longhornio/longhorn-instance-manager:v1.9.1
   target: docker.io/rancher/mirrored-longhornio-longhorn-instance-manager:v1.9.1
   type: image
+- source: longhornio/longhorn-instance-manager:v1.9.2
+  target: docker.io/rancher/mirrored-longhornio-longhorn-instance-manager:v1.9.2
+  type: image
 - source: longhornio/longhorn-instance-manager:v1_20201216
   target: docker.io/rancher/mirrored-longhornio-longhorn-instance-manager:v1_20201216
   type: image
@@ -7058,6 +7088,9 @@ sync:
 - source: longhornio/longhorn-instance-manager:v1.9.1
   target: registry.suse.com/rancher/mirrored-longhornio-longhorn-instance-manager:v1.9.1
   type: image
+- source: longhornio/longhorn-instance-manager:v1.9.2
+  target: registry.suse.com/rancher/mirrored-longhornio-longhorn-instance-manager:v1.9.2
+  type: image
 - source: longhornio/longhorn-instance-manager:v1_20201216
   target: registry.suse.com/rancher/mirrored-longhornio-longhorn-instance-manager:v1_20201216
   type: image
@@ -7159,6 +7192,9 @@ sync:
   type: image
 - source: longhornio/longhorn-instance-manager:v1.9.1
   target: stgregistry.suse.com/rancher/mirrored-longhornio-longhorn-instance-manager:v1.9.1
+  type: image
+- source: longhornio/longhorn-instance-manager:v1.9.2
+  target: stgregistry.suse.com/rancher/mirrored-longhornio-longhorn-instance-manager:v1.9.2
   type: image
 - source: longhornio/longhorn-instance-manager:v1_20201216
   target: stgregistry.suse.com/rancher/mirrored-longhornio-longhorn-instance-manager:v1_20201216
@@ -7424,6 +7460,9 @@ sync:
 - source: longhornio/longhorn-manager:v1.9.1
   target: docker.io/rancher/mirrored-longhornio-longhorn-manager:v1.9.1
   type: image
+- source: longhornio/longhorn-manager:v1.9.2
+  target: docker.io/rancher/mirrored-longhornio-longhorn-manager:v1.9.2
+  type: image
 - source: longhornio/longhorn-manager:v1.1.0
   target: registry.suse.com/rancher/mirrored-longhornio-longhorn-manager:v1.1.0
   type: image
@@ -7538,6 +7577,9 @@ sync:
 - source: longhornio/longhorn-manager:v1.9.1
   target: registry.suse.com/rancher/mirrored-longhornio-longhorn-manager:v1.9.1
   type: image
+- source: longhornio/longhorn-manager:v1.9.2
+  target: registry.suse.com/rancher/mirrored-longhornio-longhorn-manager:v1.9.2
+  type: image
 - source: longhornio/longhorn-manager:v1.1.0
   target: stgregistry.suse.com/rancher/mirrored-longhornio-longhorn-manager:v1.1.0
   type: image
@@ -7651,6 +7693,9 @@ sync:
   type: image
 - source: longhornio/longhorn-manager:v1.9.1
   target: stgregistry.suse.com/rancher/mirrored-longhornio-longhorn-manager:v1.9.1
+  type: image
+- source: longhornio/longhorn-manager:v1.9.2
+  target: stgregistry.suse.com/rancher/mirrored-longhornio-longhorn-manager:v1.9.2
   type: image
 - source: longhornio/longhorn-share-manager:v1_20201204
   target: docker.io/rancher/longhornio-longhorn-share-manager:v1_20201204
@@ -7802,6 +7847,9 @@ sync:
 - source: longhornio/longhorn-share-manager:v1.9.1
   target: docker.io/rancher/mirrored-longhornio-longhorn-share-manager:v1.9.1
   type: image
+- source: longhornio/longhorn-share-manager:v1.9.2
+  target: docker.io/rancher/mirrored-longhornio-longhorn-share-manager:v1.9.2
+  type: image
 - source: longhornio/longhorn-share-manager:v1_20201204
   target: docker.io/rancher/mirrored-longhornio-longhorn-share-manager:v1_20201204
   type: image
@@ -7907,6 +7955,9 @@ sync:
 - source: longhornio/longhorn-share-manager:v1.9.1
   target: registry.suse.com/rancher/mirrored-longhornio-longhorn-share-manager:v1.9.1
   type: image
+- source: longhornio/longhorn-share-manager:v1.9.2
+  target: registry.suse.com/rancher/mirrored-longhornio-longhorn-share-manager:v1.9.2
+  type: image
 - source: longhornio/longhorn-share-manager:v1_20201204
   target: registry.suse.com/rancher/mirrored-longhornio-longhorn-share-manager:v1_20201204
   type: image
@@ -8011,6 +8062,9 @@ sync:
   type: image
 - source: longhornio/longhorn-share-manager:v1.9.1
   target: stgregistry.suse.com/rancher/mirrored-longhornio-longhorn-share-manager:v1.9.1
+  type: image
+- source: longhornio/longhorn-share-manager:v1.9.2
+  target: stgregistry.suse.com/rancher/mirrored-longhornio-longhorn-share-manager:v1.9.2
   type: image
 - source: longhornio/longhorn-share-manager:v1_20201204
   target: stgregistry.suse.com/rancher/mirrored-longhornio-longhorn-share-manager:v1_20201204
@@ -8279,6 +8333,9 @@ sync:
 - source: longhornio/longhorn-ui:v1.9.1
   target: docker.io/rancher/mirrored-longhornio-longhorn-ui:v1.9.1
   type: image
+- source: longhornio/longhorn-ui:v1.9.2
+  target: docker.io/rancher/mirrored-longhornio-longhorn-ui:v1.9.2
+  type: image
 - source: longhornio/longhorn-ui:v1.1.0
   target: registry.suse.com/rancher/mirrored-longhornio-longhorn-ui:v1.1.0
   type: image
@@ -8392,6 +8449,9 @@ sync:
   type: image
 - source: longhornio/longhorn-ui:v1.9.1
   target: registry.suse.com/rancher/mirrored-longhornio-longhorn-ui:v1.9.1
+  type: image
+- source: longhornio/longhorn-ui:v1.9.2
+  target: registry.suse.com/rancher/mirrored-longhornio-longhorn-ui:v1.9.2
   type: image
 - source: longhornio/longhorn-ui:v1.1.0
   target: stgregistry.suse.com/rancher/mirrored-longhornio-longhorn-ui:v1.1.0
@@ -8507,6 +8567,9 @@ sync:
 - source: longhornio/longhorn-ui:v1.9.1
   target: stgregistry.suse.com/rancher/mirrored-longhornio-longhorn-ui:v1.9.1
   type: image
+- source: longhornio/longhorn-ui:v1.9.2
+  target: stgregistry.suse.com/rancher/mirrored-longhornio-longhorn-ui:v1.9.2
+  type: image
 - source: longhornio/openshift-origin-oauth-proxy:4.14
   target: docker.io/rancher/mirrored-longhornio-openshift-origin-oauth-proxy:4.14
   type: image
@@ -8579,6 +8642,9 @@ sync:
 - source: longhornio/support-bundle-kit:v0.0.61
   target: docker.io/rancher/mirrored-longhornio-support-bundle-kit:v0.0.61
   type: image
+- source: longhornio/support-bundle-kit:v0.0.69
+  target: docker.io/rancher/mirrored-longhornio-support-bundle-kit:v0.0.69
+  type: image
 - source: longhornio/support-bundle-kit:v0.0.17
   target: registry.suse.com/rancher/mirrored-longhornio-support-bundle-kit:v0.0.17
   type: image
@@ -8633,6 +8699,9 @@ sync:
 - source: longhornio/support-bundle-kit:v0.0.61
   target: registry.suse.com/rancher/mirrored-longhornio-support-bundle-kit:v0.0.61
   type: image
+- source: longhornio/support-bundle-kit:v0.0.69
+  target: registry.suse.com/rancher/mirrored-longhornio-support-bundle-kit:v0.0.69
+  type: image
 - source: longhornio/support-bundle-kit:v0.0.17
   target: stgregistry.suse.com/rancher/mirrored-longhornio-support-bundle-kit:v0.0.17
   type: image
@@ -8686,6 +8755,9 @@ sync:
   type: image
 - source: longhornio/support-bundle-kit:v0.0.61
   target: stgregistry.suse.com/rancher/mirrored-longhornio-support-bundle-kit:v0.0.61
+  type: image
+- source: longhornio/support-bundle-kit:v0.0.69
+  target: stgregistry.suse.com/rancher/mirrored-longhornio-support-bundle-kit:v0.0.69
   type: image
 - source: messagebird/sachet:0.2.3
   target: docker.io/rancher/mirrored-messagebird-sachet:0.2.3


### PR DESCRIPTION
#### Pull Request Checklist ####

- [ ] If an entire image is being added, a repo has been created for the image in DockerHub under the `rancher` org
- [ ] Additions are licensed with Rancher favored licenses - Apache 2 and MIT - or approved licenses - as according to [CNCF approved licenses](https://github.com/cncf/foundation/blob/main/allowed-third-party-license-policy.md).
- [ ] Additions, when used in Rancher or Rancher's provided charts, have their corresponding origin added in Rancher's images [origins](https://github.com/rancher/rancher/blob/release/v2.7/pkg/image/origins.go) file (must be added for all Rancher versions `>= v2.7`).
- [ ] Any changes to scripting or CI config have been tested to the best of your ability

#### Change Description ####

<!-- Describe what you are doing and why. Link any related issues, pull requests and commit hashes. -->

#### Final Checks after the PR is merged ####

- [ ] Confirm that you can pull the mirrored images and tags from all target locations

https://github.com/longhorn/longhorn/issues/11699