### PR TITLE
Remove `coredns/coredns:v1.12.4`

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -62,7 +62,6 @@ Images:
   - 1.9.1
   - 1.9.3
   - 1.9.4
-  - v1.12.4
 - SourceImage: curlimages/curl
   Tags:
   - 7.70.0

--- a/regsync.yaml
+++ b/regsync.yaml
@@ -284,9 +284,6 @@ sync:
 - source: coredns/coredns:1.9.4
   target: docker.io/rancher/mirrored-coredns-coredns:1.9.4
   type: image
-- source: coredns/coredns:v1.12.4
-  target: docker.io/rancher/mirrored-coredns-coredns:v1.12.4
-  type: image
 - source: coredns/coredns:1.10.1
   target: registry.suse.com/rancher/mirrored-coredns-coredns:1.10.1
   type: image
@@ -344,9 +341,6 @@ sync:
 - source: coredns/coredns:1.9.4
   target: registry.suse.com/rancher/mirrored-coredns-coredns:1.9.4
   type: image
-- source: coredns/coredns:v1.12.4
-  target: registry.suse.com/rancher/mirrored-coredns-coredns:v1.12.4
-  type: image
 - source: coredns/coredns:1.10.1
   target: stgregistry.suse.com/rancher/mirrored-coredns-coredns:1.10.1
   type: image
@@ -403,9 +397,6 @@ sync:
   type: image
 - source: coredns/coredns:1.9.4
   target: stgregistry.suse.com/rancher/mirrored-coredns-coredns:1.9.4
-  type: image
-- source: coredns/coredns:v1.12.4
-  target: stgregistry.suse.com/rancher/mirrored-coredns-coredns:v1.12.4
   type: image
 - source: curlimages/curl:7.70.0
   target: docker.io/rancher/curlimages-curl:7.70.0


### PR DESCRIPTION
This PR removes the `v1.12.4` tag of `coredns/coredns` because it does not exist. This tag was added in https://github.com/rancher/image-mirror/pull/1089. We have https://github.com/rancher/rancher/issues/51451 to address the addition of the `v` in the version in the autoupdate workflow.
