### PR TITLE
Remove invalid `kubernetes-cluster-autoscaler` chart tags

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -95,8 +95,6 @@ Images:
   - v0.8.3
 - SourceImage: dp.apps.rancher.io/charts/kubernetes-cluster-autoscaler
   Tags:
-  - 9.44.0
-  - 9.46.6
   - 9.50.1
   TargetRepositories:
   - registry.suse.com/rancher

--- a/regsync.yaml
+++ b/regsync.yaml
@@ -572,20 +572,8 @@ sync:
 - source: directxman12/k8s-prometheus-adapter-amd64:v0.8.3
   target: stgregistry.suse.com/rancher/mirrored-directxman12-k8s-prometheus-adapter-amd64:v0.8.3
   type: image
-- source: dp.apps.rancher.io/charts/kubernetes-cluster-autoscaler:9.44.0
-  target: registry.suse.com/rancher/appco-kubernetes-cluster-autoscaler:9.44.0
-  type: image
-- source: dp.apps.rancher.io/charts/kubernetes-cluster-autoscaler:9.46.6
-  target: registry.suse.com/rancher/appco-kubernetes-cluster-autoscaler:9.46.6
-  type: image
 - source: dp.apps.rancher.io/charts/kubernetes-cluster-autoscaler:9.50.1
   target: registry.suse.com/rancher/appco-kubernetes-cluster-autoscaler:9.50.1
-  type: image
-- source: dp.apps.rancher.io/charts/kubernetes-cluster-autoscaler:9.44.0
-  target: stgregistry.suse.com/rancher/appco-kubernetes-cluster-autoscaler:9.44.0
-  type: image
-- source: dp.apps.rancher.io/charts/kubernetes-cluster-autoscaler:9.46.6
-  target: stgregistry.suse.com/rancher/appco-kubernetes-cluster-autoscaler:9.46.6
   type: image
 - source: dp.apps.rancher.io/charts/kubernetes-cluster-autoscaler:9.50.1
   target: stgregistry.suse.com/rancher/appco-kubernetes-cluster-autoscaler:9.50.1


### PR DESCRIPTION
An error was made in #1116: these tags do not exist in the application collection. They are causing the mirroring workflow to fail. This PR is for https://github.com/rancher/rancher/issues/52325.

Note that this will fail validation because it removes tags. Please disregard this failure. I'll force merge this PR once approved.
