### PR TITLE
Add new images for 4.11 logging bump

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -425,11 +425,13 @@ Images:
 - SourceImage: ghcr.io/kube-logging/fluentd
   Tags:
   - v1.16-4.10-full
+  - v1.16-4.11-full
   - v1.16-4.8-full
   - v1.16-ruby3.3-full-build.140
 - SourceImage: ghcr.io/kube-logging/logging-operator
   Tags:
   - 4.10.0
+  - 4.11.4
   - 4.4.0
   - 4.8.0
   - 4.9.1

--- a/regsync.yaml
+++ b/regsync.yaml
@@ -1952,6 +1952,9 @@ sync:
 - source: ghcr.io/kube-logging/fluentd:v1.16-4.10-full
   target: docker.io/rancher/mirrored-kube-logging-fluentd:v1.16-4.10-full
   type: image
+- source: ghcr.io/kube-logging/fluentd:v1.16-4.11-full
+  target: docker.io/rancher/mirrored-kube-logging-fluentd:v1.16-4.11-full
+  type: image
 - source: ghcr.io/kube-logging/fluentd:v1.16-4.8-full
   target: docker.io/rancher/mirrored-kube-logging-fluentd:v1.16-4.8-full
   type: image
@@ -1960,6 +1963,9 @@ sync:
   type: image
 - source: ghcr.io/kube-logging/fluentd:v1.16-4.10-full
   target: registry.suse.com/rancher/mirrored-kube-logging-fluentd:v1.16-4.10-full
+  type: image
+- source: ghcr.io/kube-logging/fluentd:v1.16-4.11-full
+  target: registry.suse.com/rancher/mirrored-kube-logging-fluentd:v1.16-4.11-full
   type: image
 - source: ghcr.io/kube-logging/fluentd:v1.16-4.8-full
   target: registry.suse.com/rancher/mirrored-kube-logging-fluentd:v1.16-4.8-full
@@ -1970,6 +1976,9 @@ sync:
 - source: ghcr.io/kube-logging/fluentd:v1.16-4.10-full
   target: stgregistry.suse.com/rancher/mirrored-kube-logging-fluentd:v1.16-4.10-full
   type: image
+- source: ghcr.io/kube-logging/fluentd:v1.16-4.11-full
+  target: stgregistry.suse.com/rancher/mirrored-kube-logging-fluentd:v1.16-4.11-full
+  type: image
 - source: ghcr.io/kube-logging/fluentd:v1.16-4.8-full
   target: stgregistry.suse.com/rancher/mirrored-kube-logging-fluentd:v1.16-4.8-full
   type: image
@@ -1978,6 +1987,9 @@ sync:
   type: image
 - source: ghcr.io/kube-logging/logging-operator:4.10.0
   target: docker.io/rancher/mirrored-kube-logging-logging-operator:4.10.0
+  type: image
+- source: ghcr.io/kube-logging/logging-operator:4.11.4
+  target: docker.io/rancher/mirrored-kube-logging-logging-operator:4.11.4
   type: image
 - source: ghcr.io/kube-logging/logging-operator:4.4.0
   target: docker.io/rancher/mirrored-kube-logging-logging-operator:4.4.0
@@ -1991,6 +2003,9 @@ sync:
 - source: ghcr.io/kube-logging/logging-operator:4.10.0
   target: registry.suse.com/rancher/mirrored-kube-logging-logging-operator:4.10.0
   type: image
+- source: ghcr.io/kube-logging/logging-operator:4.11.4
+  target: registry.suse.com/rancher/mirrored-kube-logging-logging-operator:4.11.4
+  type: image
 - source: ghcr.io/kube-logging/logging-operator:4.4.0
   target: registry.suse.com/rancher/mirrored-kube-logging-logging-operator:4.4.0
   type: image
@@ -2002,6 +2017,9 @@ sync:
   type: image
 - source: ghcr.io/kube-logging/logging-operator:4.10.0
   target: stgregistry.suse.com/rancher/mirrored-kube-logging-logging-operator:4.10.0
+  type: image
+- source: ghcr.io/kube-logging/logging-operator:4.11.4
+  target: stgregistry.suse.com/rancher/mirrored-kube-logging-logging-operator:4.11.4
   type: image
 - source: ghcr.io/kube-logging/logging-operator:4.4.0
   target: stgregistry.suse.com/rancher/mirrored-kube-logging-logging-operator:4.4.0


### PR DESCRIPTION
#### Pull Request Checklist ####

- [x] If an entire image is being added, a repo has been created for the image in DockerHub under the `rancher` org
- [x] Additions are licensed with Rancher favored licenses - Apache 2 and MIT - or approved licenses - as according to [CNCF approved licenses](https://github.com/cncf/foundation/blob/main/allowed-third-party-license-policy.md).
- [x] Additions, when used in Rancher or Rancher's provided charts, have their corresponding origin added in Rancher's images [origins](https://github.com/rancher/rancher/blob/release/v2.7/pkg/image/origins.go) file (must be added for all Rancher versions `>= v2.7`).
- [x] Any changes to scripting or CI config have been tested to the best of your ability

#### Change Description ####

Add new image tags for Rancher logging minor bump

#### Final Checks after the PR is merged ####

- [ ] Confirm that you can pull the mirrored images and tags from all target locations
