### PR TITLE
add nginx 1.29.1 image

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -820,6 +820,7 @@ Images:
   - 1.23.2-alpine
   - 1.24.0-alpine
   - 1.27.2-alpine
+  - 1.29.1-alpine
 - SourceImage: library/redis
   Tags:
   - 7.2.9

--- a/regsync.yaml
+++ b/regsync.yaml
@@ -4763,6 +4763,9 @@ sync:
 - source: library/nginx:1.27.2-alpine
   target: docker.io/rancher/mirrored-library-nginx:1.27.2-alpine
   type: image
+- source: library/nginx:1.29.1-alpine
+  target: docker.io/rancher/mirrored-library-nginx:1.29.1-alpine
+  type: image
 - source: library/nginx:1.19.2-alpine
   target: registry.suse.com/rancher/mirrored-library-nginx:1.19.2-alpine
   type: image
@@ -4790,6 +4793,9 @@ sync:
 - source: library/nginx:1.27.2-alpine
   target: registry.suse.com/rancher/mirrored-library-nginx:1.27.2-alpine
   type: image
+- source: library/nginx:1.29.1-alpine
+  target: registry.suse.com/rancher/mirrored-library-nginx:1.29.1-alpine
+  type: image
 - source: library/nginx:1.19.2-alpine
   target: stgregistry.suse.com/rancher/mirrored-library-nginx:1.19.2-alpine
   type: image
@@ -4816,6 +4822,9 @@ sync:
   type: image
 - source: library/nginx:1.27.2-alpine
   target: stgregistry.suse.com/rancher/mirrored-library-nginx:1.27.2-alpine
+  type: image
+- source: library/nginx:1.29.1-alpine
+  target: stgregistry.suse.com/rancher/mirrored-library-nginx:1.29.1-alpine
   type: image
 - source: library/redis:7.2.9
   target: docker.io/rancher/mirrored-library-redis:7.2.9


### PR DESCRIPTION
#### Pull Request Checklist ####

- [ ] If an entire image is being added, a repo has been created for the image in DockerHub under the `rancher` org
- [ ] Additions are licensed with Rancher favored licenses - Apache 2 and MIT - or approved licenses - as according to [CNCF approved licenses](https://github.com/cncf/foundation/blob/main/allowed-third-party-license-policy.md).
- [ ] Additions, when used in Rancher or Rancher's provided charts, have their corresponding origin added in Rancher's images [origins](https://github.com/rancher/rancher/blob/release/v2.7/pkg/image/origins.go) file (must be added for all Rancher versions `>= v2.7`).
- [ ] Any changes to scripting or CI config have been tested to the best of your ability

#### Change Description ####

Adding the latest nginx supported version (1.29.1)
Issue: https://github.com/rancher/rancher/issues/52258

#### Final Checks after the PR is merged ####

- [ ] Confirm that you can pull the mirrored images and tags from all target locations
