### PR TITLE
move cluster-autoscaler chart to exist in 'rancher/charts' instead of just 'rancher'

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ This section roughly correlates to the `creds` section of `regsync.yaml`.
 | `Password` | yes | The password to use when authenticating against the registry. See [the regsync documentation](https://regclient.org/usage/regsync/) for more details.
 | `Registry` | yes | The registry URL. See [the regsync documentation](https://regclient.org/usage/regsync/) for more details.
 | `ReqConcurrent` | no | The number of concurrent requests that are made to this registry. See [the regsync documentation](https://regclient.org/usage/regsync/) for more details.
-| `Target` | no | When `true`, denotes a target repository. This means that all images will be mirrored to this repository.
+| `DefaultTarget` | no | Whether the Repository is used as a target repository for a given Image when the `TargetRepositories` field of the Image is not set.
 | `Username` | yes | The username to use when authenticating against the registry. See [the regsync documentation](https://regclient.org/usage/regsync/) for more details.
 
 #### `Images`
@@ -92,7 +92,7 @@ repository.
 | `SourceImage` | yes | The source image. If there is no host, the image is assumed to be from Docker Hub.
 | `Tags` | yes | The tags to mirror.
 | `TargetImageName` | no | By default, the target image name is derived from the source image, and is of the format `mirrored-<org>-<name>`. For example, `banzaicloud/logging-operator` becomes `mirrored-banzaicloud-logging-operator`. However, there are some images that do not follow this convention - this field exists for these cases. New images should not set this field.
-| `TargetRepositories` | no | Repositories to mirror the image to. Repositories are specified via their BaseUrl field. If not specified, the Image is mirrored to all Repositories that have their Target field set to true.
+| `TargetRepositories` | no | Repositories to mirror the image to. Repositories are specified via their `BaseUrl` field. If not specified, the Image is mirrored to all Repositories that have `DefaultTarget` set to true.
 
 ### `autoupdate.yaml`
 

--- a/config.yaml
+++ b/config.yaml
@@ -97,8 +97,8 @@ Images:
   Tags:
   - 9.50.1
   TargetRepositories:
-  - registry.suse.com/rancher
-  - stgregistry.suse.com/rancher
+  - registry.suse.com/rancher/charts
+  - stgregistry.suse.com/rancher/charts
 - SourceImage: dp.apps.rancher.io/containers/k8s-sidecar
   Tags:
   - 1.30.7-11.3
@@ -3038,9 +3038,21 @@ Repositories:
   RepoAuth: true
   Target: true
   Username: '{{ env "PRIME_USERNAME" }}'
+- BaseUrl: registry.suse.com/rancher/charts
+  Password: '{{ env "PRIME_PASSWORD" }}'
+  Registry: registry.suse.com
+  RepoAuth: true
+  Target: true
+  Username: '{{ env "PRIME_USERNAME" }}'
 - BaseUrl: stgregistry.suse.com/rancher
   Password: '{{ env "PRIME_STAGING_PASSWORD" }}'
   Registry: stgregistry.suse.com
   RepoAuth: true
   Target: true
   Username: '{{ env "PRIME_STAGING_USERNAME" }}'
+- BaseUrl: stgregistry.suse.com/rancher/charts
+  Password: '{{ env "PRIME_STAGING_PASSWORD" }}'
+  Registry: stgregistry.suse.com
+  RepoAuth: true
+  Target: true
+  Username: ""

--- a/config.yaml
+++ b/config.yaml
@@ -3055,4 +3055,4 @@ Repositories:
   Password: '{{ env "PRIME_STAGING_PASSWORD" }}'
   Registry: stgregistry.suse.com
   RepoAuth: true
-  Username: ""
+  Username: '{{ env "PRIME_STAGING_USERNAME" }}'

--- a/config.yaml
+++ b/config.yaml
@@ -3039,7 +3039,7 @@ Repositories:
   RepoAuth: true
   Username: '{{ env "PRIME_USERNAME" }}'
 - BaseUrl: registry.suse.com/rancher/charts
-  DefaultTarget: true
+  DefaultTarget: false
   Password: '{{ env "PRIME_PASSWORD" }}'
   Registry: registry.suse.com
   RepoAuth: true
@@ -3051,7 +3051,7 @@ Repositories:
   RepoAuth: true
   Username: '{{ env "PRIME_STAGING_USERNAME" }}'
 - BaseUrl: stgregistry.suse.com/rancher/charts
-  DefaultTarget: true
+  DefaultTarget: false
   Password: '{{ env "PRIME_STAGING_PASSWORD" }}'
   Registry: stgregistry.suse.com
   RepoAuth: true

--- a/config.yaml
+++ b/config.yaml
@@ -3017,42 +3017,42 @@ Images:
   TargetImageName: mirrored-kubernetes-external-dns
 Repositories:
 - BaseUrl: docker.io/rancher
+  DefaultTarget: true
   Password: '{{ env "DOCKER_PASSWORD" }}'
   Registry: docker.io
   RepoAuth: true
-  Target: true
   Username: '{{ env "DOCKER_USERNAME" }}'
 - BaseUrl: dp.apps.rancher.io/charts
+  DefaultTarget: false
   Password: '{{ env "APPCO_PASSWORD" }}'
   Registry: dp.apps.rancher.io
-  Target: false
   Username: '{{ env "APPCO_USERNAME" }}'
 - BaseUrl: dp.apps.rancher.io/containers
+  DefaultTarget: false
   Password: '{{ env "APPCO_PASSWORD" }}'
   Registry: dp.apps.rancher.io
-  Target: false
   Username: '{{ env "APPCO_USERNAME" }}'
 - BaseUrl: registry.suse.com/rancher
+  DefaultTarget: true
   Password: '{{ env "PRIME_PASSWORD" }}'
   Registry: registry.suse.com
   RepoAuth: true
-  Target: true
   Username: '{{ env "PRIME_USERNAME" }}'
 - BaseUrl: registry.suse.com/rancher/charts
+  DefaultTarget: true
   Password: '{{ env "PRIME_PASSWORD" }}'
   Registry: registry.suse.com
   RepoAuth: true
-  Target: true
   Username: '{{ env "PRIME_USERNAME" }}'
 - BaseUrl: stgregistry.suse.com/rancher
+  DefaultTarget: true
   Password: '{{ env "PRIME_STAGING_PASSWORD" }}'
   Registry: stgregistry.suse.com
   RepoAuth: true
-  Target: true
   Username: '{{ env "PRIME_STAGING_USERNAME" }}'
 - BaseUrl: stgregistry.suse.com/rancher/charts
+  DefaultTarget: true
   Password: '{{ env "PRIME_STAGING_PASSWORD" }}'
   Registry: stgregistry.suse.com
   RepoAuth: true
-  Target: true
   Username: ""

--- a/regsync.yaml
+++ b/regsync.yaml
@@ -27,7 +27,7 @@ creds:
 - pass: '{{ env "PRIME_STAGING_PASSWORD" }}'
   registry: stgregistry.suse.com
   repoAuth: true
-  user: ""
+  user: '{{ env "PRIME_STAGING_USERNAME" }}'
 defaults:
   userAgent: rancher-image-mirror
 sync:

--- a/regsync.yaml
+++ b/regsync.yaml
@@ -16,10 +16,18 @@ creds:
   registry: registry.suse.com
   repoAuth: true
   user: '{{ env "PRIME_USERNAME" }}'
+- pass: '{{ env "PRIME_PASSWORD" }}'
+  registry: registry.suse.com
+  repoAuth: true
+  user: '{{ env "PRIME_USERNAME" }}'
 - pass: '{{ env "PRIME_STAGING_PASSWORD" }}'
   registry: stgregistry.suse.com
   repoAuth: true
   user: '{{ env "PRIME_STAGING_USERNAME" }}'
+- pass: '{{ env "PRIME_STAGING_PASSWORD" }}'
+  registry: stgregistry.suse.com
+  repoAuth: true
+  user: ""
 defaults:
   userAgent: rancher-image-mirror
 sync:
@@ -54,6 +62,21 @@ sync:
   target: registry.suse.com/rancher/mirrored-amazon-aws-cli:2.9.14
   type: image
 - source: amazon/aws-cli:2.0.52
+  target: registry.suse.com/rancher/charts/mirrored-amazon-aws-cli:2.0.52
+  type: image
+- source: amazon/aws-cli:2.8.5
+  target: registry.suse.com/rancher/charts/mirrored-amazon-aws-cli:2.8.5
+  type: image
+- source: amazon/aws-cli:2.8.9
+  target: registry.suse.com/rancher/charts/mirrored-amazon-aws-cli:2.8.9
+  type: image
+- source: amazon/aws-cli:2.9.0
+  target: registry.suse.com/rancher/charts/mirrored-amazon-aws-cli:2.9.0
+  type: image
+- source: amazon/aws-cli:2.9.14
+  target: registry.suse.com/rancher/charts/mirrored-amazon-aws-cli:2.9.14
+  type: image
+- source: amazon/aws-cli:2.0.52
   target: stgregistry.suse.com/rancher/mirrored-amazon-aws-cli:2.0.52
   type: image
 - source: amazon/aws-cli:2.8.5
@@ -67,6 +90,21 @@ sync:
   type: image
 - source: amazon/aws-cli:2.9.14
   target: stgregistry.suse.com/rancher/mirrored-amazon-aws-cli:2.9.14
+  type: image
+- source: amazon/aws-cli:2.0.52
+  target: stgregistry.suse.com/rancher/charts/mirrored-amazon-aws-cli:2.0.52
+  type: image
+- source: amazon/aws-cli:2.8.5
+  target: stgregistry.suse.com/rancher/charts/mirrored-amazon-aws-cli:2.8.5
+  type: image
+- source: amazon/aws-cli:2.8.9
+  target: stgregistry.suse.com/rancher/charts/mirrored-amazon-aws-cli:2.8.9
+  type: image
+- source: amazon/aws-cli:2.9.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-amazon-aws-cli:2.9.0
+  type: image
+- source: amazon/aws-cli:2.9.14
+  target: stgregistry.suse.com/rancher/charts/mirrored-amazon-aws-cli:2.9.14
   type: image
 - source: banzaicloud/logging-operator:3.6.0
   target: docker.io/rancher/banzaicloud-logging-operator:3.6.0
@@ -105,6 +143,24 @@ sync:
   target: registry.suse.com/rancher/banzaicloud-logging-operator:3.9.0
   type: image
 - source: banzaicloud/logging-operator:3.6.0
+  target: registry.suse.com/rancher/charts/banzaicloud-logging-operator:3.6.0
+  type: image
+- source: banzaicloud/logging-operator:3.7.0
+  target: registry.suse.com/rancher/charts/banzaicloud-logging-operator:3.7.0
+  type: image
+- source: banzaicloud/logging-operator:3.7.3
+  target: registry.suse.com/rancher/charts/banzaicloud-logging-operator:3.7.3
+  type: image
+- source: banzaicloud/logging-operator:3.8.0
+  target: registry.suse.com/rancher/charts/banzaicloud-logging-operator:3.8.0
+  type: image
+- source: banzaicloud/logging-operator:3.8.2
+  target: registry.suse.com/rancher/charts/banzaicloud-logging-operator:3.8.2
+  type: image
+- source: banzaicloud/logging-operator:3.9.0
+  target: registry.suse.com/rancher/charts/banzaicloud-logging-operator:3.9.0
+  type: image
+- source: banzaicloud/logging-operator:3.6.0
   target: stgregistry.suse.com/rancher/banzaicloud-logging-operator:3.6.0
   type: image
 - source: banzaicloud/logging-operator:3.7.0
@@ -121,6 +177,24 @@ sync:
   type: image
 - source: banzaicloud/logging-operator:3.9.0
   target: stgregistry.suse.com/rancher/banzaicloud-logging-operator:3.9.0
+  type: image
+- source: banzaicloud/logging-operator:3.6.0
+  target: stgregistry.suse.com/rancher/charts/banzaicloud-logging-operator:3.6.0
+  type: image
+- source: banzaicloud/logging-operator:3.7.0
+  target: stgregistry.suse.com/rancher/charts/banzaicloud-logging-operator:3.7.0
+  type: image
+- source: banzaicloud/logging-operator:3.7.3
+  target: stgregistry.suse.com/rancher/charts/banzaicloud-logging-operator:3.7.3
+  type: image
+- source: banzaicloud/logging-operator:3.8.0
+  target: stgregistry.suse.com/rancher/charts/banzaicloud-logging-operator:3.8.0
+  type: image
+- source: banzaicloud/logging-operator:3.8.2
+  target: stgregistry.suse.com/rancher/charts/banzaicloud-logging-operator:3.8.2
+  type: image
+- source: banzaicloud/logging-operator:3.9.0
+  target: stgregistry.suse.com/rancher/charts/banzaicloud-logging-operator:3.9.0
   type: image
 - source: banzaicloud/logging-operator:3.10.0
   target: docker.io/rancher/mirrored-banzaicloud-logging-operator:3.10.0
@@ -153,6 +227,21 @@ sync:
   target: registry.suse.com/rancher/mirrored-banzaicloud-logging-operator:3.9.5
   type: image
 - source: banzaicloud/logging-operator:3.10.0
+  target: registry.suse.com/rancher/charts/mirrored-banzaicloud-logging-operator:3.10.0
+  type: image
+- source: banzaicloud/logging-operator:3.12.0
+  target: registry.suse.com/rancher/charts/mirrored-banzaicloud-logging-operator:3.12.0
+  type: image
+- source: banzaicloud/logging-operator:3.9.0
+  target: registry.suse.com/rancher/charts/mirrored-banzaicloud-logging-operator:3.9.0
+  type: image
+- source: banzaicloud/logging-operator:3.9.4
+  target: registry.suse.com/rancher/charts/mirrored-banzaicloud-logging-operator:3.9.4
+  type: image
+- source: banzaicloud/logging-operator:3.9.5
+  target: registry.suse.com/rancher/charts/mirrored-banzaicloud-logging-operator:3.9.5
+  type: image
+- source: banzaicloud/logging-operator:3.10.0
   target: stgregistry.suse.com/rancher/mirrored-banzaicloud-logging-operator:3.10.0
   type: image
 - source: banzaicloud/logging-operator:3.12.0
@@ -167,6 +256,21 @@ sync:
 - source: banzaicloud/logging-operator:3.9.5
   target: stgregistry.suse.com/rancher/mirrored-banzaicloud-logging-operator:3.9.5
   type: image
+- source: banzaicloud/logging-operator:3.10.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-banzaicloud-logging-operator:3.10.0
+  type: image
+- source: banzaicloud/logging-operator:3.12.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-banzaicloud-logging-operator:3.12.0
+  type: image
+- source: banzaicloud/logging-operator:3.9.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-banzaicloud-logging-operator:3.9.0
+  type: image
+- source: banzaicloud/logging-operator:3.9.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-banzaicloud-logging-operator:3.9.4
+  type: image
+- source: banzaicloud/logging-operator:3.9.5
+  target: stgregistry.suse.com/rancher/charts/mirrored-banzaicloud-logging-operator:3.9.5
+  type: image
 - source: bats/bats:v1.1.0
   target: docker.io/rancher/bats-bats:v1.1.0
   type: image
@@ -174,7 +278,13 @@ sync:
   target: registry.suse.com/rancher/bats-bats:v1.1.0
   type: image
 - source: bats/bats:v1.1.0
+  target: registry.suse.com/rancher/charts/bats-bats:v1.1.0
+  type: image
+- source: bats/bats:v1.1.0
   target: stgregistry.suse.com/rancher/bats-bats:v1.1.0
+  type: image
+- source: bats/bats:v1.1.0
+  target: stgregistry.suse.com/rancher/charts/bats-bats:v1.1.0
   type: image
 - source: bats/bats:v1.1.0
   target: docker.io/rancher/mirrored-bats-bats:v1.1.0
@@ -189,10 +299,22 @@ sync:
   target: registry.suse.com/rancher/mirrored-bats-bats:v1.4.1
   type: image
 - source: bats/bats:v1.1.0
+  target: registry.suse.com/rancher/charts/mirrored-bats-bats:v1.1.0
+  type: image
+- source: bats/bats:v1.4.1
+  target: registry.suse.com/rancher/charts/mirrored-bats-bats:v1.4.1
+  type: image
+- source: bats/bats:v1.1.0
   target: stgregistry.suse.com/rancher/mirrored-bats-bats:v1.1.0
   type: image
 - source: bats/bats:v1.4.1
   target: stgregistry.suse.com/rancher/mirrored-bats-bats:v1.4.1
+  type: image
+- source: bats/bats:v1.1.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-bats-bats:v1.1.0
+  type: image
+- source: bats/bats:v1.4.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-bats-bats:v1.4.1
   type: image
 - source: coredns/coredns:1.7.0
   target: docker.io/rancher/coredns-coredns:1.7.0
@@ -219,6 +341,18 @@ sync:
   target: registry.suse.com/rancher/coredns-coredns:1.8.3
   type: image
 - source: coredns/coredns:1.7.0
+  target: registry.suse.com/rancher/charts/coredns-coredns:1.7.0
+  type: image
+- source: coredns/coredns:1.7.1
+  target: registry.suse.com/rancher/charts/coredns-coredns:1.7.1
+  type: image
+- source: coredns/coredns:1.8.0
+  target: registry.suse.com/rancher/charts/coredns-coredns:1.8.0
+  type: image
+- source: coredns/coredns:1.8.3
+  target: registry.suse.com/rancher/charts/coredns-coredns:1.8.3
+  type: image
+- source: coredns/coredns:1.7.0
   target: stgregistry.suse.com/rancher/coredns-coredns:1.7.0
   type: image
 - source: coredns/coredns:1.7.1
@@ -229,6 +363,18 @@ sync:
   type: image
 - source: coredns/coredns:1.8.3
   target: stgregistry.suse.com/rancher/coredns-coredns:1.8.3
+  type: image
+- source: coredns/coredns:1.7.0
+  target: stgregistry.suse.com/rancher/charts/coredns-coredns:1.7.0
+  type: image
+- source: coredns/coredns:1.7.1
+  target: stgregistry.suse.com/rancher/charts/coredns-coredns:1.7.1
+  type: image
+- source: coredns/coredns:1.8.0
+  target: stgregistry.suse.com/rancher/charts/coredns-coredns:1.8.0
+  type: image
+- source: coredns/coredns:1.8.3
+  target: stgregistry.suse.com/rancher/charts/coredns-coredns:1.8.3
   type: image
 - source: coredns/coredns:1.10.1
   target: docker.io/rancher/mirrored-coredns-coredns:1.10.1
@@ -357,6 +503,69 @@ sync:
   target: registry.suse.com/rancher/mirrored-coredns-coredns:1.9.4
   type: image
 - source: coredns/coredns:1.10.1
+  target: registry.suse.com/rancher/charts/mirrored-coredns-coredns:1.10.1
+  type: image
+- source: coredns/coredns:1.11.1
+  target: registry.suse.com/rancher/charts/mirrored-coredns-coredns:1.11.1
+  type: image
+- source: coredns/coredns:1.11.3
+  target: registry.suse.com/rancher/charts/mirrored-coredns-coredns:1.11.3
+  type: image
+- source: coredns/coredns:1.11.4
+  target: registry.suse.com/rancher/charts/mirrored-coredns-coredns:1.11.4
+  type: image
+- source: coredns/coredns:1.12.0
+  target: registry.suse.com/rancher/charts/mirrored-coredns-coredns:1.12.0
+  type: image
+- source: coredns/coredns:1.12.1
+  target: registry.suse.com/rancher/charts/mirrored-coredns-coredns:1.12.1
+  type: image
+- source: coredns/coredns:1.12.3
+  target: registry.suse.com/rancher/charts/mirrored-coredns-coredns:1.12.3
+  type: image
+- source: coredns/coredns:1.12.4
+  target: registry.suse.com/rancher/charts/mirrored-coredns-coredns:1.12.4
+  type: image
+- source: coredns/coredns:1.13.1
+  target: registry.suse.com/rancher/charts/mirrored-coredns-coredns:1.13.1
+  type: image
+- source: coredns/coredns:1.6.2
+  target: registry.suse.com/rancher/charts/mirrored-coredns-coredns:1.6.2
+  type: image
+- source: coredns/coredns:1.6.5
+  target: registry.suse.com/rancher/charts/mirrored-coredns-coredns:1.6.5
+  type: image
+- source: coredns/coredns:1.6.9
+  target: registry.suse.com/rancher/charts/mirrored-coredns-coredns:1.6.9
+  type: image
+- source: coredns/coredns:1.7.0
+  target: registry.suse.com/rancher/charts/mirrored-coredns-coredns:1.7.0
+  type: image
+- source: coredns/coredns:1.8.0
+  target: registry.suse.com/rancher/charts/mirrored-coredns-coredns:1.8.0
+  type: image
+- source: coredns/coredns:1.8.3
+  target: registry.suse.com/rancher/charts/mirrored-coredns-coredns:1.8.3
+  type: image
+- source: coredns/coredns:1.8.4
+  target: registry.suse.com/rancher/charts/mirrored-coredns-coredns:1.8.4
+  type: image
+- source: coredns/coredns:1.8.6
+  target: registry.suse.com/rancher/charts/mirrored-coredns-coredns:1.8.6
+  type: image
+- source: coredns/coredns:1.9.0
+  target: registry.suse.com/rancher/charts/mirrored-coredns-coredns:1.9.0
+  type: image
+- source: coredns/coredns:1.9.1
+  target: registry.suse.com/rancher/charts/mirrored-coredns-coredns:1.9.1
+  type: image
+- source: coredns/coredns:1.9.3
+  target: registry.suse.com/rancher/charts/mirrored-coredns-coredns:1.9.3
+  type: image
+- source: coredns/coredns:1.9.4
+  target: registry.suse.com/rancher/charts/mirrored-coredns-coredns:1.9.4
+  type: image
+- source: coredns/coredns:1.10.1
   target: stgregistry.suse.com/rancher/mirrored-coredns-coredns:1.10.1
   type: image
 - source: coredns/coredns:1.11.1
@@ -419,6 +628,69 @@ sync:
 - source: coredns/coredns:1.9.4
   target: stgregistry.suse.com/rancher/mirrored-coredns-coredns:1.9.4
   type: image
+- source: coredns/coredns:1.10.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-coredns-coredns:1.10.1
+  type: image
+- source: coredns/coredns:1.11.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-coredns-coredns:1.11.1
+  type: image
+- source: coredns/coredns:1.11.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-coredns-coredns:1.11.3
+  type: image
+- source: coredns/coredns:1.11.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-coredns-coredns:1.11.4
+  type: image
+- source: coredns/coredns:1.12.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-coredns-coredns:1.12.0
+  type: image
+- source: coredns/coredns:1.12.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-coredns-coredns:1.12.1
+  type: image
+- source: coredns/coredns:1.12.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-coredns-coredns:1.12.3
+  type: image
+- source: coredns/coredns:1.12.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-coredns-coredns:1.12.4
+  type: image
+- source: coredns/coredns:1.13.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-coredns-coredns:1.13.1
+  type: image
+- source: coredns/coredns:1.6.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-coredns-coredns:1.6.2
+  type: image
+- source: coredns/coredns:1.6.5
+  target: stgregistry.suse.com/rancher/charts/mirrored-coredns-coredns:1.6.5
+  type: image
+- source: coredns/coredns:1.6.9
+  target: stgregistry.suse.com/rancher/charts/mirrored-coredns-coredns:1.6.9
+  type: image
+- source: coredns/coredns:1.7.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-coredns-coredns:1.7.0
+  type: image
+- source: coredns/coredns:1.8.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-coredns-coredns:1.8.0
+  type: image
+- source: coredns/coredns:1.8.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-coredns-coredns:1.8.3
+  type: image
+- source: coredns/coredns:1.8.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-coredns-coredns:1.8.4
+  type: image
+- source: coredns/coredns:1.8.6
+  target: stgregistry.suse.com/rancher/charts/mirrored-coredns-coredns:1.8.6
+  type: image
+- source: coredns/coredns:1.9.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-coredns-coredns:1.9.0
+  type: image
+- source: coredns/coredns:1.9.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-coredns-coredns:1.9.1
+  type: image
+- source: coredns/coredns:1.9.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-coredns-coredns:1.9.3
+  type: image
+- source: coredns/coredns:1.9.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-coredns-coredns:1.9.4
+  type: image
 - source: curlimages/curl:7.70.0
   target: docker.io/rancher/curlimages-curl:7.70.0
   type: image
@@ -432,10 +704,22 @@ sync:
   target: registry.suse.com/rancher/curlimages-curl:7.73.0
   type: image
 - source: curlimages/curl:7.70.0
+  target: registry.suse.com/rancher/charts/curlimages-curl:7.70.0
+  type: image
+- source: curlimages/curl:7.73.0
+  target: registry.suse.com/rancher/charts/curlimages-curl:7.73.0
+  type: image
+- source: curlimages/curl:7.70.0
   target: stgregistry.suse.com/rancher/curlimages-curl:7.70.0
   type: image
 - source: curlimages/curl:7.73.0
   target: stgregistry.suse.com/rancher/curlimages-curl:7.73.0
+  type: image
+- source: curlimages/curl:7.70.0
+  target: stgregistry.suse.com/rancher/charts/curlimages-curl:7.70.0
+  type: image
+- source: curlimages/curl:7.73.0
+  target: stgregistry.suse.com/rancher/charts/curlimages-curl:7.73.0
   type: image
 - source: curlimages/curl:7.70.0
   target: docker.io/rancher/mirrored-curlimages-curl:7.70.0
@@ -492,6 +776,33 @@ sync:
   target: registry.suse.com/rancher/mirrored-curlimages-curl:8.9.1
   type: image
 - source: curlimages/curl:7.70.0
+  target: registry.suse.com/rancher/charts/mirrored-curlimages-curl:7.70.0
+  type: image
+- source: curlimages/curl:7.73.0
+  target: registry.suse.com/rancher/charts/mirrored-curlimages-curl:7.73.0
+  type: image
+- source: curlimages/curl:7.77.0
+  target: registry.suse.com/rancher/charts/mirrored-curlimages-curl:7.77.0
+  type: image
+- source: curlimages/curl:7.83.1
+  target: registry.suse.com/rancher/charts/mirrored-curlimages-curl:7.83.1
+  type: image
+- source: curlimages/curl:7.85.0
+  target: registry.suse.com/rancher/charts/mirrored-curlimages-curl:7.85.0
+  type: image
+- source: curlimages/curl:8.10.1
+  target: registry.suse.com/rancher/charts/mirrored-curlimages-curl:8.10.1
+  type: image
+- source: curlimages/curl:8.12.1
+  target: registry.suse.com/rancher/charts/mirrored-curlimages-curl:8.12.1
+  type: image
+- source: curlimages/curl:8.13.0
+  target: registry.suse.com/rancher/charts/mirrored-curlimages-curl:8.13.0
+  type: image
+- source: curlimages/curl:8.9.1
+  target: registry.suse.com/rancher/charts/mirrored-curlimages-curl:8.9.1
+  type: image
+- source: curlimages/curl:7.70.0
   target: stgregistry.suse.com/rancher/mirrored-curlimages-curl:7.70.0
   type: image
 - source: curlimages/curl:7.73.0
@@ -518,6 +829,33 @@ sync:
 - source: curlimages/curl:8.9.1
   target: stgregistry.suse.com/rancher/mirrored-curlimages-curl:8.9.1
   type: image
+- source: curlimages/curl:7.70.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-curlimages-curl:7.70.0
+  type: image
+- source: curlimages/curl:7.73.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-curlimages-curl:7.73.0
+  type: image
+- source: curlimages/curl:7.77.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-curlimages-curl:7.77.0
+  type: image
+- source: curlimages/curl:7.83.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-curlimages-curl:7.83.1
+  type: image
+- source: curlimages/curl:7.85.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-curlimages-curl:7.85.0
+  type: image
+- source: curlimages/curl:8.10.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-curlimages-curl:8.10.1
+  type: image
+- source: curlimages/curl:8.12.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-curlimages-curl:8.12.1
+  type: image
+- source: curlimages/curl:8.13.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-curlimages-curl:8.13.0
+  type: image
+- source: curlimages/curl:8.9.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-curlimages-curl:8.9.1
+  type: image
 - source: directxman12/k8s-prometheus-adapter:v0.8.3
   target: docker.io/rancher/mirrored-directxman12-k8s-prometheus-adapter:v0.8.3
   type: image
@@ -531,10 +869,22 @@ sync:
   target: registry.suse.com/rancher/mirrored-directxman12-k8s-prometheus-adapter:v0.8.4
   type: image
 - source: directxman12/k8s-prometheus-adapter:v0.8.3
+  target: registry.suse.com/rancher/charts/mirrored-directxman12-k8s-prometheus-adapter:v0.8.3
+  type: image
+- source: directxman12/k8s-prometheus-adapter:v0.8.4
+  target: registry.suse.com/rancher/charts/mirrored-directxman12-k8s-prometheus-adapter:v0.8.4
+  type: image
+- source: directxman12/k8s-prometheus-adapter:v0.8.3
   target: stgregistry.suse.com/rancher/mirrored-directxman12-k8s-prometheus-adapter:v0.8.3
   type: image
 - source: directxman12/k8s-prometheus-adapter:v0.8.4
   target: stgregistry.suse.com/rancher/mirrored-directxman12-k8s-prometheus-adapter:v0.8.4
+  type: image
+- source: directxman12/k8s-prometheus-adapter:v0.8.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-directxman12-k8s-prometheus-adapter:v0.8.3
+  type: image
+- source: directxman12/k8s-prometheus-adapter:v0.8.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-directxman12-k8s-prometheus-adapter:v0.8.4
   type: image
 - source: directxman12/k8s-prometheus-adapter-amd64:v0.6.0
   target: docker.io/rancher/directxman12-k8s-prometheus-adapter-amd64:v0.6.0
@@ -549,10 +899,22 @@ sync:
   target: registry.suse.com/rancher/directxman12-k8s-prometheus-adapter-amd64:v0.7.0
   type: image
 - source: directxman12/k8s-prometheus-adapter-amd64:v0.6.0
+  target: registry.suse.com/rancher/charts/directxman12-k8s-prometheus-adapter-amd64:v0.6.0
+  type: image
+- source: directxman12/k8s-prometheus-adapter-amd64:v0.7.0
+  target: registry.suse.com/rancher/charts/directxman12-k8s-prometheus-adapter-amd64:v0.7.0
+  type: image
+- source: directxman12/k8s-prometheus-adapter-amd64:v0.6.0
   target: stgregistry.suse.com/rancher/directxman12-k8s-prometheus-adapter-amd64:v0.6.0
   type: image
 - source: directxman12/k8s-prometheus-adapter-amd64:v0.7.0
   target: stgregistry.suse.com/rancher/directxman12-k8s-prometheus-adapter-amd64:v0.7.0
+  type: image
+- source: directxman12/k8s-prometheus-adapter-amd64:v0.6.0
+  target: stgregistry.suse.com/rancher/charts/directxman12-k8s-prometheus-adapter-amd64:v0.6.0
+  type: image
+- source: directxman12/k8s-prometheus-adapter-amd64:v0.7.0
+  target: stgregistry.suse.com/rancher/charts/directxman12-k8s-prometheus-adapter-amd64:v0.7.0
   type: image
 - source: directxman12/k8s-prometheus-adapter-amd64:v0.7.0
   target: docker.io/rancher/mirrored-directxman12-k8s-prometheus-adapter-amd64:v0.7.0
@@ -567,16 +929,28 @@ sync:
   target: registry.suse.com/rancher/mirrored-directxman12-k8s-prometheus-adapter-amd64:v0.8.3
   type: image
 - source: directxman12/k8s-prometheus-adapter-amd64:v0.7.0
+  target: registry.suse.com/rancher/charts/mirrored-directxman12-k8s-prometheus-adapter-amd64:v0.7.0
+  type: image
+- source: directxman12/k8s-prometheus-adapter-amd64:v0.8.3
+  target: registry.suse.com/rancher/charts/mirrored-directxman12-k8s-prometheus-adapter-amd64:v0.8.3
+  type: image
+- source: directxman12/k8s-prometheus-adapter-amd64:v0.7.0
   target: stgregistry.suse.com/rancher/mirrored-directxman12-k8s-prometheus-adapter-amd64:v0.7.0
   type: image
 - source: directxman12/k8s-prometheus-adapter-amd64:v0.8.3
   target: stgregistry.suse.com/rancher/mirrored-directxman12-k8s-prometheus-adapter-amd64:v0.8.3
   type: image
-- source: dp.apps.rancher.io/charts/kubernetes-cluster-autoscaler:9.50.1
-  target: registry.suse.com/rancher/appco-kubernetes-cluster-autoscaler:9.50.1
+- source: directxman12/k8s-prometheus-adapter-amd64:v0.7.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-directxman12-k8s-prometheus-adapter-amd64:v0.7.0
+  type: image
+- source: directxman12/k8s-prometheus-adapter-amd64:v0.8.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-directxman12-k8s-prometheus-adapter-amd64:v0.8.3
   type: image
 - source: dp.apps.rancher.io/charts/kubernetes-cluster-autoscaler:9.50.1
-  target: stgregistry.suse.com/rancher/appco-kubernetes-cluster-autoscaler:9.50.1
+  target: registry.suse.com/rancher/charts/appco-kubernetes-cluster-autoscaler:9.50.1
+  type: image
+- source: dp.apps.rancher.io/charts/kubernetes-cluster-autoscaler:9.50.1
+  target: stgregistry.suse.com/rancher/charts/appco-kubernetes-cluster-autoscaler:9.50.1
   type: image
 - source: dp.apps.rancher.io/containers/k8s-sidecar:1.30.7-11.3
   target: docker.io/rancher/appco-k8s-sidecar:1.30.7-11.3
@@ -585,7 +959,13 @@ sync:
   target: registry.suse.com/rancher/appco-k8s-sidecar:1.30.7-11.3
   type: image
 - source: dp.apps.rancher.io/containers/k8s-sidecar:1.30.7-11.3
+  target: registry.suse.com/rancher/charts/appco-k8s-sidecar:1.30.7-11.3
+  type: image
+- source: dp.apps.rancher.io/containers/k8s-sidecar:1.30.7-11.3
   target: stgregistry.suse.com/rancher/appco-k8s-sidecar:1.30.7-11.3
+  type: image
+- source: dp.apps.rancher.io/containers/k8s-sidecar:1.30.7-11.3
+  target: stgregistry.suse.com/rancher/charts/appco-k8s-sidecar:1.30.7-11.3
   type: image
 - source: dp.apps.rancher.io/containers/kubernetes-cluster-autoscaler:1.32.3-1.5
   target: registry.suse.com/rancher/appco-kubernetes-cluster-autoscaler:1.32.3-1.5
@@ -612,7 +992,13 @@ sync:
   target: registry.suse.com/rancher/appco-redis:8.0.3-2.1
   type: image
 - source: dp.apps.rancher.io/containers/redis:8.0.3-2.1
+  target: registry.suse.com/rancher/charts/appco-redis:8.0.3-2.1
+  type: image
+- source: dp.apps.rancher.io/containers/redis:8.0.3-2.1
   target: stgregistry.suse.com/rancher/appco-redis:8.0.3-2.1
+  type: image
+- source: dp.apps.rancher.io/containers/redis:8.0.3-2.1
+  target: stgregistry.suse.com/rancher/charts/appco-redis:8.0.3-2.1
   type: image
 - source: flannel/flannel:v0.21.2
   target: docker.io/rancher/mirrored-flannel-flannel:v0.21.2
@@ -765,6 +1151,81 @@ sync:
   target: registry.suse.com/rancher/mirrored-flannel-flannel:v0.27.4
   type: image
 - source: flannel/flannel:v0.21.2
+  target: registry.suse.com/rancher/charts/mirrored-flannel-flannel:v0.21.2
+  type: image
+- source: flannel/flannel:v0.21.4
+  target: registry.suse.com/rancher/charts/mirrored-flannel-flannel:v0.21.4
+  type: image
+- source: flannel/flannel:v0.21.5
+  target: registry.suse.com/rancher/charts/mirrored-flannel-flannel:v0.21.5
+  type: image
+- source: flannel/flannel:v0.22.0
+  target: registry.suse.com/rancher/charts/mirrored-flannel-flannel:v0.22.0
+  type: image
+- source: flannel/flannel:v0.22.1
+  target: registry.suse.com/rancher/charts/mirrored-flannel-flannel:v0.22.1
+  type: image
+- source: flannel/flannel:v0.22.2
+  target: registry.suse.com/rancher/charts/mirrored-flannel-flannel:v0.22.2
+  type: image
+- source: flannel/flannel:v0.22.3
+  target: registry.suse.com/rancher/charts/mirrored-flannel-flannel:v0.22.3
+  type: image
+- source: flannel/flannel:v0.23.0
+  target: registry.suse.com/rancher/charts/mirrored-flannel-flannel:v0.23.0
+  type: image
+- source: flannel/flannel:v0.24.2
+  target: registry.suse.com/rancher/charts/mirrored-flannel-flannel:v0.24.2
+  type: image
+- source: flannel/flannel:v0.25.1
+  target: registry.suse.com/rancher/charts/mirrored-flannel-flannel:v0.25.1
+  type: image
+- source: flannel/flannel:v0.25.2
+  target: registry.suse.com/rancher/charts/mirrored-flannel-flannel:v0.25.2
+  type: image
+- source: flannel/flannel:v0.25.5
+  target: registry.suse.com/rancher/charts/mirrored-flannel-flannel:v0.25.5
+  type: image
+- source: flannel/flannel:v0.25.7
+  target: registry.suse.com/rancher/charts/mirrored-flannel-flannel:v0.25.7
+  type: image
+- source: flannel/flannel:v0.26.1
+  target: registry.suse.com/rancher/charts/mirrored-flannel-flannel:v0.26.1
+  type: image
+- source: flannel/flannel:v0.26.2
+  target: registry.suse.com/rancher/charts/mirrored-flannel-flannel:v0.26.2
+  type: image
+- source: flannel/flannel:v0.26.3
+  target: registry.suse.com/rancher/charts/mirrored-flannel-flannel:v0.26.3
+  type: image
+- source: flannel/flannel:v0.26.4
+  target: registry.suse.com/rancher/charts/mirrored-flannel-flannel:v0.26.4
+  type: image
+- source: flannel/flannel:v0.26.5
+  target: registry.suse.com/rancher/charts/mirrored-flannel-flannel:v0.26.5
+  type: image
+- source: flannel/flannel:v0.26.6
+  target: registry.suse.com/rancher/charts/mirrored-flannel-flannel:v0.26.6
+  type: image
+- source: flannel/flannel:v0.26.7
+  target: registry.suse.com/rancher/charts/mirrored-flannel-flannel:v0.26.7
+  type: image
+- source: flannel/flannel:v0.27.0
+  target: registry.suse.com/rancher/charts/mirrored-flannel-flannel:v0.27.0
+  type: image
+- source: flannel/flannel:v0.27.1
+  target: registry.suse.com/rancher/charts/mirrored-flannel-flannel:v0.27.1
+  type: image
+- source: flannel/flannel:v0.27.2
+  target: registry.suse.com/rancher/charts/mirrored-flannel-flannel:v0.27.2
+  type: image
+- source: flannel/flannel:v0.27.3
+  target: registry.suse.com/rancher/charts/mirrored-flannel-flannel:v0.27.3
+  type: image
+- source: flannel/flannel:v0.27.4
+  target: registry.suse.com/rancher/charts/mirrored-flannel-flannel:v0.27.4
+  type: image
+- source: flannel/flannel:v0.21.2
   target: stgregistry.suse.com/rancher/mirrored-flannel-flannel:v0.21.2
   type: image
 - source: flannel/flannel:v0.21.4
@@ -839,6 +1300,81 @@ sync:
 - source: flannel/flannel:v0.27.4
   target: stgregistry.suse.com/rancher/mirrored-flannel-flannel:v0.27.4
   type: image
+- source: flannel/flannel:v0.21.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-flannel-flannel:v0.21.2
+  type: image
+- source: flannel/flannel:v0.21.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-flannel-flannel:v0.21.4
+  type: image
+- source: flannel/flannel:v0.21.5
+  target: stgregistry.suse.com/rancher/charts/mirrored-flannel-flannel:v0.21.5
+  type: image
+- source: flannel/flannel:v0.22.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-flannel-flannel:v0.22.0
+  type: image
+- source: flannel/flannel:v0.22.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-flannel-flannel:v0.22.1
+  type: image
+- source: flannel/flannel:v0.22.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-flannel-flannel:v0.22.2
+  type: image
+- source: flannel/flannel:v0.22.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-flannel-flannel:v0.22.3
+  type: image
+- source: flannel/flannel:v0.23.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-flannel-flannel:v0.23.0
+  type: image
+- source: flannel/flannel:v0.24.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-flannel-flannel:v0.24.2
+  type: image
+- source: flannel/flannel:v0.25.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-flannel-flannel:v0.25.1
+  type: image
+- source: flannel/flannel:v0.25.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-flannel-flannel:v0.25.2
+  type: image
+- source: flannel/flannel:v0.25.5
+  target: stgregistry.suse.com/rancher/charts/mirrored-flannel-flannel:v0.25.5
+  type: image
+- source: flannel/flannel:v0.25.7
+  target: stgregistry.suse.com/rancher/charts/mirrored-flannel-flannel:v0.25.7
+  type: image
+- source: flannel/flannel:v0.26.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-flannel-flannel:v0.26.1
+  type: image
+- source: flannel/flannel:v0.26.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-flannel-flannel:v0.26.2
+  type: image
+- source: flannel/flannel:v0.26.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-flannel-flannel:v0.26.3
+  type: image
+- source: flannel/flannel:v0.26.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-flannel-flannel:v0.26.4
+  type: image
+- source: flannel/flannel:v0.26.5
+  target: stgregistry.suse.com/rancher/charts/mirrored-flannel-flannel:v0.26.5
+  type: image
+- source: flannel/flannel:v0.26.6
+  target: stgregistry.suse.com/rancher/charts/mirrored-flannel-flannel:v0.26.6
+  type: image
+- source: flannel/flannel:v0.26.7
+  target: stgregistry.suse.com/rancher/charts/mirrored-flannel-flannel:v0.26.7
+  type: image
+- source: flannel/flannel:v0.27.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-flannel-flannel:v0.27.0
+  type: image
+- source: flannel/flannel:v0.27.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-flannel-flannel:v0.27.1
+  type: image
+- source: flannel/flannel:v0.27.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-flannel-flannel:v0.27.2
+  type: image
+- source: flannel/flannel:v0.27.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-flannel-flannel:v0.27.3
+  type: image
+- source: flannel/flannel:v0.27.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-flannel-flannel:v0.27.4
+  type: image
 - source: flannel/flannel-cni-plugin:v1.2.0
   target: docker.io/rancher/mirrored-flannel-flannel-cni-plugin:v1.2.0
   type: image
@@ -882,6 +1418,27 @@ sync:
   target: registry.suse.com/rancher/mirrored-flannel-flannel-cni-plugin:v1.8.0-flannel1
   type: image
 - source: flannel/flannel-cni-plugin:v1.2.0
+  target: registry.suse.com/rancher/charts/mirrored-flannel-flannel-cni-plugin:v1.2.0
+  type: image
+- source: flannel/flannel-cni-plugin:v1.5.1-flannel1
+  target: registry.suse.com/rancher/charts/mirrored-flannel-flannel-cni-plugin:v1.5.1-flannel1
+  type: image
+- source: flannel/flannel-cni-plugin:v1.5.1-flannel2
+  target: registry.suse.com/rancher/charts/mirrored-flannel-flannel-cni-plugin:v1.5.1-flannel2
+  type: image
+- source: flannel/flannel-cni-plugin:v1.6.2-flannel1
+  target: registry.suse.com/rancher/charts/mirrored-flannel-flannel-cni-plugin:v1.6.2-flannel1
+  type: image
+- source: flannel/flannel-cni-plugin:v1.7.1-flannel1
+  target: registry.suse.com/rancher/charts/mirrored-flannel-flannel-cni-plugin:v1.7.1-flannel1
+  type: image
+- source: flannel/flannel-cni-plugin:v1.7.1-flannel2
+  target: registry.suse.com/rancher/charts/mirrored-flannel-flannel-cni-plugin:v1.7.1-flannel2
+  type: image
+- source: flannel/flannel-cni-plugin:v1.8.0-flannel1
+  target: registry.suse.com/rancher/charts/mirrored-flannel-flannel-cni-plugin:v1.8.0-flannel1
+  type: image
+- source: flannel/flannel-cni-plugin:v1.2.0
   target: stgregistry.suse.com/rancher/mirrored-flannel-flannel-cni-plugin:v1.2.0
   type: image
 - source: flannel/flannel-cni-plugin:v1.5.1-flannel1
@@ -901,6 +1458,27 @@ sync:
   type: image
 - source: flannel/flannel-cni-plugin:v1.8.0-flannel1
   target: stgregistry.suse.com/rancher/mirrored-flannel-flannel-cni-plugin:v1.8.0-flannel1
+  type: image
+- source: flannel/flannel-cni-plugin:v1.2.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-flannel-flannel-cni-plugin:v1.2.0
+  type: image
+- source: flannel/flannel-cni-plugin:v1.5.1-flannel1
+  target: stgregistry.suse.com/rancher/charts/mirrored-flannel-flannel-cni-plugin:v1.5.1-flannel1
+  type: image
+- source: flannel/flannel-cni-plugin:v1.5.1-flannel2
+  target: stgregistry.suse.com/rancher/charts/mirrored-flannel-flannel-cni-plugin:v1.5.1-flannel2
+  type: image
+- source: flannel/flannel-cni-plugin:v1.6.2-flannel1
+  target: stgregistry.suse.com/rancher/charts/mirrored-flannel-flannel-cni-plugin:v1.6.2-flannel1
+  type: image
+- source: flannel/flannel-cni-plugin:v1.7.1-flannel1
+  target: stgregistry.suse.com/rancher/charts/mirrored-flannel-flannel-cni-plugin:v1.7.1-flannel1
+  type: image
+- source: flannel/flannel-cni-plugin:v1.7.1-flannel2
+  target: stgregistry.suse.com/rancher/charts/mirrored-flannel-flannel-cni-plugin:v1.7.1-flannel2
+  type: image
+- source: flannel/flannel-cni-plugin:v1.8.0-flannel1
+  target: stgregistry.suse.com/rancher/charts/mirrored-flannel-flannel-cni-plugin:v1.8.0-flannel1
   type: image
 - source: flannelcni/flannel:v0.16.0
   target: docker.io/rancher/mirrored-flannelcni-flannel:v0.16.0
@@ -981,6 +1559,45 @@ sync:
   target: registry.suse.com/rancher/mirrored-flannelcni-flannel:v0.20.2
   type: image
 - source: flannelcni/flannel:v0.16.0
+  target: registry.suse.com/rancher/charts/mirrored-flannelcni-flannel:v0.16.0
+  type: image
+- source: flannelcni/flannel:v0.16.1
+  target: registry.suse.com/rancher/charts/mirrored-flannelcni-flannel:v0.16.1
+  type: image
+- source: flannelcni/flannel:v0.16.2
+  target: registry.suse.com/rancher/charts/mirrored-flannelcni-flannel:v0.16.2
+  type: image
+- source: flannelcni/flannel:v0.16.3
+  target: registry.suse.com/rancher/charts/mirrored-flannelcni-flannel:v0.16.3
+  type: image
+- source: flannelcni/flannel:v0.17.0
+  target: registry.suse.com/rancher/charts/mirrored-flannelcni-flannel:v0.17.0
+  type: image
+- source: flannelcni/flannel:v0.18.0
+  target: registry.suse.com/rancher/charts/mirrored-flannelcni-flannel:v0.18.0
+  type: image
+- source: flannelcni/flannel:v0.18.1
+  target: registry.suse.com/rancher/charts/mirrored-flannelcni-flannel:v0.18.1
+  type: image
+- source: flannelcni/flannel:v0.19.0
+  target: registry.suse.com/rancher/charts/mirrored-flannelcni-flannel:v0.19.0
+  type: image
+- source: flannelcni/flannel:v0.19.1
+  target: registry.suse.com/rancher/charts/mirrored-flannelcni-flannel:v0.19.1
+  type: image
+- source: flannelcni/flannel:v0.19.2
+  target: registry.suse.com/rancher/charts/mirrored-flannelcni-flannel:v0.19.2
+  type: image
+- source: flannelcni/flannel:v0.20.0
+  target: registry.suse.com/rancher/charts/mirrored-flannelcni-flannel:v0.20.0
+  type: image
+- source: flannelcni/flannel:v0.20.1
+  target: registry.suse.com/rancher/charts/mirrored-flannelcni-flannel:v0.20.1
+  type: image
+- source: flannelcni/flannel:v0.20.2
+  target: registry.suse.com/rancher/charts/mirrored-flannelcni-flannel:v0.20.2
+  type: image
+- source: flannelcni/flannel:v0.16.0
   target: stgregistry.suse.com/rancher/mirrored-flannelcni-flannel:v0.16.0
   type: image
 - source: flannelcni/flannel:v0.16.1
@@ -1019,6 +1636,45 @@ sync:
 - source: flannelcni/flannel:v0.20.2
   target: stgregistry.suse.com/rancher/mirrored-flannelcni-flannel:v0.20.2
   type: image
+- source: flannelcni/flannel:v0.16.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-flannelcni-flannel:v0.16.0
+  type: image
+- source: flannelcni/flannel:v0.16.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-flannelcni-flannel:v0.16.1
+  type: image
+- source: flannelcni/flannel:v0.16.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-flannelcni-flannel:v0.16.2
+  type: image
+- source: flannelcni/flannel:v0.16.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-flannelcni-flannel:v0.16.3
+  type: image
+- source: flannelcni/flannel:v0.17.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-flannelcni-flannel:v0.17.0
+  type: image
+- source: flannelcni/flannel:v0.18.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-flannelcni-flannel:v0.18.0
+  type: image
+- source: flannelcni/flannel:v0.18.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-flannelcni-flannel:v0.18.1
+  type: image
+- source: flannelcni/flannel:v0.19.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-flannelcni-flannel:v0.19.0
+  type: image
+- source: flannelcni/flannel:v0.19.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-flannelcni-flannel:v0.19.1
+  type: image
+- source: flannelcni/flannel:v0.19.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-flannelcni-flannel:v0.19.2
+  type: image
+- source: flannelcni/flannel:v0.20.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-flannelcni-flannel:v0.20.0
+  type: image
+- source: flannelcni/flannel:v0.20.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-flannelcni-flannel:v0.20.1
+  type: image
+- source: flannelcni/flannel:v0.20.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-flannelcni-flannel:v0.20.2
+  type: image
 - source: flannelcni/flannel-cni-plugin:v1.0.0
   target: docker.io/rancher/mirrored-flannelcni-flannel-cni-plugin:v1.0.0
   type: image
@@ -1050,6 +1706,21 @@ sync:
   target: registry.suse.com/rancher/mirrored-flannelcni-flannel-cni-plugin:v1.2.0
   type: image
 - source: flannelcni/flannel-cni-plugin:v1.0.0
+  target: registry.suse.com/rancher/charts/mirrored-flannelcni-flannel-cni-plugin:v1.0.0
+  type: image
+- source: flannelcni/flannel-cni-plugin:v1.0.1
+  target: registry.suse.com/rancher/charts/mirrored-flannelcni-flannel-cni-plugin:v1.0.1
+  type: image
+- source: flannelcni/flannel-cni-plugin:v1.1.0
+  target: registry.suse.com/rancher/charts/mirrored-flannelcni-flannel-cni-plugin:v1.1.0
+  type: image
+- source: flannelcni/flannel-cni-plugin:v1.1.2
+  target: registry.suse.com/rancher/charts/mirrored-flannelcni-flannel-cni-plugin:v1.1.2
+  type: image
+- source: flannelcni/flannel-cni-plugin:v1.2.0
+  target: registry.suse.com/rancher/charts/mirrored-flannelcni-flannel-cni-plugin:v1.2.0
+  type: image
+- source: flannelcni/flannel-cni-plugin:v1.0.0
   target: stgregistry.suse.com/rancher/mirrored-flannelcni-flannel-cni-plugin:v1.0.0
   type: image
 - source: flannelcni/flannel-cni-plugin:v1.0.1
@@ -1064,6 +1735,21 @@ sync:
 - source: flannelcni/flannel-cni-plugin:v1.2.0
   target: stgregistry.suse.com/rancher/mirrored-flannelcni-flannel-cni-plugin:v1.2.0
   type: image
+- source: flannelcni/flannel-cni-plugin:v1.0.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-flannelcni-flannel-cni-plugin:v1.0.0
+  type: image
+- source: flannelcni/flannel-cni-plugin:v1.0.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-flannelcni-flannel-cni-plugin:v1.0.1
+  type: image
+- source: flannelcni/flannel-cni-plugin:v1.1.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-flannelcni-flannel-cni-plugin:v1.1.0
+  type: image
+- source: flannelcni/flannel-cni-plugin:v1.1.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-flannelcni-flannel-cni-plugin:v1.1.2
+  type: image
+- source: flannelcni/flannel-cni-plugin:v1.2.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-flannelcni-flannel-cni-plugin:v1.2.0
+  type: image
 - source: fluent/fluent-bit:windows-2019-3.1.8
   target: docker.io/rancher/fluent-bit:windows-2019-3.1.8
   type: image
@@ -1077,10 +1763,22 @@ sync:
   target: registry.suse.com/rancher/fluent-bit:windows-2022-3.1.8
   type: image
 - source: fluent/fluent-bit:windows-2019-3.1.8
+  target: registry.suse.com/rancher/charts/fluent-bit:windows-2019-3.1.8
+  type: image
+- source: fluent/fluent-bit:windows-2022-3.1.8
+  target: registry.suse.com/rancher/charts/fluent-bit:windows-2022-3.1.8
+  type: image
+- source: fluent/fluent-bit:windows-2019-3.1.8
   target: stgregistry.suse.com/rancher/fluent-bit:windows-2019-3.1.8
   type: image
 - source: fluent/fluent-bit:windows-2022-3.1.8
   target: stgregistry.suse.com/rancher/fluent-bit:windows-2022-3.1.8
+  type: image
+- source: fluent/fluent-bit:windows-2019-3.1.8
+  target: stgregistry.suse.com/rancher/charts/fluent-bit:windows-2019-3.1.8
+  type: image
+- source: fluent/fluent-bit:windows-2022-3.1.8
+  target: stgregistry.suse.com/rancher/charts/fluent-bit:windows-2022-3.1.8
   type: image
 - source: fluent/fluent-bit:1.5.4
   target: docker.io/rancher/fluent-fluent-bit:1.5.4
@@ -1137,6 +1835,33 @@ sync:
   target: registry.suse.com/rancher/fluent-fluent-bit:1.8.5-debug
   type: image
 - source: fluent/fluent-bit:1.5.4
+  target: registry.suse.com/rancher/charts/fluent-fluent-bit:1.5.4
+  type: image
+- source: fluent/fluent-bit:1.5.4-debug
+  target: registry.suse.com/rancher/charts/fluent-fluent-bit:1.5.4-debug
+  type: image
+- source: fluent/fluent-bit:1.6.1
+  target: registry.suse.com/rancher/charts/fluent-fluent-bit:1.6.1
+  type: image
+- source: fluent/fluent-bit:1.6.1-debug
+  target: registry.suse.com/rancher/charts/fluent-fluent-bit:1.6.1-debug
+  type: image
+- source: fluent/fluent-bit:1.6.10
+  target: registry.suse.com/rancher/charts/fluent-fluent-bit:1.6.10
+  type: image
+- source: fluent/fluent-bit:1.6.10-debug
+  target: registry.suse.com/rancher/charts/fluent-fluent-bit:1.6.10-debug
+  type: image
+- source: fluent/fluent-bit:1.6.4
+  target: registry.suse.com/rancher/charts/fluent-fluent-bit:1.6.4
+  type: image
+- source: fluent/fluent-bit:1.6.4-debug
+  target: registry.suse.com/rancher/charts/fluent-fluent-bit:1.6.4-debug
+  type: image
+- source: fluent/fluent-bit:1.8.5-debug
+  target: registry.suse.com/rancher/charts/fluent-fluent-bit:1.8.5-debug
+  type: image
+- source: fluent/fluent-bit:1.5.4
   target: stgregistry.suse.com/rancher/fluent-fluent-bit:1.5.4
   type: image
 - source: fluent/fluent-bit:1.5.4-debug
@@ -1162,6 +1887,33 @@ sync:
   type: image
 - source: fluent/fluent-bit:1.8.5-debug
   target: stgregistry.suse.com/rancher/fluent-fluent-bit:1.8.5-debug
+  type: image
+- source: fluent/fluent-bit:1.5.4
+  target: stgregistry.suse.com/rancher/charts/fluent-fluent-bit:1.5.4
+  type: image
+- source: fluent/fluent-bit:1.5.4-debug
+  target: stgregistry.suse.com/rancher/charts/fluent-fluent-bit:1.5.4-debug
+  type: image
+- source: fluent/fluent-bit:1.6.1
+  target: stgregistry.suse.com/rancher/charts/fluent-fluent-bit:1.6.1
+  type: image
+- source: fluent/fluent-bit:1.6.1-debug
+  target: stgregistry.suse.com/rancher/charts/fluent-fluent-bit:1.6.1-debug
+  type: image
+- source: fluent/fluent-bit:1.6.10
+  target: stgregistry.suse.com/rancher/charts/fluent-fluent-bit:1.6.10
+  type: image
+- source: fluent/fluent-bit:1.6.10-debug
+  target: stgregistry.suse.com/rancher/charts/fluent-fluent-bit:1.6.10-debug
+  type: image
+- source: fluent/fluent-bit:1.6.4
+  target: stgregistry.suse.com/rancher/charts/fluent-fluent-bit:1.6.4
+  type: image
+- source: fluent/fluent-bit:1.6.4-debug
+  target: stgregistry.suse.com/rancher/charts/fluent-fluent-bit:1.6.4-debug
+  type: image
+- source: fluent/fluent-bit:1.8.5-debug
+  target: stgregistry.suse.com/rancher/charts/fluent-fluent-bit:1.8.5-debug
   type: image
 - source: fluent/fluent-bit:1.6.10
   target: docker.io/rancher/mirrored-fluent-fluent-bit:1.6.10
@@ -1320,6 +2072,84 @@ sync:
   target: registry.suse.com/rancher/mirrored-fluent-fluent-bit:3.1.8-debug
   type: image
 - source: fluent/fluent-bit:1.6.10
+  target: registry.suse.com/rancher/charts/mirrored-fluent-fluent-bit:1.6.10
+  type: image
+- source: fluent/fluent-bit:1.6.10-debug
+  target: registry.suse.com/rancher/charts/mirrored-fluent-fluent-bit:1.6.10-debug
+  type: image
+- source: fluent/fluent-bit:1.7.4
+  target: registry.suse.com/rancher/charts/mirrored-fluent-fluent-bit:1.7.4
+  type: image
+- source: fluent/fluent-bit:1.7.4-debug
+  target: registry.suse.com/rancher/charts/mirrored-fluent-fluent-bit:1.7.4-debug
+  type: image
+- source: fluent/fluent-bit:1.7.9
+  target: registry.suse.com/rancher/charts/mirrored-fluent-fluent-bit:1.7.9
+  type: image
+- source: fluent/fluent-bit:1.7.9-debug
+  target: registry.suse.com/rancher/charts/mirrored-fluent-fluent-bit:1.7.9-debug
+  type: image
+- source: fluent/fluent-bit:1.8.15
+  target: registry.suse.com/rancher/charts/mirrored-fluent-fluent-bit:1.8.15
+  type: image
+- source: fluent/fluent-bit:1.8.15-debug
+  target: registry.suse.com/rancher/charts/mirrored-fluent-fluent-bit:1.8.15-debug
+  type: image
+- source: fluent/fluent-bit:1.8.5
+  target: registry.suse.com/rancher/charts/mirrored-fluent-fluent-bit:1.8.5
+  type: image
+- source: fluent/fluent-bit:1.8.5-debug
+  target: registry.suse.com/rancher/charts/mirrored-fluent-fluent-bit:1.8.5-debug
+  type: image
+- source: fluent/fluent-bit:1.8.7
+  target: registry.suse.com/rancher/charts/mirrored-fluent-fluent-bit:1.8.7
+  type: image
+- source: fluent/fluent-bit:1.8.7-debug
+  target: registry.suse.com/rancher/charts/mirrored-fluent-fluent-bit:1.8.7-debug
+  type: image
+- source: fluent/fluent-bit:1.8.8
+  target: registry.suse.com/rancher/charts/mirrored-fluent-fluent-bit:1.8.8
+  type: image
+- source: fluent/fluent-bit:1.8.8-debug
+  target: registry.suse.com/rancher/charts/mirrored-fluent-fluent-bit:1.8.8-debug
+  type: image
+- source: fluent/fluent-bit:1.8.9
+  target: registry.suse.com/rancher/charts/mirrored-fluent-fluent-bit:1.8.9
+  type: image
+- source: fluent/fluent-bit:1.8.9-debug
+  target: registry.suse.com/rancher/charts/mirrored-fluent-fluent-bit:1.8.9-debug
+  type: image
+- source: fluent/fluent-bit:1.9.3
+  target: registry.suse.com/rancher/charts/mirrored-fluent-fluent-bit:1.9.3
+  type: image
+- source: fluent/fluent-bit:1.9.3-debug
+  target: registry.suse.com/rancher/charts/mirrored-fluent-fluent-bit:1.9.3-debug
+  type: image
+- source: fluent/fluent-bit:1.9.5
+  target: registry.suse.com/rancher/charts/mirrored-fluent-fluent-bit:1.9.5
+  type: image
+- source: fluent/fluent-bit:1.9.5-debug
+  target: registry.suse.com/rancher/charts/mirrored-fluent-fluent-bit:1.9.5-debug
+  type: image
+- source: fluent/fluent-bit:2.2.0
+  target: registry.suse.com/rancher/charts/mirrored-fluent-fluent-bit:2.2.0
+  type: image
+- source: fluent/fluent-bit:2.2.0-debug
+  target: registry.suse.com/rancher/charts/mirrored-fluent-fluent-bit:2.2.0-debug
+  type: image
+- source: fluent/fluent-bit:3.0.4
+  target: registry.suse.com/rancher/charts/mirrored-fluent-fluent-bit:3.0.4
+  type: image
+- source: fluent/fluent-bit:3.0.4-debug
+  target: registry.suse.com/rancher/charts/mirrored-fluent-fluent-bit:3.0.4-debug
+  type: image
+- source: fluent/fluent-bit:3.1.8
+  target: registry.suse.com/rancher/charts/mirrored-fluent-fluent-bit:3.1.8
+  type: image
+- source: fluent/fluent-bit:3.1.8-debug
+  target: registry.suse.com/rancher/charts/mirrored-fluent-fluent-bit:3.1.8-debug
+  type: image
+- source: fluent/fluent-bit:1.6.10
   target: stgregistry.suse.com/rancher/mirrored-fluent-fluent-bit:1.6.10
   type: image
 - source: fluent/fluent-bit:1.6.10-debug
@@ -1397,6 +2227,84 @@ sync:
 - source: fluent/fluent-bit:3.1.8-debug
   target: stgregistry.suse.com/rancher/mirrored-fluent-fluent-bit:3.1.8-debug
   type: image
+- source: fluent/fluent-bit:1.6.10
+  target: stgregistry.suse.com/rancher/charts/mirrored-fluent-fluent-bit:1.6.10
+  type: image
+- source: fluent/fluent-bit:1.6.10-debug
+  target: stgregistry.suse.com/rancher/charts/mirrored-fluent-fluent-bit:1.6.10-debug
+  type: image
+- source: fluent/fluent-bit:1.7.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-fluent-fluent-bit:1.7.4
+  type: image
+- source: fluent/fluent-bit:1.7.4-debug
+  target: stgregistry.suse.com/rancher/charts/mirrored-fluent-fluent-bit:1.7.4-debug
+  type: image
+- source: fluent/fluent-bit:1.7.9
+  target: stgregistry.suse.com/rancher/charts/mirrored-fluent-fluent-bit:1.7.9
+  type: image
+- source: fluent/fluent-bit:1.7.9-debug
+  target: stgregistry.suse.com/rancher/charts/mirrored-fluent-fluent-bit:1.7.9-debug
+  type: image
+- source: fluent/fluent-bit:1.8.15
+  target: stgregistry.suse.com/rancher/charts/mirrored-fluent-fluent-bit:1.8.15
+  type: image
+- source: fluent/fluent-bit:1.8.15-debug
+  target: stgregistry.suse.com/rancher/charts/mirrored-fluent-fluent-bit:1.8.15-debug
+  type: image
+- source: fluent/fluent-bit:1.8.5
+  target: stgregistry.suse.com/rancher/charts/mirrored-fluent-fluent-bit:1.8.5
+  type: image
+- source: fluent/fluent-bit:1.8.5-debug
+  target: stgregistry.suse.com/rancher/charts/mirrored-fluent-fluent-bit:1.8.5-debug
+  type: image
+- source: fluent/fluent-bit:1.8.7
+  target: stgregistry.suse.com/rancher/charts/mirrored-fluent-fluent-bit:1.8.7
+  type: image
+- source: fluent/fluent-bit:1.8.7-debug
+  target: stgregistry.suse.com/rancher/charts/mirrored-fluent-fluent-bit:1.8.7-debug
+  type: image
+- source: fluent/fluent-bit:1.8.8
+  target: stgregistry.suse.com/rancher/charts/mirrored-fluent-fluent-bit:1.8.8
+  type: image
+- source: fluent/fluent-bit:1.8.8-debug
+  target: stgregistry.suse.com/rancher/charts/mirrored-fluent-fluent-bit:1.8.8-debug
+  type: image
+- source: fluent/fluent-bit:1.8.9
+  target: stgregistry.suse.com/rancher/charts/mirrored-fluent-fluent-bit:1.8.9
+  type: image
+- source: fluent/fluent-bit:1.8.9-debug
+  target: stgregistry.suse.com/rancher/charts/mirrored-fluent-fluent-bit:1.8.9-debug
+  type: image
+- source: fluent/fluent-bit:1.9.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-fluent-fluent-bit:1.9.3
+  type: image
+- source: fluent/fluent-bit:1.9.3-debug
+  target: stgregistry.suse.com/rancher/charts/mirrored-fluent-fluent-bit:1.9.3-debug
+  type: image
+- source: fluent/fluent-bit:1.9.5
+  target: stgregistry.suse.com/rancher/charts/mirrored-fluent-fluent-bit:1.9.5
+  type: image
+- source: fluent/fluent-bit:1.9.5-debug
+  target: stgregistry.suse.com/rancher/charts/mirrored-fluent-fluent-bit:1.9.5-debug
+  type: image
+- source: fluent/fluent-bit:2.2.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-fluent-fluent-bit:2.2.0
+  type: image
+- source: fluent/fluent-bit:2.2.0-debug
+  target: stgregistry.suse.com/rancher/charts/mirrored-fluent-fluent-bit:2.2.0-debug
+  type: image
+- source: fluent/fluent-bit:3.0.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-fluent-fluent-bit:3.0.4
+  type: image
+- source: fluent/fluent-bit:3.0.4-debug
+  target: stgregistry.suse.com/rancher/charts/mirrored-fluent-fluent-bit:3.0.4-debug
+  type: image
+- source: fluent/fluent-bit:3.1.8
+  target: stgregistry.suse.com/rancher/charts/mirrored-fluent-fluent-bit:3.1.8
+  type: image
+- source: fluent/fluent-bit:3.1.8-debug
+  target: stgregistry.suse.com/rancher/charts/mirrored-fluent-fluent-bit:3.1.8-debug
+  type: image
 - source: gcr.io/google-containers/k8s-dns-node-cache:1.15.13
   target: docker.io/rancher/mirrored-k8s-dns-node-cache:1.15.13
   type: image
@@ -1410,10 +2318,22 @@ sync:
   target: registry.suse.com/rancher/mirrored-k8s-dns-node-cache:1.15.7
   type: image
 - source: gcr.io/google-containers/k8s-dns-node-cache:1.15.13
+  target: registry.suse.com/rancher/charts/mirrored-k8s-dns-node-cache:1.15.13
+  type: image
+- source: gcr.io/google-containers/k8s-dns-node-cache:1.15.7
+  target: registry.suse.com/rancher/charts/mirrored-k8s-dns-node-cache:1.15.7
+  type: image
+- source: gcr.io/google-containers/k8s-dns-node-cache:1.15.13
   target: stgregistry.suse.com/rancher/mirrored-k8s-dns-node-cache:1.15.13
   type: image
 - source: gcr.io/google-containers/k8s-dns-node-cache:1.15.7
   target: stgregistry.suse.com/rancher/mirrored-k8s-dns-node-cache:1.15.7
+  type: image
+- source: gcr.io/google-containers/k8s-dns-node-cache:1.15.13
+  target: stgregistry.suse.com/rancher/charts/mirrored-k8s-dns-node-cache:1.15.13
+  type: image
+- source: gcr.io/google-containers/k8s-dns-node-cache:1.15.7
+  target: stgregistry.suse.com/rancher/charts/mirrored-k8s-dns-node-cache:1.15.7
   type: image
 - source: gcr.io/google_containers/k8s-dns-dnsmasq-nanny:1.15.0
   target: docker.io/rancher/mirrored-k8s-dns-dnsmasq-nanny:1.15.0
@@ -1434,6 +2354,15 @@ sync:
   target: registry.suse.com/rancher/mirrored-k8s-dns-dnsmasq-nanny:1.15.2
   type: image
 - source: gcr.io/google_containers/k8s-dns-dnsmasq-nanny:1.15.0
+  target: registry.suse.com/rancher/charts/mirrored-k8s-dns-dnsmasq-nanny:1.15.0
+  type: image
+- source: gcr.io/google_containers/k8s-dns-dnsmasq-nanny:1.15.10
+  target: registry.suse.com/rancher/charts/mirrored-k8s-dns-dnsmasq-nanny:1.15.10
+  type: image
+- source: gcr.io/google_containers/k8s-dns-dnsmasq-nanny:1.15.2
+  target: registry.suse.com/rancher/charts/mirrored-k8s-dns-dnsmasq-nanny:1.15.2
+  type: image
+- source: gcr.io/google_containers/k8s-dns-dnsmasq-nanny:1.15.0
   target: stgregistry.suse.com/rancher/mirrored-k8s-dns-dnsmasq-nanny:1.15.0
   type: image
 - source: gcr.io/google_containers/k8s-dns-dnsmasq-nanny:1.15.10
@@ -1441,6 +2370,15 @@ sync:
   type: image
 - source: gcr.io/google_containers/k8s-dns-dnsmasq-nanny:1.15.2
   target: stgregistry.suse.com/rancher/mirrored-k8s-dns-dnsmasq-nanny:1.15.2
+  type: image
+- source: gcr.io/google_containers/k8s-dns-dnsmasq-nanny:1.15.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-k8s-dns-dnsmasq-nanny:1.15.0
+  type: image
+- source: gcr.io/google_containers/k8s-dns-dnsmasq-nanny:1.15.10
+  target: stgregistry.suse.com/rancher/charts/mirrored-k8s-dns-dnsmasq-nanny:1.15.10
+  type: image
+- source: gcr.io/google_containers/k8s-dns-dnsmasq-nanny:1.15.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-k8s-dns-dnsmasq-nanny:1.15.2
   type: image
 - source: gcr.io/google_containers/k8s-dns-kube-dns:1.15.0
   target: docker.io/rancher/mirrored-k8s-dns-kube-dns:1.15.0
@@ -1461,6 +2399,15 @@ sync:
   target: registry.suse.com/rancher/mirrored-k8s-dns-kube-dns:1.15.2
   type: image
 - source: gcr.io/google_containers/k8s-dns-kube-dns:1.15.0
+  target: registry.suse.com/rancher/charts/mirrored-k8s-dns-kube-dns:1.15.0
+  type: image
+- source: gcr.io/google_containers/k8s-dns-kube-dns:1.15.10
+  target: registry.suse.com/rancher/charts/mirrored-k8s-dns-kube-dns:1.15.10
+  type: image
+- source: gcr.io/google_containers/k8s-dns-kube-dns:1.15.2
+  target: registry.suse.com/rancher/charts/mirrored-k8s-dns-kube-dns:1.15.2
+  type: image
+- source: gcr.io/google_containers/k8s-dns-kube-dns:1.15.0
   target: stgregistry.suse.com/rancher/mirrored-k8s-dns-kube-dns:1.15.0
   type: image
 - source: gcr.io/google_containers/k8s-dns-kube-dns:1.15.10
@@ -1468,6 +2415,15 @@ sync:
   type: image
 - source: gcr.io/google_containers/k8s-dns-kube-dns:1.15.2
   target: stgregistry.suse.com/rancher/mirrored-k8s-dns-kube-dns:1.15.2
+  type: image
+- source: gcr.io/google_containers/k8s-dns-kube-dns:1.15.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-k8s-dns-kube-dns:1.15.0
+  type: image
+- source: gcr.io/google_containers/k8s-dns-kube-dns:1.15.10
+  target: stgregistry.suse.com/rancher/charts/mirrored-k8s-dns-kube-dns:1.15.10
+  type: image
+- source: gcr.io/google_containers/k8s-dns-kube-dns:1.15.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-k8s-dns-kube-dns:1.15.2
   type: image
 - source: gcr.io/google_containers/k8s-dns-sidecar:1.15.0
   target: docker.io/rancher/mirrored-k8s-dns-sidecar:1.15.0
@@ -1488,6 +2444,15 @@ sync:
   target: registry.suse.com/rancher/mirrored-k8s-dns-sidecar:1.15.2
   type: image
 - source: gcr.io/google_containers/k8s-dns-sidecar:1.15.0
+  target: registry.suse.com/rancher/charts/mirrored-k8s-dns-sidecar:1.15.0
+  type: image
+- source: gcr.io/google_containers/k8s-dns-sidecar:1.15.10
+  target: registry.suse.com/rancher/charts/mirrored-k8s-dns-sidecar:1.15.10
+  type: image
+- source: gcr.io/google_containers/k8s-dns-sidecar:1.15.2
+  target: registry.suse.com/rancher/charts/mirrored-k8s-dns-sidecar:1.15.2
+  type: image
+- source: gcr.io/google_containers/k8s-dns-sidecar:1.15.0
   target: stgregistry.suse.com/rancher/mirrored-k8s-dns-sidecar:1.15.0
   type: image
 - source: gcr.io/google_containers/k8s-dns-sidecar:1.15.10
@@ -1495,6 +2460,15 @@ sync:
   type: image
 - source: gcr.io/google_containers/k8s-dns-sidecar:1.15.2
   target: stgregistry.suse.com/rancher/mirrored-k8s-dns-sidecar:1.15.2
+  type: image
+- source: gcr.io/google_containers/k8s-dns-sidecar:1.15.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-k8s-dns-sidecar:1.15.0
+  type: image
+- source: gcr.io/google_containers/k8s-dns-sidecar:1.15.10
+  target: stgregistry.suse.com/rancher/charts/mirrored-k8s-dns-sidecar:1.15.10
+  type: image
+- source: gcr.io/google_containers/k8s-dns-sidecar:1.15.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-k8s-dns-sidecar:1.15.2
   type: image
 - source: gcr.io/google_containers/pause:3.1
   target: docker.io/rancher/mirrored-pause:3.1
@@ -1509,10 +2483,22 @@ sync:
   target: registry.suse.com/rancher/mirrored-pause:3.2
   type: image
 - source: gcr.io/google_containers/pause:3.1
+  target: registry.suse.com/rancher/charts/mirrored-pause:3.1
+  type: image
+- source: gcr.io/google_containers/pause:3.2
+  target: registry.suse.com/rancher/charts/mirrored-pause:3.2
+  type: image
+- source: gcr.io/google_containers/pause:3.1
   target: stgregistry.suse.com/rancher/mirrored-pause:3.1
   type: image
 - source: gcr.io/google_containers/pause:3.2
   target: stgregistry.suse.com/rancher/mirrored-pause:3.2
+  type: image
+- source: gcr.io/google_containers/pause:3.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-pause:3.1
+  type: image
+- source: gcr.io/google_containers/pause:3.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-pause:3.2
   type: image
 - source: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
   target: docker.io/rancher/kube-rbac-proxy:v0.5.0
@@ -1521,7 +2507,13 @@ sync:
   target: registry.suse.com/rancher/kube-rbac-proxy:v0.5.0
   type: image
 - source: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
+  target: registry.suse.com/rancher/charts/kube-rbac-proxy:v0.5.0
+  type: image
+- source: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
   target: stgregistry.suse.com/rancher/kube-rbac-proxy:v0.5.0
+  type: image
+- source: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
+  target: stgregistry.suse.com/rancher/charts/kube-rbac-proxy:v0.5.0
   type: image
 - source: gcr.io/kubebuilder/kube-rbac-proxy:v0.14.0
   target: docker.io/rancher/mirrored-kube-rbac-proxy:v0.14.0
@@ -1542,6 +2534,15 @@ sync:
   target: registry.suse.com/rancher/mirrored-kube-rbac-proxy:v0.5.0
   type: image
 - source: gcr.io/kubebuilder/kube-rbac-proxy:v0.14.0
+  target: registry.suse.com/rancher/charts/mirrored-kube-rbac-proxy:v0.14.0
+  type: image
+- source: gcr.io/kubebuilder/kube-rbac-proxy:v0.15.0
+  target: registry.suse.com/rancher/charts/mirrored-kube-rbac-proxy:v0.15.0
+  type: image
+- source: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
+  target: registry.suse.com/rancher/charts/mirrored-kube-rbac-proxy:v0.5.0
+  type: image
+- source: gcr.io/kubebuilder/kube-rbac-proxy:v0.14.0
   target: stgregistry.suse.com/rancher/mirrored-kube-rbac-proxy:v0.14.0
   type: image
 - source: gcr.io/kubebuilder/kube-rbac-proxy:v0.15.0
@@ -1549,6 +2550,15 @@ sync:
   type: image
 - source: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
   target: stgregistry.suse.com/rancher/mirrored-kube-rbac-proxy:v0.5.0
+  type: image
+- source: gcr.io/kubebuilder/kube-rbac-proxy:v0.14.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-kube-rbac-proxy:v0.14.0
+  type: image
+- source: gcr.io/kubebuilder/kube-rbac-proxy:v0.15.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-kube-rbac-proxy:v0.15.0
+  type: image
+- source: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-kube-rbac-proxy:v0.5.0
   type: image
 - source: ghcr.io/banzaicloud/fluentd:v1.12.4-alpine-1
   target: docker.io/rancher/mirrored-banzaicloud-fluentd:v1.12.4-alpine-1
@@ -1587,6 +2597,24 @@ sync:
   target: registry.suse.com/rancher/mirrored-banzaicloud-fluentd:v1.14.6-alpine-5
   type: image
 - source: ghcr.io/banzaicloud/fluentd:v1.12.4-alpine-1
+  target: registry.suse.com/rancher/charts/mirrored-banzaicloud-fluentd:v1.12.4-alpine-1
+  type: image
+- source: ghcr.io/banzaicloud/fluentd:v1.13.3-alpine-1
+  target: registry.suse.com/rancher/charts/mirrored-banzaicloud-fluentd:v1.13.3-alpine-1
+  type: image
+- source: ghcr.io/banzaicloud/fluentd:v1.13.3-alpine-11
+  target: registry.suse.com/rancher/charts/mirrored-banzaicloud-fluentd:v1.13.3-alpine-11
+  type: image
+- source: ghcr.io/banzaicloud/fluentd:v1.14.4-alpine-2
+  target: registry.suse.com/rancher/charts/mirrored-banzaicloud-fluentd:v1.14.4-alpine-2
+  type: image
+- source: ghcr.io/banzaicloud/fluentd:v1.14.5-alpine-1
+  target: registry.suse.com/rancher/charts/mirrored-banzaicloud-fluentd:v1.14.5-alpine-1
+  type: image
+- source: ghcr.io/banzaicloud/fluentd:v1.14.6-alpine-5
+  target: registry.suse.com/rancher/charts/mirrored-banzaicloud-fluentd:v1.14.6-alpine-5
+  type: image
+- source: ghcr.io/banzaicloud/fluentd:v1.12.4-alpine-1
   target: stgregistry.suse.com/rancher/mirrored-banzaicloud-fluentd:v1.12.4-alpine-1
   type: image
 - source: ghcr.io/banzaicloud/fluentd:v1.13.3-alpine-1
@@ -1603,6 +2631,24 @@ sync:
   type: image
 - source: ghcr.io/banzaicloud/fluentd:v1.14.6-alpine-5
   target: stgregistry.suse.com/rancher/mirrored-banzaicloud-fluentd:v1.14.6-alpine-5
+  type: image
+- source: ghcr.io/banzaicloud/fluentd:v1.12.4-alpine-1
+  target: stgregistry.suse.com/rancher/charts/mirrored-banzaicloud-fluentd:v1.12.4-alpine-1
+  type: image
+- source: ghcr.io/banzaicloud/fluentd:v1.13.3-alpine-1
+  target: stgregistry.suse.com/rancher/charts/mirrored-banzaicloud-fluentd:v1.13.3-alpine-1
+  type: image
+- source: ghcr.io/banzaicloud/fluentd:v1.13.3-alpine-11
+  target: stgregistry.suse.com/rancher/charts/mirrored-banzaicloud-fluentd:v1.13.3-alpine-11
+  type: image
+- source: ghcr.io/banzaicloud/fluentd:v1.14.4-alpine-2
+  target: stgregistry.suse.com/rancher/charts/mirrored-banzaicloud-fluentd:v1.14.4-alpine-2
+  type: image
+- source: ghcr.io/banzaicloud/fluentd:v1.14.5-alpine-1
+  target: stgregistry.suse.com/rancher/charts/mirrored-banzaicloud-fluentd:v1.14.5-alpine-1
+  type: image
+- source: ghcr.io/banzaicloud/fluentd:v1.14.6-alpine-5
+  target: stgregistry.suse.com/rancher/charts/mirrored-banzaicloud-fluentd:v1.14.6-alpine-5
   type: image
 - source: ghcr.io/banzaicloud/logging-operator:3.14.0
   target: docker.io/rancher/mirrored-banzaicloud-logging-operator:3.14.0
@@ -1659,6 +2705,33 @@ sync:
   target: registry.suse.com/rancher/mirrored-banzaicloud-logging-operator:3.17.9
   type: image
 - source: ghcr.io/banzaicloud/logging-operator:3.14.0
+  target: registry.suse.com/rancher/charts/mirrored-banzaicloud-logging-operator:3.14.0
+  type: image
+- source: ghcr.io/banzaicloud/logging-operator:3.15.0
+  target: registry.suse.com/rancher/charts/mirrored-banzaicloud-logging-operator:3.15.0
+  type: image
+- source: ghcr.io/banzaicloud/logging-operator:3.17.1
+  target: registry.suse.com/rancher/charts/mirrored-banzaicloud-logging-operator:3.17.1
+  type: image
+- source: ghcr.io/banzaicloud/logging-operator:3.17.10
+  target: registry.suse.com/rancher/charts/mirrored-banzaicloud-logging-operator:3.17.10
+  type: image
+- source: ghcr.io/banzaicloud/logging-operator:3.17.3
+  target: registry.suse.com/rancher/charts/mirrored-banzaicloud-logging-operator:3.17.3
+  type: image
+- source: ghcr.io/banzaicloud/logging-operator:3.17.4
+  target: registry.suse.com/rancher/charts/mirrored-banzaicloud-logging-operator:3.17.4
+  type: image
+- source: ghcr.io/banzaicloud/logging-operator:3.17.7
+  target: registry.suse.com/rancher/charts/mirrored-banzaicloud-logging-operator:3.17.7
+  type: image
+- source: ghcr.io/banzaicloud/logging-operator:3.17.8
+  target: registry.suse.com/rancher/charts/mirrored-banzaicloud-logging-operator:3.17.8
+  type: image
+- source: ghcr.io/banzaicloud/logging-operator:3.17.9
+  target: registry.suse.com/rancher/charts/mirrored-banzaicloud-logging-operator:3.17.9
+  type: image
+- source: ghcr.io/banzaicloud/logging-operator:3.14.0
   target: stgregistry.suse.com/rancher/mirrored-banzaicloud-logging-operator:3.14.0
   type: image
 - source: ghcr.io/banzaicloud/logging-operator:3.15.0
@@ -1685,6 +2758,33 @@ sync:
 - source: ghcr.io/banzaicloud/logging-operator:3.17.9
   target: stgregistry.suse.com/rancher/mirrored-banzaicloud-logging-operator:3.17.9
   type: image
+- source: ghcr.io/banzaicloud/logging-operator:3.14.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-banzaicloud-logging-operator:3.14.0
+  type: image
+- source: ghcr.io/banzaicloud/logging-operator:3.15.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-banzaicloud-logging-operator:3.15.0
+  type: image
+- source: ghcr.io/banzaicloud/logging-operator:3.17.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-banzaicloud-logging-operator:3.17.1
+  type: image
+- source: ghcr.io/banzaicloud/logging-operator:3.17.10
+  target: stgregistry.suse.com/rancher/charts/mirrored-banzaicloud-logging-operator:3.17.10
+  type: image
+- source: ghcr.io/banzaicloud/logging-operator:3.17.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-banzaicloud-logging-operator:3.17.3
+  type: image
+- source: ghcr.io/banzaicloud/logging-operator:3.17.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-banzaicloud-logging-operator:3.17.4
+  type: image
+- source: ghcr.io/banzaicloud/logging-operator:3.17.7
+  target: stgregistry.suse.com/rancher/charts/mirrored-banzaicloud-logging-operator:3.17.7
+  type: image
+- source: ghcr.io/banzaicloud/logging-operator:3.17.8
+  target: stgregistry.suse.com/rancher/charts/mirrored-banzaicloud-logging-operator:3.17.8
+  type: image
+- source: ghcr.io/banzaicloud/logging-operator:3.17.9
+  target: stgregistry.suse.com/rancher/charts/mirrored-banzaicloud-logging-operator:3.17.9
+  type: image
 - source: ghcr.io/dexidp/dex:v2.35.3
   target: docker.io/rancher/mirrored-dexidp-dex:v2.35.3
   type: image
@@ -1704,6 +2804,15 @@ sync:
   target: registry.suse.com/rancher/mirrored-dexidp-dex:v2.37.0
   type: image
 - source: ghcr.io/dexidp/dex:v2.35.3
+  target: registry.suse.com/rancher/charts/mirrored-dexidp-dex:v2.35.3
+  type: image
+- source: ghcr.io/dexidp/dex:v2.36.0
+  target: registry.suse.com/rancher/charts/mirrored-dexidp-dex:v2.36.0
+  type: image
+- source: ghcr.io/dexidp/dex:v2.37.0
+  target: registry.suse.com/rancher/charts/mirrored-dexidp-dex:v2.37.0
+  type: image
+- source: ghcr.io/dexidp/dex:v2.35.3
   target: stgregistry.suse.com/rancher/mirrored-dexidp-dex:v2.35.3
   type: image
 - source: ghcr.io/dexidp/dex:v2.36.0
@@ -1711,6 +2820,15 @@ sync:
   type: image
 - source: ghcr.io/dexidp/dex:v2.37.0
   target: stgregistry.suse.com/rancher/mirrored-dexidp-dex:v2.37.0
+  type: image
+- source: ghcr.io/dexidp/dex:v2.35.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-dexidp-dex:v2.35.3
+  type: image
+- source: ghcr.io/dexidp/dex:v2.36.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-dexidp-dex:v2.36.0
+  type: image
+- source: ghcr.io/dexidp/dex:v2.37.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-dexidp-dex:v2.37.0
   type: image
 - source: ghcr.io/epinio/epinio-server:v0.7.1
   target: docker.io/rancher/mirrored-epinio-epinio-server:v0.7.1
@@ -1773,6 +2891,36 @@ sync:
   target: registry.suse.com/rancher/mirrored-epinio-epinio-server:v1.9.0
   type: image
 - source: ghcr.io/epinio/epinio-server:v0.7.1
+  target: registry.suse.com/rancher/charts/mirrored-epinio-epinio-server:v0.7.1
+  type: image
+- source: ghcr.io/epinio/epinio-server:v1.0.0
+  target: registry.suse.com/rancher/charts/mirrored-epinio-epinio-server:v1.0.0
+  type: image
+- source: ghcr.io/epinio/epinio-server:v1.10.0
+  target: registry.suse.com/rancher/charts/mirrored-epinio-epinio-server:v1.10.0
+  type: image
+- source: ghcr.io/epinio/epinio-server:v1.2.0
+  target: registry.suse.com/rancher/charts/mirrored-epinio-epinio-server:v1.2.0
+  type: image
+- source: ghcr.io/epinio/epinio-server:v1.4.0
+  target: registry.suse.com/rancher/charts/mirrored-epinio-epinio-server:v1.4.0
+  type: image
+- source: ghcr.io/epinio/epinio-server:v1.5.1
+  target: registry.suse.com/rancher/charts/mirrored-epinio-epinio-server:v1.5.1
+  type: image
+- source: ghcr.io/epinio/epinio-server:v1.6.1
+  target: registry.suse.com/rancher/charts/mirrored-epinio-epinio-server:v1.6.1
+  type: image
+- source: ghcr.io/epinio/epinio-server:v1.6.2
+  target: registry.suse.com/rancher/charts/mirrored-epinio-epinio-server:v1.6.2
+  type: image
+- source: ghcr.io/epinio/epinio-server:v1.8.1
+  target: registry.suse.com/rancher/charts/mirrored-epinio-epinio-server:v1.8.1
+  type: image
+- source: ghcr.io/epinio/epinio-server:v1.9.0
+  target: registry.suse.com/rancher/charts/mirrored-epinio-epinio-server:v1.9.0
+  type: image
+- source: ghcr.io/epinio/epinio-server:v0.7.1
   target: stgregistry.suse.com/rancher/mirrored-epinio-epinio-server:v0.7.1
   type: image
 - source: ghcr.io/epinio/epinio-server:v1.0.0
@@ -1801,6 +2949,36 @@ sync:
   type: image
 - source: ghcr.io/epinio/epinio-server:v1.9.0
   target: stgregistry.suse.com/rancher/mirrored-epinio-epinio-server:v1.9.0
+  type: image
+- source: ghcr.io/epinio/epinio-server:v0.7.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-epinio-epinio-server:v0.7.1
+  type: image
+- source: ghcr.io/epinio/epinio-server:v1.0.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-epinio-epinio-server:v1.0.0
+  type: image
+- source: ghcr.io/epinio/epinio-server:v1.10.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-epinio-epinio-server:v1.10.0
+  type: image
+- source: ghcr.io/epinio/epinio-server:v1.2.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-epinio-epinio-server:v1.2.0
+  type: image
+- source: ghcr.io/epinio/epinio-server:v1.4.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-epinio-epinio-server:v1.4.0
+  type: image
+- source: ghcr.io/epinio/epinio-server:v1.5.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-epinio-epinio-server:v1.5.1
+  type: image
+- source: ghcr.io/epinio/epinio-server:v1.6.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-epinio-epinio-server:v1.6.1
+  type: image
+- source: ghcr.io/epinio/epinio-server:v1.6.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-epinio-epinio-server:v1.6.2
+  type: image
+- source: ghcr.io/epinio/epinio-server:v1.8.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-epinio-epinio-server:v1.8.1
+  type: image
+- source: ghcr.io/epinio/epinio-server:v1.9.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-epinio-epinio-server:v1.9.0
   type: image
 - source: ghcr.io/epinio/epinio-ui:v0.6.2-0.0.1
   target: docker.io/rancher/mirrored-epinio-epinio-ui:v0.6.2-0.0.1
@@ -1845,6 +3023,27 @@ sync:
   target: registry.suse.com/rancher/mirrored-epinio-epinio-ui:v1.9.0-0.0.3
   type: image
 - source: ghcr.io/epinio/epinio-ui:v0.6.2-0.0.1
+  target: registry.suse.com/rancher/charts/mirrored-epinio-epinio-ui:v0.6.2-0.0.1
+  type: image
+- source: ghcr.io/epinio/epinio-ui:v1.0.0-0.0.4
+  target: registry.suse.com/rancher/charts/mirrored-epinio-epinio-ui:v1.0.0-0.0.4
+  type: image
+- source: ghcr.io/epinio/epinio-ui:v1.10.0-0.0.1
+  target: registry.suse.com/rancher/charts/mirrored-epinio-epinio-ui:v1.10.0-0.0.1
+  type: image
+- source: ghcr.io/epinio/epinio-ui:v1.2.0-0.0.1
+  target: registry.suse.com/rancher/charts/mirrored-epinio-epinio-ui:v1.2.0-0.0.1
+  type: image
+- source: ghcr.io/epinio/epinio-ui:v1.5.1-0.0.3
+  target: registry.suse.com/rancher/charts/mirrored-epinio-epinio-ui:v1.5.1-0.0.3
+  type: image
+- source: ghcr.io/epinio/epinio-ui:v1.8.1-0.0.1
+  target: registry.suse.com/rancher/charts/mirrored-epinio-epinio-ui:v1.8.1-0.0.1
+  type: image
+- source: ghcr.io/epinio/epinio-ui:v1.9.0-0.0.3
+  target: registry.suse.com/rancher/charts/mirrored-epinio-epinio-ui:v1.9.0-0.0.3
+  type: image
+- source: ghcr.io/epinio/epinio-ui:v0.6.2-0.0.1
   target: stgregistry.suse.com/rancher/mirrored-epinio-epinio-ui:v0.6.2-0.0.1
   type: image
 - source: ghcr.io/epinio/epinio-ui:v1.0.0-0.0.4
@@ -1864,6 +3063,27 @@ sync:
   type: image
 - source: ghcr.io/epinio/epinio-ui:v1.9.0-0.0.3
   target: stgregistry.suse.com/rancher/mirrored-epinio-epinio-ui:v1.9.0-0.0.3
+  type: image
+- source: ghcr.io/epinio/epinio-ui:v0.6.2-0.0.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-epinio-epinio-ui:v0.6.2-0.0.1
+  type: image
+- source: ghcr.io/epinio/epinio-ui:v1.0.0-0.0.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-epinio-epinio-ui:v1.0.0-0.0.4
+  type: image
+- source: ghcr.io/epinio/epinio-ui:v1.10.0-0.0.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-epinio-epinio-ui:v1.10.0-0.0.1
+  type: image
+- source: ghcr.io/epinio/epinio-ui:v1.2.0-0.0.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-epinio-epinio-ui:v1.2.0-0.0.1
+  type: image
+- source: ghcr.io/epinio/epinio-ui:v1.5.1-0.0.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-epinio-epinio-ui:v1.5.1-0.0.3
+  type: image
+- source: ghcr.io/epinio/epinio-ui:v1.8.1-0.0.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-epinio-epinio-ui:v1.8.1-0.0.1
+  type: image
+- source: ghcr.io/epinio/epinio-ui:v1.9.0-0.0.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-epinio-epinio-ui:v1.9.0-0.0.3
   type: image
 - source: ghcr.io/epinio/epinio-unpacker:v1.10.0
   target: docker.io/rancher/mirrored-epinio-epinio-unpacker:v1.10.0
@@ -1896,6 +3116,21 @@ sync:
   target: registry.suse.com/rancher/mirrored-epinio-epinio-unpacker:v1.9.0
   type: image
 - source: ghcr.io/epinio/epinio-unpacker:v1.10.0
+  target: registry.suse.com/rancher/charts/mirrored-epinio-epinio-unpacker:v1.10.0
+  type: image
+- source: ghcr.io/epinio/epinio-unpacker:v1.6.1
+  target: registry.suse.com/rancher/charts/mirrored-epinio-epinio-unpacker:v1.6.1
+  type: image
+- source: ghcr.io/epinio/epinio-unpacker:v1.6.2
+  target: registry.suse.com/rancher/charts/mirrored-epinio-epinio-unpacker:v1.6.2
+  type: image
+- source: ghcr.io/epinio/epinio-unpacker:v1.8.1
+  target: registry.suse.com/rancher/charts/mirrored-epinio-epinio-unpacker:v1.8.1
+  type: image
+- source: ghcr.io/epinio/epinio-unpacker:v1.9.0
+  target: registry.suse.com/rancher/charts/mirrored-epinio-epinio-unpacker:v1.9.0
+  type: image
+- source: ghcr.io/epinio/epinio-unpacker:v1.10.0
   target: stgregistry.suse.com/rancher/mirrored-epinio-epinio-unpacker:v1.10.0
   type: image
 - source: ghcr.io/epinio/epinio-unpacker:v1.6.1
@@ -1910,6 +3145,21 @@ sync:
 - source: ghcr.io/epinio/epinio-unpacker:v1.9.0
   target: stgregistry.suse.com/rancher/mirrored-epinio-epinio-unpacker:v1.9.0
   type: image
+- source: ghcr.io/epinio/epinio-unpacker:v1.10.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-epinio-epinio-unpacker:v1.10.0
+  type: image
+- source: ghcr.io/epinio/epinio-unpacker:v1.6.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-epinio-epinio-unpacker:v1.6.1
+  type: image
+- source: ghcr.io/epinio/epinio-unpacker:v1.6.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-epinio-epinio-unpacker:v1.6.2
+  type: image
+- source: ghcr.io/epinio/epinio-unpacker:v1.8.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-epinio-epinio-unpacker:v1.8.1
+  type: image
+- source: ghcr.io/epinio/epinio-unpacker:v1.9.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-epinio-epinio-unpacker:v1.9.0
+  type: image
 - source: ghcr.io/jimmidyson/configmap-reload:v0.13.1
   target: docker.io/rancher/mirrored-jimmidyson-configmap-reload:v0.13.1
   type: image
@@ -1917,7 +3167,13 @@ sync:
   target: registry.suse.com/rancher/mirrored-jimmidyson-configmap-reload:v0.13.1
   type: image
 - source: ghcr.io/jimmidyson/configmap-reload:v0.13.1
+  target: registry.suse.com/rancher/charts/mirrored-jimmidyson-configmap-reload:v0.13.1
+  type: image
+- source: ghcr.io/jimmidyson/configmap-reload:v0.13.1
   target: stgregistry.suse.com/rancher/mirrored-jimmidyson-configmap-reload:v0.13.1
+  type: image
+- source: ghcr.io/jimmidyson/configmap-reload:v0.13.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-jimmidyson-configmap-reload:v0.13.1
   type: image
 - source: ghcr.io/kube-logging/config-reloader:v0.0.5
   target: docker.io/rancher/mirrored-kube-logging-config-reloader:v0.0.5
@@ -1932,10 +3188,22 @@ sync:
   target: registry.suse.com/rancher/mirrored-kube-logging-config-reloader:v0.0.6
   type: image
 - source: ghcr.io/kube-logging/config-reloader:v0.0.5
+  target: registry.suse.com/rancher/charts/mirrored-kube-logging-config-reloader:v0.0.5
+  type: image
+- source: ghcr.io/kube-logging/config-reloader:v0.0.6
+  target: registry.suse.com/rancher/charts/mirrored-kube-logging-config-reloader:v0.0.6
+  type: image
+- source: ghcr.io/kube-logging/config-reloader:v0.0.5
   target: stgregistry.suse.com/rancher/mirrored-kube-logging-config-reloader:v0.0.5
   type: image
 - source: ghcr.io/kube-logging/config-reloader:v0.0.6
   target: stgregistry.suse.com/rancher/mirrored-kube-logging-config-reloader:v0.0.6
+  type: image
+- source: ghcr.io/kube-logging/config-reloader:v0.0.5
+  target: stgregistry.suse.com/rancher/charts/mirrored-kube-logging-config-reloader:v0.0.5
+  type: image
+- source: ghcr.io/kube-logging/config-reloader:v0.0.6
+  target: stgregistry.suse.com/rancher/charts/mirrored-kube-logging-config-reloader:v0.0.6
   type: image
 - source: ghcr.io/kube-logging/fluentd:v1.16-4.10-full
   target: docker.io/rancher/mirrored-kube-logging-fluentd:v1.16-4.10-full
@@ -1962,6 +3230,18 @@ sync:
   target: registry.suse.com/rancher/mirrored-kube-logging-fluentd:v1.16-ruby3.3-full-build.140
   type: image
 - source: ghcr.io/kube-logging/fluentd:v1.16-4.10-full
+  target: registry.suse.com/rancher/charts/mirrored-kube-logging-fluentd:v1.16-4.10-full
+  type: image
+- source: ghcr.io/kube-logging/fluentd:v1.16-4.11-full
+  target: registry.suse.com/rancher/charts/mirrored-kube-logging-fluentd:v1.16-4.11-full
+  type: image
+- source: ghcr.io/kube-logging/fluentd:v1.16-4.8-full
+  target: registry.suse.com/rancher/charts/mirrored-kube-logging-fluentd:v1.16-4.8-full
+  type: image
+- source: ghcr.io/kube-logging/fluentd:v1.16-ruby3.3-full-build.140
+  target: registry.suse.com/rancher/charts/mirrored-kube-logging-fluentd:v1.16-ruby3.3-full-build.140
+  type: image
+- source: ghcr.io/kube-logging/fluentd:v1.16-4.10-full
   target: stgregistry.suse.com/rancher/mirrored-kube-logging-fluentd:v1.16-4.10-full
   type: image
 - source: ghcr.io/kube-logging/fluentd:v1.16-4.11-full
@@ -1972,6 +3252,18 @@ sync:
   type: image
 - source: ghcr.io/kube-logging/fluentd:v1.16-ruby3.3-full-build.140
   target: stgregistry.suse.com/rancher/mirrored-kube-logging-fluentd:v1.16-ruby3.3-full-build.140
+  type: image
+- source: ghcr.io/kube-logging/fluentd:v1.16-4.10-full
+  target: stgregistry.suse.com/rancher/charts/mirrored-kube-logging-fluentd:v1.16-4.10-full
+  type: image
+- source: ghcr.io/kube-logging/fluentd:v1.16-4.11-full
+  target: stgregistry.suse.com/rancher/charts/mirrored-kube-logging-fluentd:v1.16-4.11-full
+  type: image
+- source: ghcr.io/kube-logging/fluentd:v1.16-4.8-full
+  target: stgregistry.suse.com/rancher/charts/mirrored-kube-logging-fluentd:v1.16-4.8-full
+  type: image
+- source: ghcr.io/kube-logging/fluentd:v1.16-ruby3.3-full-build.140
+  target: stgregistry.suse.com/rancher/charts/mirrored-kube-logging-fluentd:v1.16-ruby3.3-full-build.140
   type: image
 - source: ghcr.io/kube-logging/logging-operator:4.10.0
   target: docker.io/rancher/mirrored-kube-logging-logging-operator:4.10.0
@@ -2004,6 +3296,21 @@ sync:
   target: registry.suse.com/rancher/mirrored-kube-logging-logging-operator:4.9.1
   type: image
 - source: ghcr.io/kube-logging/logging-operator:4.10.0
+  target: registry.suse.com/rancher/charts/mirrored-kube-logging-logging-operator:4.10.0
+  type: image
+- source: ghcr.io/kube-logging/logging-operator:4.11.4
+  target: registry.suse.com/rancher/charts/mirrored-kube-logging-logging-operator:4.11.4
+  type: image
+- source: ghcr.io/kube-logging/logging-operator:4.4.0
+  target: registry.suse.com/rancher/charts/mirrored-kube-logging-logging-operator:4.4.0
+  type: image
+- source: ghcr.io/kube-logging/logging-operator:4.8.0
+  target: registry.suse.com/rancher/charts/mirrored-kube-logging-logging-operator:4.8.0
+  type: image
+- source: ghcr.io/kube-logging/logging-operator:4.9.1
+  target: registry.suse.com/rancher/charts/mirrored-kube-logging-logging-operator:4.9.1
+  type: image
+- source: ghcr.io/kube-logging/logging-operator:4.10.0
   target: stgregistry.suse.com/rancher/mirrored-kube-logging-logging-operator:4.10.0
   type: image
 - source: ghcr.io/kube-logging/logging-operator:4.11.4
@@ -2017,6 +3324,21 @@ sync:
   type: image
 - source: ghcr.io/kube-logging/logging-operator:4.9.1
   target: stgregistry.suse.com/rancher/mirrored-kube-logging-logging-operator:4.9.1
+  type: image
+- source: ghcr.io/kube-logging/logging-operator:4.10.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-kube-logging-logging-operator:4.10.0
+  type: image
+- source: ghcr.io/kube-logging/logging-operator:4.11.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-kube-logging-logging-operator:4.11.4
+  type: image
+- source: ghcr.io/kube-logging/logging-operator:4.4.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-kube-logging-logging-operator:4.4.0
+  type: image
+- source: ghcr.io/kube-logging/logging-operator:4.8.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-kube-logging-logging-operator:4.8.0
+  type: image
+- source: ghcr.io/kube-logging/logging-operator:4.9.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-kube-logging-logging-operator:4.9.1
   type: image
 - source: ghcr.io/kube-vip/kube-vip-iptables:v0.6.0
   target: docker.io/rancher/mirrored-kube-vip-kube-vip-iptables:v0.6.0
@@ -2091,6 +3413,42 @@ sync:
   target: registry.suse.com/rancher/mirrored-kube-vip-kube-vip-iptables:v1.0.1
   type: image
 - source: ghcr.io/kube-vip/kube-vip-iptables:v0.6.0
+  target: registry.suse.com/rancher/charts/mirrored-kube-vip-kube-vip-iptables:v0.6.0
+  type: image
+- source: ghcr.io/kube-vip/kube-vip-iptables:v0.8.10
+  target: registry.suse.com/rancher/charts/mirrored-kube-vip-kube-vip-iptables:v0.8.10
+  type: image
+- source: ghcr.io/kube-vip/kube-vip-iptables:v0.8.4
+  target: registry.suse.com/rancher/charts/mirrored-kube-vip-kube-vip-iptables:v0.8.4
+  type: image
+- source: ghcr.io/kube-vip/kube-vip-iptables:v0.8.6
+  target: registry.suse.com/rancher/charts/mirrored-kube-vip-kube-vip-iptables:v0.8.6
+  type: image
+- source: ghcr.io/kube-vip/kube-vip-iptables:v0.8.7
+  target: registry.suse.com/rancher/charts/mirrored-kube-vip-kube-vip-iptables:v0.8.7
+  type: image
+- source: ghcr.io/kube-vip/kube-vip-iptables:v0.8.8
+  target: registry.suse.com/rancher/charts/mirrored-kube-vip-kube-vip-iptables:v0.8.8
+  type: image
+- source: ghcr.io/kube-vip/kube-vip-iptables:v0.8.9
+  target: registry.suse.com/rancher/charts/mirrored-kube-vip-kube-vip-iptables:v0.8.9
+  type: image
+- source: ghcr.io/kube-vip/kube-vip-iptables:v0.9.0
+  target: registry.suse.com/rancher/charts/mirrored-kube-vip-kube-vip-iptables:v0.9.0
+  type: image
+- source: ghcr.io/kube-vip/kube-vip-iptables:v0.9.1
+  target: registry.suse.com/rancher/charts/mirrored-kube-vip-kube-vip-iptables:v0.9.1
+  type: image
+- source: ghcr.io/kube-vip/kube-vip-iptables:v0.9.2
+  target: registry.suse.com/rancher/charts/mirrored-kube-vip-kube-vip-iptables:v0.9.2
+  type: image
+- source: ghcr.io/kube-vip/kube-vip-iptables:v1.0.0
+  target: registry.suse.com/rancher/charts/mirrored-kube-vip-kube-vip-iptables:v1.0.0
+  type: image
+- source: ghcr.io/kube-vip/kube-vip-iptables:v1.0.1
+  target: registry.suse.com/rancher/charts/mirrored-kube-vip-kube-vip-iptables:v1.0.1
+  type: image
+- source: ghcr.io/kube-vip/kube-vip-iptables:v0.6.0
   target: stgregistry.suse.com/rancher/mirrored-kube-vip-kube-vip-iptables:v0.6.0
   type: image
 - source: ghcr.io/kube-vip/kube-vip-iptables:v0.8.10
@@ -2126,6 +3484,42 @@ sync:
 - source: ghcr.io/kube-vip/kube-vip-iptables:v1.0.1
   target: stgregistry.suse.com/rancher/mirrored-kube-vip-kube-vip-iptables:v1.0.1
   type: image
+- source: ghcr.io/kube-vip/kube-vip-iptables:v0.6.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-kube-vip-kube-vip-iptables:v0.6.0
+  type: image
+- source: ghcr.io/kube-vip/kube-vip-iptables:v0.8.10
+  target: stgregistry.suse.com/rancher/charts/mirrored-kube-vip-kube-vip-iptables:v0.8.10
+  type: image
+- source: ghcr.io/kube-vip/kube-vip-iptables:v0.8.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-kube-vip-kube-vip-iptables:v0.8.4
+  type: image
+- source: ghcr.io/kube-vip/kube-vip-iptables:v0.8.6
+  target: stgregistry.suse.com/rancher/charts/mirrored-kube-vip-kube-vip-iptables:v0.8.6
+  type: image
+- source: ghcr.io/kube-vip/kube-vip-iptables:v0.8.7
+  target: stgregistry.suse.com/rancher/charts/mirrored-kube-vip-kube-vip-iptables:v0.8.7
+  type: image
+- source: ghcr.io/kube-vip/kube-vip-iptables:v0.8.8
+  target: stgregistry.suse.com/rancher/charts/mirrored-kube-vip-kube-vip-iptables:v0.8.8
+  type: image
+- source: ghcr.io/kube-vip/kube-vip-iptables:v0.8.9
+  target: stgregistry.suse.com/rancher/charts/mirrored-kube-vip-kube-vip-iptables:v0.8.9
+  type: image
+- source: ghcr.io/kube-vip/kube-vip-iptables:v0.9.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-kube-vip-kube-vip-iptables:v0.9.0
+  type: image
+- source: ghcr.io/kube-vip/kube-vip-iptables:v0.9.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-kube-vip-kube-vip-iptables:v0.9.1
+  type: image
+- source: ghcr.io/kube-vip/kube-vip-iptables:v0.9.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-kube-vip-kube-vip-iptables:v0.9.2
+  type: image
+- source: ghcr.io/kube-vip/kube-vip-iptables:v1.0.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-kube-vip-kube-vip-iptables:v1.0.0
+  type: image
+- source: ghcr.io/kube-vip/kube-vip-iptables:v1.0.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-kube-vip-kube-vip-iptables:v1.0.1
+  type: image
 - source: ghcr.io/prometheus-community/windows-exporter:0.25.1
   target: docker.io/rancher/mirrored-prometheus-windows-exporter:0.25.1
   type: image
@@ -2157,6 +3551,21 @@ sync:
   target: registry.suse.com/rancher/mirrored-prometheus-windows-exporter:0.31.3
   type: image
 - source: ghcr.io/prometheus-community/windows-exporter:0.25.1
+  target: registry.suse.com/rancher/charts/mirrored-prometheus-windows-exporter:0.25.1
+  type: image
+- source: ghcr.io/prometheus-community/windows-exporter:0.29.2
+  target: registry.suse.com/rancher/charts/mirrored-prometheus-windows-exporter:0.29.2
+  type: image
+- source: ghcr.io/prometheus-community/windows-exporter:0.30.5
+  target: registry.suse.com/rancher/charts/mirrored-prometheus-windows-exporter:0.30.5
+  type: image
+- source: ghcr.io/prometheus-community/windows-exporter:0.31.2
+  target: registry.suse.com/rancher/charts/mirrored-prometheus-windows-exporter:0.31.2
+  type: image
+- source: ghcr.io/prometheus-community/windows-exporter:0.31.3
+  target: registry.suse.com/rancher/charts/mirrored-prometheus-windows-exporter:0.31.3
+  type: image
+- source: ghcr.io/prometheus-community/windows-exporter:0.25.1
   target: stgregistry.suse.com/rancher/mirrored-prometheus-windows-exporter:0.25.1
   type: image
 - source: ghcr.io/prometheus-community/windows-exporter:0.29.2
@@ -2171,6 +3580,21 @@ sync:
 - source: ghcr.io/prometheus-community/windows-exporter:0.31.3
   target: stgregistry.suse.com/rancher/mirrored-prometheus-windows-exporter:0.31.3
   type: image
+- source: ghcr.io/prometheus-community/windows-exporter:0.25.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-windows-exporter:0.25.1
+  type: image
+- source: ghcr.io/prometheus-community/windows-exporter:0.29.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-windows-exporter:0.29.2
+  type: image
+- source: ghcr.io/prometheus-community/windows-exporter:0.30.5
+  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-windows-exporter:0.30.5
+  type: image
+- source: ghcr.io/prometheus-community/windows-exporter:0.31.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-windows-exporter:0.31.2
+  type: image
+- source: ghcr.io/prometheus-community/windows-exporter:0.31.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-windows-exporter:0.31.3
+  type: image
 - source: grafana/grafana:7.1.5
   target: docker.io/rancher/grafana-grafana:7.1.5
   type: image
@@ -2184,10 +3608,22 @@ sync:
   target: registry.suse.com/rancher/grafana-grafana:7.2.1
   type: image
 - source: grafana/grafana:7.1.5
+  target: registry.suse.com/rancher/charts/grafana-grafana:7.1.5
+  type: image
+- source: grafana/grafana:7.2.1
+  target: registry.suse.com/rancher/charts/grafana-grafana:7.2.1
+  type: image
+- source: grafana/grafana:7.1.5
   target: stgregistry.suse.com/rancher/grafana-grafana:7.1.5
   type: image
 - source: grafana/grafana:7.2.1
   target: stgregistry.suse.com/rancher/grafana-grafana:7.2.1
+  type: image
+- source: grafana/grafana:7.1.5
+  target: stgregistry.suse.com/rancher/charts/grafana-grafana:7.1.5
+  type: image
+- source: grafana/grafana:7.2.1
+  target: stgregistry.suse.com/rancher/charts/grafana-grafana:7.2.1
   type: image
 - source: grafana/grafana:10.3.3
   target: docker.io/rancher/mirrored-grafana-grafana:10.3.3
@@ -2292,6 +3728,57 @@ sync:
   target: registry.suse.com/rancher/mirrored-grafana-grafana:9.5.14
   type: image
 - source: grafana/grafana:10.3.3
+  target: registry.suse.com/rancher/charts/mirrored-grafana-grafana:10.3.3
+  type: image
+- source: grafana/grafana:10.4.9
+  target: registry.suse.com/rancher/charts/mirrored-grafana-grafana:10.4.9
+  type: image
+- source: grafana/grafana:11.1.0
+  target: registry.suse.com/rancher/charts/mirrored-grafana-grafana:11.1.0
+  type: image
+- source: grafana/grafana:11.3.0
+  target: registry.suse.com/rancher/charts/mirrored-grafana-grafana:11.3.0
+  type: image
+- source: grafana/grafana:11.4.0
+  target: registry.suse.com/rancher/charts/mirrored-grafana-grafana:11.4.0
+  type: image
+- source: grafana/grafana:11.4.5
+  target: registry.suse.com/rancher/charts/mirrored-grafana-grafana:11.4.5
+  type: image
+- source: grafana/grafana:11.5.2
+  target: registry.suse.com/rancher/charts/mirrored-grafana-grafana:11.5.2
+  type: image
+- source: grafana/grafana:11.5.5
+  target: registry.suse.com/rancher/charts/mirrored-grafana-grafana:11.5.5
+  type: image
+- source: grafana/grafana:12.1.1
+  target: registry.suse.com/rancher/charts/mirrored-grafana-grafana:12.1.1
+  type: image
+- source: grafana/grafana:6.7.4
+  target: registry.suse.com/rancher/charts/mirrored-grafana-grafana:6.7.4
+  type: image
+- source: grafana/grafana:7.1.5
+  target: registry.suse.com/rancher/charts/mirrored-grafana-grafana:7.1.5
+  type: image
+- source: grafana/grafana:7.4.5
+  target: registry.suse.com/rancher/charts/mirrored-grafana-grafana:7.4.5
+  type: image
+- source: grafana/grafana:7.5.11
+  target: registry.suse.com/rancher/charts/mirrored-grafana-grafana:7.5.11
+  type: image
+- source: grafana/grafana:7.5.8
+  target: registry.suse.com/rancher/charts/mirrored-grafana-grafana:7.5.8
+  type: image
+- source: grafana/grafana:8.5.3
+  target: registry.suse.com/rancher/charts/mirrored-grafana-grafana:8.5.3
+  type: image
+- source: grafana/grafana:9.1.5
+  target: registry.suse.com/rancher/charts/mirrored-grafana-grafana:9.1.5
+  type: image
+- source: grafana/grafana:9.5.14
+  target: registry.suse.com/rancher/charts/mirrored-grafana-grafana:9.5.14
+  type: image
+- source: grafana/grafana:10.3.3
   target: stgregistry.suse.com/rancher/mirrored-grafana-grafana:10.3.3
   type: image
 - source: grafana/grafana:10.4.9
@@ -2342,6 +3829,57 @@ sync:
 - source: grafana/grafana:9.5.14
   target: stgregistry.suse.com/rancher/mirrored-grafana-grafana:9.5.14
   type: image
+- source: grafana/grafana:10.3.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-grafana-grafana:10.3.3
+  type: image
+- source: grafana/grafana:10.4.9
+  target: stgregistry.suse.com/rancher/charts/mirrored-grafana-grafana:10.4.9
+  type: image
+- source: grafana/grafana:11.1.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-grafana-grafana:11.1.0
+  type: image
+- source: grafana/grafana:11.3.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-grafana-grafana:11.3.0
+  type: image
+- source: grafana/grafana:11.4.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-grafana-grafana:11.4.0
+  type: image
+- source: grafana/grafana:11.4.5
+  target: stgregistry.suse.com/rancher/charts/mirrored-grafana-grafana:11.4.5
+  type: image
+- source: grafana/grafana:11.5.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-grafana-grafana:11.5.2
+  type: image
+- source: grafana/grafana:11.5.5
+  target: stgregistry.suse.com/rancher/charts/mirrored-grafana-grafana:11.5.5
+  type: image
+- source: grafana/grafana:12.1.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-grafana-grafana:12.1.1
+  type: image
+- source: grafana/grafana:6.7.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-grafana-grafana:6.7.4
+  type: image
+- source: grafana/grafana:7.1.5
+  target: stgregistry.suse.com/rancher/charts/mirrored-grafana-grafana:7.1.5
+  type: image
+- source: grafana/grafana:7.4.5
+  target: stgregistry.suse.com/rancher/charts/mirrored-grafana-grafana:7.4.5
+  type: image
+- source: grafana/grafana:7.5.11
+  target: stgregistry.suse.com/rancher/charts/mirrored-grafana-grafana:7.5.11
+  type: image
+- source: grafana/grafana:7.5.8
+  target: stgregistry.suse.com/rancher/charts/mirrored-grafana-grafana:7.5.8
+  type: image
+- source: grafana/grafana:8.5.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-grafana-grafana:8.5.3
+  type: image
+- source: grafana/grafana:9.1.5
+  target: stgregistry.suse.com/rancher/charts/mirrored-grafana-grafana:9.1.5
+  type: image
+- source: grafana/grafana:9.5.14
+  target: stgregistry.suse.com/rancher/charts/mirrored-grafana-grafana:9.5.14
+  type: image
 - source: grafana/grafana-image-renderer:2.0.0
   target: docker.io/rancher/grafana-grafana-image-renderer:2.0.0
   type: image
@@ -2349,7 +3887,13 @@ sync:
   target: registry.suse.com/rancher/grafana-grafana-image-renderer:2.0.0
   type: image
 - source: grafana/grafana-image-renderer:2.0.0
+  target: registry.suse.com/rancher/charts/grafana-grafana-image-renderer:2.0.0
+  type: image
+- source: grafana/grafana-image-renderer:2.0.0
   target: stgregistry.suse.com/rancher/grafana-grafana-image-renderer:2.0.0
+  type: image
+- source: grafana/grafana-image-renderer:2.0.0
+  target: stgregistry.suse.com/rancher/charts/grafana-grafana-image-renderer:2.0.0
   type: image
 - source: grafana/grafana-image-renderer:2.0.1
   target: docker.io/rancher/mirrored-grafana-grafana-image-renderer:2.0.1
@@ -2418,6 +3962,39 @@ sync:
   target: registry.suse.com/rancher/mirrored-grafana-grafana-image-renderer:v4.0.5
   type: image
 - source: grafana/grafana-image-renderer:2.0.1
+  target: registry.suse.com/rancher/charts/mirrored-grafana-grafana-image-renderer:2.0.1
+  type: image
+- source: grafana/grafana-image-renderer:3.0.1
+  target: registry.suse.com/rancher/charts/mirrored-grafana-grafana-image-renderer:3.0.1
+  type: image
+- source: grafana/grafana-image-renderer:3.10.1
+  target: registry.suse.com/rancher/charts/mirrored-grafana-grafana-image-renderer:3.10.1
+  type: image
+- source: grafana/grafana-image-renderer:3.10.5
+  target: registry.suse.com/rancher/charts/mirrored-grafana-grafana-image-renderer:3.10.5
+  type: image
+- source: grafana/grafana-image-renderer:3.11.1
+  target: registry.suse.com/rancher/charts/mirrored-grafana-grafana-image-renderer:3.11.1
+  type: image
+- source: grafana/grafana-image-renderer:3.11.6
+  target: registry.suse.com/rancher/charts/mirrored-grafana-grafana-image-renderer:3.11.6
+  type: image
+- source: grafana/grafana-image-renderer:3.12.3
+  target: registry.suse.com/rancher/charts/mirrored-grafana-grafana-image-renderer:3.12.3
+  type: image
+- source: grafana/grafana-image-renderer:3.12.6
+  target: registry.suse.com/rancher/charts/mirrored-grafana-grafana-image-renderer:3.12.6
+  type: image
+- source: grafana/grafana-image-renderer:3.8.0
+  target: registry.suse.com/rancher/charts/mirrored-grafana-grafana-image-renderer:3.8.0
+  type: image
+- source: grafana/grafana-image-renderer:v4.0.15
+  target: registry.suse.com/rancher/charts/mirrored-grafana-grafana-image-renderer:v4.0.15
+  type: image
+- source: grafana/grafana-image-renderer:v4.0.5
+  target: registry.suse.com/rancher/charts/mirrored-grafana-grafana-image-renderer:v4.0.5
+  type: image
+- source: grafana/grafana-image-renderer:2.0.1
   target: stgregistry.suse.com/rancher/mirrored-grafana-grafana-image-renderer:2.0.1
   type: image
 - source: grafana/grafana-image-renderer:3.0.1
@@ -2450,6 +4027,39 @@ sync:
 - source: grafana/grafana-image-renderer:v4.0.5
   target: stgregistry.suse.com/rancher/mirrored-grafana-grafana-image-renderer:v4.0.5
   type: image
+- source: grafana/grafana-image-renderer:2.0.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-grafana-grafana-image-renderer:2.0.1
+  type: image
+- source: grafana/grafana-image-renderer:3.0.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-grafana-grafana-image-renderer:3.0.1
+  type: image
+- source: grafana/grafana-image-renderer:3.10.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-grafana-grafana-image-renderer:3.10.1
+  type: image
+- source: grafana/grafana-image-renderer:3.10.5
+  target: stgregistry.suse.com/rancher/charts/mirrored-grafana-grafana-image-renderer:3.10.5
+  type: image
+- source: grafana/grafana-image-renderer:3.11.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-grafana-grafana-image-renderer:3.11.1
+  type: image
+- source: grafana/grafana-image-renderer:3.11.6
+  target: stgregistry.suse.com/rancher/charts/mirrored-grafana-grafana-image-renderer:3.11.6
+  type: image
+- source: grafana/grafana-image-renderer:3.12.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-grafana-grafana-image-renderer:3.12.3
+  type: image
+- source: grafana/grafana-image-renderer:3.12.6
+  target: stgregistry.suse.com/rancher/charts/mirrored-grafana-grafana-image-renderer:3.12.6
+  type: image
+- source: grafana/grafana-image-renderer:3.8.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-grafana-grafana-image-renderer:3.8.0
+  type: image
+- source: grafana/grafana-image-renderer:v4.0.15
+  target: stgregistry.suse.com/rancher/charts/mirrored-grafana-grafana-image-renderer:v4.0.15
+  type: image
+- source: grafana/grafana-image-renderer:v4.0.5
+  target: stgregistry.suse.com/rancher/charts/mirrored-grafana-grafana-image-renderer:v4.0.5
+  type: image
 - source: idealista/prom2teams:3.2.1
   target: docker.io/rancher/mirrored-idealista-prom2teams:3.2.1
   type: image
@@ -2481,6 +4091,21 @@ sync:
   target: registry.suse.com/rancher/mirrored-idealista-prom2teams:4.2.1
   type: image
 - source: idealista/prom2teams:3.2.1
+  target: registry.suse.com/rancher/charts/mirrored-idealista-prom2teams:3.2.1
+  type: image
+- source: idealista/prom2teams:3.2.2
+  target: registry.suse.com/rancher/charts/mirrored-idealista-prom2teams:3.2.2
+  type: image
+- source: idealista/prom2teams:3.2.3
+  target: registry.suse.com/rancher/charts/mirrored-idealista-prom2teams:3.2.3
+  type: image
+- source: idealista/prom2teams:4.2.0
+  target: registry.suse.com/rancher/charts/mirrored-idealista-prom2teams:4.2.0
+  type: image
+- source: idealista/prom2teams:4.2.1
+  target: registry.suse.com/rancher/charts/mirrored-idealista-prom2teams:4.2.1
+  type: image
+- source: idealista/prom2teams:3.2.1
   target: stgregistry.suse.com/rancher/mirrored-idealista-prom2teams:3.2.1
   type: image
 - source: idealista/prom2teams:3.2.2
@@ -2495,6 +4120,21 @@ sync:
 - source: idealista/prom2teams:4.2.1
   target: stgregistry.suse.com/rancher/mirrored-idealista-prom2teams:4.2.1
   type: image
+- source: idealista/prom2teams:3.2.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-idealista-prom2teams:3.2.1
+  type: image
+- source: idealista/prom2teams:3.2.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-idealista-prom2teams:3.2.2
+  type: image
+- source: idealista/prom2teams:3.2.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-idealista-prom2teams:3.2.3
+  type: image
+- source: idealista/prom2teams:4.2.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-idealista-prom2teams:4.2.0
+  type: image
+- source: idealista/prom2teams:4.2.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-idealista-prom2teams:4.2.1
+  type: image
 - source: istio/citadel:1.5.9
   target: docker.io/rancher/mirrored-istio-citadel:1.5.9
   type: image
@@ -2502,7 +4142,13 @@ sync:
   target: registry.suse.com/rancher/mirrored-istio-citadel:1.5.9
   type: image
 - source: istio/citadel:1.5.9
+  target: registry.suse.com/rancher/charts/mirrored-istio-citadel:1.5.9
+  type: image
+- source: istio/citadel:1.5.9
   target: stgregistry.suse.com/rancher/mirrored-istio-citadel:1.5.9
+  type: image
+- source: istio/citadel:1.5.9
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-citadel:1.5.9
   type: image
 - source: istio/coredns-plugin:0.2-istio-1.1
   target: docker.io/rancher/istio-coredns-plugin:0.2-istio-1.1
@@ -2511,7 +4157,13 @@ sync:
   target: registry.suse.com/rancher/istio-coredns-plugin:0.2-istio-1.1
   type: image
 - source: istio/coredns-plugin:0.2-istio-1.1
+  target: registry.suse.com/rancher/charts/istio-coredns-plugin:0.2-istio-1.1
+  type: image
+- source: istio/coredns-plugin:0.2-istio-1.1
   target: stgregistry.suse.com/rancher/istio-coredns-plugin:0.2-istio-1.1
+  type: image
+- source: istio/coredns-plugin:0.2-istio-1.1
+  target: stgregistry.suse.com/rancher/charts/istio-coredns-plugin:0.2-istio-1.1
   type: image
 - source: istio/coredns-plugin:0.2-istio-1.1
   target: docker.io/rancher/mirrored-istio-coredns-plugin:0.2-istio-1.1
@@ -2520,7 +4172,13 @@ sync:
   target: registry.suse.com/rancher/mirrored-istio-coredns-plugin:0.2-istio-1.1
   type: image
 - source: istio/coredns-plugin:0.2-istio-1.1
+  target: registry.suse.com/rancher/charts/mirrored-istio-coredns-plugin:0.2-istio-1.1
+  type: image
+- source: istio/coredns-plugin:0.2-istio-1.1
   target: stgregistry.suse.com/rancher/mirrored-istio-coredns-plugin:0.2-istio-1.1
+  type: image
+- source: istio/coredns-plugin:0.2-istio-1.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-coredns-plugin:0.2-istio-1.1
   type: image
 - source: istio/galley:1.5.9
   target: docker.io/rancher/mirrored-istio-galley:1.5.9
@@ -2529,7 +4187,13 @@ sync:
   target: registry.suse.com/rancher/mirrored-istio-galley:1.5.9
   type: image
 - source: istio/galley:1.5.9
+  target: registry.suse.com/rancher/charts/mirrored-istio-galley:1.5.9
+  type: image
+- source: istio/galley:1.5.9
   target: stgregistry.suse.com/rancher/mirrored-istio-galley:1.5.9
+  type: image
+- source: istio/galley:1.5.9
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-galley:1.5.9
   type: image
 - source: istio/install-cni:1.7.0
   target: docker.io/rancher/istio-install-cni:1.7.0
@@ -2568,6 +4232,24 @@ sync:
   target: registry.suse.com/rancher/istio-install-cni:1.8.3
   type: image
 - source: istio/install-cni:1.7.0
+  target: registry.suse.com/rancher/charts/istio-install-cni:1.7.0
+  type: image
+- source: istio/install-cni:1.7.1
+  target: registry.suse.com/rancher/charts/istio-install-cni:1.7.1
+  type: image
+- source: istio/install-cni:1.7.3
+  target: registry.suse.com/rancher/charts/istio-install-cni:1.7.3
+  type: image
+- source: istio/install-cni:1.7.6
+  target: registry.suse.com/rancher/charts/istio-install-cni:1.7.6
+  type: image
+- source: istio/install-cni:1.8.1
+  target: registry.suse.com/rancher/charts/istio-install-cni:1.8.1
+  type: image
+- source: istio/install-cni:1.8.3
+  target: registry.suse.com/rancher/charts/istio-install-cni:1.8.3
+  type: image
+- source: istio/install-cni:1.7.0
   target: stgregistry.suse.com/rancher/istio-install-cni:1.7.0
   type: image
 - source: istio/install-cni:1.7.1
@@ -2584,6 +4266,24 @@ sync:
   type: image
 - source: istio/install-cni:1.8.3
   target: stgregistry.suse.com/rancher/istio-install-cni:1.8.3
+  type: image
+- source: istio/install-cni:1.7.0
+  target: stgregistry.suse.com/rancher/charts/istio-install-cni:1.7.0
+  type: image
+- source: istio/install-cni:1.7.1
+  target: stgregistry.suse.com/rancher/charts/istio-install-cni:1.7.1
+  type: image
+- source: istio/install-cni:1.7.3
+  target: stgregistry.suse.com/rancher/charts/istio-install-cni:1.7.3
+  type: image
+- source: istio/install-cni:1.7.6
+  target: stgregistry.suse.com/rancher/charts/istio-install-cni:1.7.6
+  type: image
+- source: istio/install-cni:1.8.1
+  target: stgregistry.suse.com/rancher/charts/istio-install-cni:1.8.1
+  type: image
+- source: istio/install-cni:1.8.3
+  target: stgregistry.suse.com/rancher/charts/istio-install-cni:1.8.3
   type: image
 - source: istio/install-cni:1.10.0
   target: docker.io/rancher/mirrored-istio-install-cni:1.10.0
@@ -2928,6 +4628,177 @@ sync:
   target: registry.suse.com/rancher/mirrored-istio-install-cni:1.9.8
   type: image
 - source: istio/install-cni:1.10.0
+  target: registry.suse.com/rancher/charts/mirrored-istio-install-cni:1.10.0
+  type: image
+- source: istio/install-cni:1.10.1
+  target: registry.suse.com/rancher/charts/mirrored-istio-install-cni:1.10.1
+  type: image
+- source: istio/install-cni:1.10.2
+  target: registry.suse.com/rancher/charts/mirrored-istio-install-cni:1.10.2
+  type: image
+- source: istio/install-cni:1.10.4
+  target: registry.suse.com/rancher/charts/mirrored-istio-install-cni:1.10.4
+  type: image
+- source: istio/install-cni:1.11.2
+  target: registry.suse.com/rancher/charts/mirrored-istio-install-cni:1.11.2
+  type: image
+- source: istio/install-cni:1.11.4
+  target: registry.suse.com/rancher/charts/mirrored-istio-install-cni:1.11.4
+  type: image
+- source: istio/install-cni:1.11.7
+  target: registry.suse.com/rancher/charts/mirrored-istio-install-cni:1.11.7
+  type: image
+- source: istio/install-cni:1.11.8
+  target: registry.suse.com/rancher/charts/mirrored-istio-install-cni:1.11.8
+  type: image
+- source: istio/install-cni:1.12.6
+  target: registry.suse.com/rancher/charts/mirrored-istio-install-cni:1.12.6
+  type: image
+- source: istio/install-cni:1.13.3
+  target: registry.suse.com/rancher/charts/mirrored-istio-install-cni:1.13.3
+  type: image
+- source: istio/install-cni:1.14.1
+  target: registry.suse.com/rancher/charts/mirrored-istio-install-cni:1.14.1
+  type: image
+- source: istio/install-cni:1.14.1-distroless
+  target: registry.suse.com/rancher/charts/mirrored-istio-install-cni:1.14.1-distroless
+  type: image
+- source: istio/install-cni:1.14.3
+  target: registry.suse.com/rancher/charts/mirrored-istio-install-cni:1.14.3
+  type: image
+- source: istio/install-cni:1.14.3-distroless
+  target: registry.suse.com/rancher/charts/mirrored-istio-install-cni:1.14.3-distroless
+  type: image
+- source: istio/install-cni:1.15.2
+  target: registry.suse.com/rancher/charts/mirrored-istio-install-cni:1.15.2
+  type: image
+- source: istio/install-cni:1.15.2-distroless
+  target: registry.suse.com/rancher/charts/mirrored-istio-install-cni:1.15.2-distroless
+  type: image
+- source: istio/install-cni:1.15.3
+  target: registry.suse.com/rancher/charts/mirrored-istio-install-cni:1.15.3
+  type: image
+- source: istio/install-cni:1.15.3-distroless
+  target: registry.suse.com/rancher/charts/mirrored-istio-install-cni:1.15.3-distroless
+  type: image
+- source: istio/install-cni:1.16.3
+  target: registry.suse.com/rancher/charts/mirrored-istio-install-cni:1.16.3
+  type: image
+- source: istio/install-cni:1.16.3-distroless
+  target: registry.suse.com/rancher/charts/mirrored-istio-install-cni:1.16.3-distroless
+  type: image
+- source: istio/install-cni:1.17.2
+  target: registry.suse.com/rancher/charts/mirrored-istio-install-cni:1.17.2
+  type: image
+- source: istio/install-cni:1.17.2-distroless
+  target: registry.suse.com/rancher/charts/mirrored-istio-install-cni:1.17.2-distroless
+  type: image
+- source: istio/install-cni:1.18.2
+  target: registry.suse.com/rancher/charts/mirrored-istio-install-cni:1.18.2
+  type: image
+- source: istio/install-cni:1.18.2-distroless
+  target: registry.suse.com/rancher/charts/mirrored-istio-install-cni:1.18.2-distroless
+  type: image
+- source: istio/install-cni:1.19.0
+  target: registry.suse.com/rancher/charts/mirrored-istio-install-cni:1.19.0
+  type: image
+- source: istio/install-cni:1.19.0-distroless
+  target: registry.suse.com/rancher/charts/mirrored-istio-install-cni:1.19.0-distroless
+  type: image
+- source: istio/install-cni:1.19.5
+  target: registry.suse.com/rancher/charts/mirrored-istio-install-cni:1.19.5
+  type: image
+- source: istio/install-cni:1.19.5-distroless
+  target: registry.suse.com/rancher/charts/mirrored-istio-install-cni:1.19.5-distroless
+  type: image
+- source: istio/install-cni:1.19.6
+  target: registry.suse.com/rancher/charts/mirrored-istio-install-cni:1.19.6
+  type: image
+- source: istio/install-cni:1.19.6-distroless
+  target: registry.suse.com/rancher/charts/mirrored-istio-install-cni:1.19.6-distroless
+  type: image
+- source: istio/install-cni:1.20.3
+  target: registry.suse.com/rancher/charts/mirrored-istio-install-cni:1.20.3
+  type: image
+- source: istio/install-cni:1.20.3-distroless
+  target: registry.suse.com/rancher/charts/mirrored-istio-install-cni:1.20.3-distroless
+  type: image
+- source: istio/install-cni:1.21.1
+  target: registry.suse.com/rancher/charts/mirrored-istio-install-cni:1.21.1
+  type: image
+- source: istio/install-cni:1.21.1-distroless
+  target: registry.suse.com/rancher/charts/mirrored-istio-install-cni:1.21.1-distroless
+  type: image
+- source: istio/install-cni:1.22.1
+  target: registry.suse.com/rancher/charts/mirrored-istio-install-cni:1.22.1
+  type: image
+- source: istio/install-cni:1.22.1-distroless
+  target: registry.suse.com/rancher/charts/mirrored-istio-install-cni:1.22.1-distroless
+  type: image
+- source: istio/install-cni:1.23.2
+  target: registry.suse.com/rancher/charts/mirrored-istio-install-cni:1.23.2
+  type: image
+- source: istio/install-cni:1.23.2-distroless
+  target: registry.suse.com/rancher/charts/mirrored-istio-install-cni:1.23.2-distroless
+  type: image
+- source: istio/install-cni:1.24.0
+  target: registry.suse.com/rancher/charts/mirrored-istio-install-cni:1.24.0
+  type: image
+- source: istio/install-cni:1.24.0-distroless
+  target: registry.suse.com/rancher/charts/mirrored-istio-install-cni:1.24.0-distroless
+  type: image
+- source: istio/install-cni:1.24.1
+  target: registry.suse.com/rancher/charts/mirrored-istio-install-cni:1.24.1
+  type: image
+- source: istio/install-cni:1.24.1-distroless
+  target: registry.suse.com/rancher/charts/mirrored-istio-install-cni:1.24.1-distroless
+  type: image
+- source: istio/install-cni:1.25.0
+  target: registry.suse.com/rancher/charts/mirrored-istio-install-cni:1.25.0
+  type: image
+- source: istio/install-cni:1.25.0-distroless
+  target: registry.suse.com/rancher/charts/mirrored-istio-install-cni:1.25.0-distroless
+  type: image
+- source: istio/install-cni:1.26.2
+  target: registry.suse.com/rancher/charts/mirrored-istio-install-cni:1.26.2
+  type: image
+- source: istio/install-cni:1.26.2-distroless
+  target: registry.suse.com/rancher/charts/mirrored-istio-install-cni:1.26.2-distroless
+  type: image
+- source: istio/install-cni:1.7.8
+  target: registry.suse.com/rancher/charts/mirrored-istio-install-cni:1.7.8
+  type: image
+- source: istio/install-cni:1.8.3
+  target: registry.suse.com/rancher/charts/mirrored-istio-install-cni:1.8.3
+  type: image
+- source: istio/install-cni:1.8.4
+  target: registry.suse.com/rancher/charts/mirrored-istio-install-cni:1.8.4
+  type: image
+- source: istio/install-cni:1.8.5
+  target: registry.suse.com/rancher/charts/mirrored-istio-install-cni:1.8.5
+  type: image
+- source: istio/install-cni:1.8.6
+  target: registry.suse.com/rancher/charts/mirrored-istio-install-cni:1.8.6
+  type: image
+- source: istio/install-cni:1.9.1
+  target: registry.suse.com/rancher/charts/mirrored-istio-install-cni:1.9.1
+  type: image
+- source: istio/install-cni:1.9.2
+  target: registry.suse.com/rancher/charts/mirrored-istio-install-cni:1.9.2
+  type: image
+- source: istio/install-cni:1.9.3
+  target: registry.suse.com/rancher/charts/mirrored-istio-install-cni:1.9.3
+  type: image
+- source: istio/install-cni:1.9.5
+  target: registry.suse.com/rancher/charts/mirrored-istio-install-cni:1.9.5
+  type: image
+- source: istio/install-cni:1.9.6
+  target: registry.suse.com/rancher/charts/mirrored-istio-install-cni:1.9.6
+  type: image
+- source: istio/install-cni:1.9.8
+  target: registry.suse.com/rancher/charts/mirrored-istio-install-cni:1.9.8
+  type: image
+- source: istio/install-cni:1.10.0
   target: stgregistry.suse.com/rancher/mirrored-istio-install-cni:1.10.0
   type: image
 - source: istio/install-cni:1.10.1
@@ -3098,6 +4969,177 @@ sync:
 - source: istio/install-cni:1.9.8
   target: stgregistry.suse.com/rancher/mirrored-istio-install-cni:1.9.8
   type: image
+- source: istio/install-cni:1.10.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-install-cni:1.10.0
+  type: image
+- source: istio/install-cni:1.10.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-install-cni:1.10.1
+  type: image
+- source: istio/install-cni:1.10.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-install-cni:1.10.2
+  type: image
+- source: istio/install-cni:1.10.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-install-cni:1.10.4
+  type: image
+- source: istio/install-cni:1.11.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-install-cni:1.11.2
+  type: image
+- source: istio/install-cni:1.11.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-install-cni:1.11.4
+  type: image
+- source: istio/install-cni:1.11.7
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-install-cni:1.11.7
+  type: image
+- source: istio/install-cni:1.11.8
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-install-cni:1.11.8
+  type: image
+- source: istio/install-cni:1.12.6
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-install-cni:1.12.6
+  type: image
+- source: istio/install-cni:1.13.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-install-cni:1.13.3
+  type: image
+- source: istio/install-cni:1.14.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-install-cni:1.14.1
+  type: image
+- source: istio/install-cni:1.14.1-distroless
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-install-cni:1.14.1-distroless
+  type: image
+- source: istio/install-cni:1.14.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-install-cni:1.14.3
+  type: image
+- source: istio/install-cni:1.14.3-distroless
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-install-cni:1.14.3-distroless
+  type: image
+- source: istio/install-cni:1.15.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-install-cni:1.15.2
+  type: image
+- source: istio/install-cni:1.15.2-distroless
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-install-cni:1.15.2-distroless
+  type: image
+- source: istio/install-cni:1.15.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-install-cni:1.15.3
+  type: image
+- source: istio/install-cni:1.15.3-distroless
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-install-cni:1.15.3-distroless
+  type: image
+- source: istio/install-cni:1.16.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-install-cni:1.16.3
+  type: image
+- source: istio/install-cni:1.16.3-distroless
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-install-cni:1.16.3-distroless
+  type: image
+- source: istio/install-cni:1.17.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-install-cni:1.17.2
+  type: image
+- source: istio/install-cni:1.17.2-distroless
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-install-cni:1.17.2-distroless
+  type: image
+- source: istio/install-cni:1.18.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-install-cni:1.18.2
+  type: image
+- source: istio/install-cni:1.18.2-distroless
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-install-cni:1.18.2-distroless
+  type: image
+- source: istio/install-cni:1.19.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-install-cni:1.19.0
+  type: image
+- source: istio/install-cni:1.19.0-distroless
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-install-cni:1.19.0-distroless
+  type: image
+- source: istio/install-cni:1.19.5
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-install-cni:1.19.5
+  type: image
+- source: istio/install-cni:1.19.5-distroless
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-install-cni:1.19.5-distroless
+  type: image
+- source: istio/install-cni:1.19.6
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-install-cni:1.19.6
+  type: image
+- source: istio/install-cni:1.19.6-distroless
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-install-cni:1.19.6-distroless
+  type: image
+- source: istio/install-cni:1.20.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-install-cni:1.20.3
+  type: image
+- source: istio/install-cni:1.20.3-distroless
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-install-cni:1.20.3-distroless
+  type: image
+- source: istio/install-cni:1.21.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-install-cni:1.21.1
+  type: image
+- source: istio/install-cni:1.21.1-distroless
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-install-cni:1.21.1-distroless
+  type: image
+- source: istio/install-cni:1.22.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-install-cni:1.22.1
+  type: image
+- source: istio/install-cni:1.22.1-distroless
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-install-cni:1.22.1-distroless
+  type: image
+- source: istio/install-cni:1.23.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-install-cni:1.23.2
+  type: image
+- source: istio/install-cni:1.23.2-distroless
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-install-cni:1.23.2-distroless
+  type: image
+- source: istio/install-cni:1.24.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-install-cni:1.24.0
+  type: image
+- source: istio/install-cni:1.24.0-distroless
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-install-cni:1.24.0-distroless
+  type: image
+- source: istio/install-cni:1.24.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-install-cni:1.24.1
+  type: image
+- source: istio/install-cni:1.24.1-distroless
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-install-cni:1.24.1-distroless
+  type: image
+- source: istio/install-cni:1.25.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-install-cni:1.25.0
+  type: image
+- source: istio/install-cni:1.25.0-distroless
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-install-cni:1.25.0-distroless
+  type: image
+- source: istio/install-cni:1.26.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-install-cni:1.26.2
+  type: image
+- source: istio/install-cni:1.26.2-distroless
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-install-cni:1.26.2-distroless
+  type: image
+- source: istio/install-cni:1.7.8
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-install-cni:1.7.8
+  type: image
+- source: istio/install-cni:1.8.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-install-cni:1.8.3
+  type: image
+- source: istio/install-cni:1.8.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-install-cni:1.8.4
+  type: image
+- source: istio/install-cni:1.8.5
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-install-cni:1.8.5
+  type: image
+- source: istio/install-cni:1.8.6
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-install-cni:1.8.6
+  type: image
+- source: istio/install-cni:1.9.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-install-cni:1.9.1
+  type: image
+- source: istio/install-cni:1.9.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-install-cni:1.9.2
+  type: image
+- source: istio/install-cni:1.9.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-install-cni:1.9.3
+  type: image
+- source: istio/install-cni:1.9.5
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-install-cni:1.9.5
+  type: image
+- source: istio/install-cni:1.9.6
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-install-cni:1.9.6
+  type: image
+- source: istio/install-cni:1.9.8
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-install-cni:1.9.8
+  type: image
 - source: istio/kubectl:1.5.10
   target: docker.io/rancher/istio-kubectl:1.5.10
   type: image
@@ -3105,7 +5147,13 @@ sync:
   target: registry.suse.com/rancher/istio-kubectl:1.5.10
   type: image
 - source: istio/kubectl:1.5.10
+  target: registry.suse.com/rancher/charts/istio-kubectl:1.5.10
+  type: image
+- source: istio/kubectl:1.5.10
   target: stgregistry.suse.com/rancher/istio-kubectl:1.5.10
+  type: image
+- source: istio/kubectl:1.5.10
+  target: stgregistry.suse.com/rancher/charts/istio-kubectl:1.5.10
   type: image
 - source: istio/kubectl:1.5.9
   target: docker.io/rancher/mirrored-istio-kubectl:1.5.9
@@ -3114,7 +5162,13 @@ sync:
   target: registry.suse.com/rancher/mirrored-istio-kubectl:1.5.9
   type: image
 - source: istio/kubectl:1.5.9
+  target: registry.suse.com/rancher/charts/mirrored-istio-kubectl:1.5.9
+  type: image
+- source: istio/kubectl:1.5.9
   target: stgregistry.suse.com/rancher/mirrored-istio-kubectl:1.5.9
+  type: image
+- source: istio/kubectl:1.5.9
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-kubectl:1.5.9
   type: image
 - source: istio/mixer:1.7.0
   target: docker.io/rancher/istio-mixer:1.7.0
@@ -3141,6 +5195,18 @@ sync:
   target: registry.suse.com/rancher/istio-mixer:1.7.6
   type: image
 - source: istio/mixer:1.7.0
+  target: registry.suse.com/rancher/charts/istio-mixer:1.7.0
+  type: image
+- source: istio/mixer:1.7.1
+  target: registry.suse.com/rancher/charts/istio-mixer:1.7.1
+  type: image
+- source: istio/mixer:1.7.3
+  target: registry.suse.com/rancher/charts/istio-mixer:1.7.3
+  type: image
+- source: istio/mixer:1.7.6
+  target: registry.suse.com/rancher/charts/istio-mixer:1.7.6
+  type: image
+- source: istio/mixer:1.7.0
   target: stgregistry.suse.com/rancher/istio-mixer:1.7.0
   type: image
 - source: istio/mixer:1.7.1
@@ -3151,6 +5217,18 @@ sync:
   type: image
 - source: istio/mixer:1.7.6
   target: stgregistry.suse.com/rancher/istio-mixer:1.7.6
+  type: image
+- source: istio/mixer:1.7.0
+  target: stgregistry.suse.com/rancher/charts/istio-mixer:1.7.0
+  type: image
+- source: istio/mixer:1.7.1
+  target: stgregistry.suse.com/rancher/charts/istio-mixer:1.7.1
+  type: image
+- source: istio/mixer:1.7.3
+  target: stgregistry.suse.com/rancher/charts/istio-mixer:1.7.3
+  type: image
+- source: istio/mixer:1.7.6
+  target: stgregistry.suse.com/rancher/charts/istio-mixer:1.7.6
   type: image
 - source: istio/mixer:1.5.9
   target: docker.io/rancher/mirrored-istio-mixer:1.5.9
@@ -3165,10 +5243,22 @@ sync:
   target: registry.suse.com/rancher/mirrored-istio-mixer:1.7.8
   type: image
 - source: istio/mixer:1.5.9
+  target: registry.suse.com/rancher/charts/mirrored-istio-mixer:1.5.9
+  type: image
+- source: istio/mixer:1.7.8
+  target: registry.suse.com/rancher/charts/mirrored-istio-mixer:1.7.8
+  type: image
+- source: istio/mixer:1.5.9
   target: stgregistry.suse.com/rancher/mirrored-istio-mixer:1.5.9
   type: image
 - source: istio/mixer:1.7.8
   target: stgregistry.suse.com/rancher/mirrored-istio-mixer:1.7.8
+  type: image
+- source: istio/mixer:1.5.9
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-mixer:1.5.9
+  type: image
+- source: istio/mixer:1.7.8
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-mixer:1.7.8
   type: image
 - source: istio/node-agent-k8s:1.5.9
   target: docker.io/rancher/mirrored-istio-node-agent-k8s:1.5.9
@@ -3177,7 +5267,13 @@ sync:
   target: registry.suse.com/rancher/mirrored-istio-node-agent-k8s:1.5.9
   type: image
 - source: istio/node-agent-k8s:1.5.9
+  target: registry.suse.com/rancher/charts/mirrored-istio-node-agent-k8s:1.5.9
+  type: image
+- source: istio/node-agent-k8s:1.5.9
   target: stgregistry.suse.com/rancher/mirrored-istio-node-agent-k8s:1.5.9
+  type: image
+- source: istio/node-agent-k8s:1.5.9
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-node-agent-k8s:1.5.9
   type: image
 - source: istio/pilot:1.7.0
   target: docker.io/rancher/istio-pilot:1.7.0
@@ -3216,6 +5312,24 @@ sync:
   target: registry.suse.com/rancher/istio-pilot:1.8.3
   type: image
 - source: istio/pilot:1.7.0
+  target: registry.suse.com/rancher/charts/istio-pilot:1.7.0
+  type: image
+- source: istio/pilot:1.7.1
+  target: registry.suse.com/rancher/charts/istio-pilot:1.7.1
+  type: image
+- source: istio/pilot:1.7.3
+  target: registry.suse.com/rancher/charts/istio-pilot:1.7.3
+  type: image
+- source: istio/pilot:1.7.6
+  target: registry.suse.com/rancher/charts/istio-pilot:1.7.6
+  type: image
+- source: istio/pilot:1.8.1
+  target: registry.suse.com/rancher/charts/istio-pilot:1.8.1
+  type: image
+- source: istio/pilot:1.8.3
+  target: registry.suse.com/rancher/charts/istio-pilot:1.8.3
+  type: image
+- source: istio/pilot:1.7.0
   target: stgregistry.suse.com/rancher/istio-pilot:1.7.0
   type: image
 - source: istio/pilot:1.7.1
@@ -3232,6 +5346,24 @@ sync:
   type: image
 - source: istio/pilot:1.8.3
   target: stgregistry.suse.com/rancher/istio-pilot:1.8.3
+  type: image
+- source: istio/pilot:1.7.0
+  target: stgregistry.suse.com/rancher/charts/istio-pilot:1.7.0
+  type: image
+- source: istio/pilot:1.7.1
+  target: stgregistry.suse.com/rancher/charts/istio-pilot:1.7.1
+  type: image
+- source: istio/pilot:1.7.3
+  target: stgregistry.suse.com/rancher/charts/istio-pilot:1.7.3
+  type: image
+- source: istio/pilot:1.7.6
+  target: stgregistry.suse.com/rancher/charts/istio-pilot:1.7.6
+  type: image
+- source: istio/pilot:1.8.1
+  target: stgregistry.suse.com/rancher/charts/istio-pilot:1.8.1
+  type: image
+- source: istio/pilot:1.8.3
+  target: stgregistry.suse.com/rancher/charts/istio-pilot:1.8.3
   type: image
 - source: istio/pilot:1.10.0
   target: docker.io/rancher/mirrored-istio-pilot:1.10.0
@@ -3582,6 +5714,180 @@ sync:
   target: registry.suse.com/rancher/mirrored-istio-pilot:1.9.8
   type: image
 - source: istio/pilot:1.10.0
+  target: registry.suse.com/rancher/charts/mirrored-istio-pilot:1.10.0
+  type: image
+- source: istio/pilot:1.10.1
+  target: registry.suse.com/rancher/charts/mirrored-istio-pilot:1.10.1
+  type: image
+- source: istio/pilot:1.10.2
+  target: registry.suse.com/rancher/charts/mirrored-istio-pilot:1.10.2
+  type: image
+- source: istio/pilot:1.10.4
+  target: registry.suse.com/rancher/charts/mirrored-istio-pilot:1.10.4
+  type: image
+- source: istio/pilot:1.11.2
+  target: registry.suse.com/rancher/charts/mirrored-istio-pilot:1.11.2
+  type: image
+- source: istio/pilot:1.11.4
+  target: registry.suse.com/rancher/charts/mirrored-istio-pilot:1.11.4
+  type: image
+- source: istio/pilot:1.11.7
+  target: registry.suse.com/rancher/charts/mirrored-istio-pilot:1.11.7
+  type: image
+- source: istio/pilot:1.11.8
+  target: registry.suse.com/rancher/charts/mirrored-istio-pilot:1.11.8
+  type: image
+- source: istio/pilot:1.12.6
+  target: registry.suse.com/rancher/charts/mirrored-istio-pilot:1.12.6
+  type: image
+- source: istio/pilot:1.13.3
+  target: registry.suse.com/rancher/charts/mirrored-istio-pilot:1.13.3
+  type: image
+- source: istio/pilot:1.14.1
+  target: registry.suse.com/rancher/charts/mirrored-istio-pilot:1.14.1
+  type: image
+- source: istio/pilot:1.14.1-distroless
+  target: registry.suse.com/rancher/charts/mirrored-istio-pilot:1.14.1-distroless
+  type: image
+- source: istio/pilot:1.14.3
+  target: registry.suse.com/rancher/charts/mirrored-istio-pilot:1.14.3
+  type: image
+- source: istio/pilot:1.14.3-distroless
+  target: registry.suse.com/rancher/charts/mirrored-istio-pilot:1.14.3-distroless
+  type: image
+- source: istio/pilot:1.15.2
+  target: registry.suse.com/rancher/charts/mirrored-istio-pilot:1.15.2
+  type: image
+- source: istio/pilot:1.15.2-distroless
+  target: registry.suse.com/rancher/charts/mirrored-istio-pilot:1.15.2-distroless
+  type: image
+- source: istio/pilot:1.15.3
+  target: registry.suse.com/rancher/charts/mirrored-istio-pilot:1.15.3
+  type: image
+- source: istio/pilot:1.15.3-distroless
+  target: registry.suse.com/rancher/charts/mirrored-istio-pilot:1.15.3-distroless
+  type: image
+- source: istio/pilot:1.16.3
+  target: registry.suse.com/rancher/charts/mirrored-istio-pilot:1.16.3
+  type: image
+- source: istio/pilot:1.16.3-distroless
+  target: registry.suse.com/rancher/charts/mirrored-istio-pilot:1.16.3-distroless
+  type: image
+- source: istio/pilot:1.17.2
+  target: registry.suse.com/rancher/charts/mirrored-istio-pilot:1.17.2
+  type: image
+- source: istio/pilot:1.17.2-distroless
+  target: registry.suse.com/rancher/charts/mirrored-istio-pilot:1.17.2-distroless
+  type: image
+- source: istio/pilot:1.18.2
+  target: registry.suse.com/rancher/charts/mirrored-istio-pilot:1.18.2
+  type: image
+- source: istio/pilot:1.18.2-distroless
+  target: registry.suse.com/rancher/charts/mirrored-istio-pilot:1.18.2-distroless
+  type: image
+- source: istio/pilot:1.19.0
+  target: registry.suse.com/rancher/charts/mirrored-istio-pilot:1.19.0
+  type: image
+- source: istio/pilot:1.19.0-distroless
+  target: registry.suse.com/rancher/charts/mirrored-istio-pilot:1.19.0-distroless
+  type: image
+- source: istio/pilot:1.19.5
+  target: registry.suse.com/rancher/charts/mirrored-istio-pilot:1.19.5
+  type: image
+- source: istio/pilot:1.19.5-distroless
+  target: registry.suse.com/rancher/charts/mirrored-istio-pilot:1.19.5-distroless
+  type: image
+- source: istio/pilot:1.19.6
+  target: registry.suse.com/rancher/charts/mirrored-istio-pilot:1.19.6
+  type: image
+- source: istio/pilot:1.19.6-distroless
+  target: registry.suse.com/rancher/charts/mirrored-istio-pilot:1.19.6-distroless
+  type: image
+- source: istio/pilot:1.20.3
+  target: registry.suse.com/rancher/charts/mirrored-istio-pilot:1.20.3
+  type: image
+- source: istio/pilot:1.20.3-distroless
+  target: registry.suse.com/rancher/charts/mirrored-istio-pilot:1.20.3-distroless
+  type: image
+- source: istio/pilot:1.21.1
+  target: registry.suse.com/rancher/charts/mirrored-istio-pilot:1.21.1
+  type: image
+- source: istio/pilot:1.21.1-distroless
+  target: registry.suse.com/rancher/charts/mirrored-istio-pilot:1.21.1-distroless
+  type: image
+- source: istio/pilot:1.22.1
+  target: registry.suse.com/rancher/charts/mirrored-istio-pilot:1.22.1
+  type: image
+- source: istio/pilot:1.22.1-distroless
+  target: registry.suse.com/rancher/charts/mirrored-istio-pilot:1.22.1-distroless
+  type: image
+- source: istio/pilot:1.23.2
+  target: registry.suse.com/rancher/charts/mirrored-istio-pilot:1.23.2
+  type: image
+- source: istio/pilot:1.23.2-distroless
+  target: registry.suse.com/rancher/charts/mirrored-istio-pilot:1.23.2-distroless
+  type: image
+- source: istio/pilot:1.24.0
+  target: registry.suse.com/rancher/charts/mirrored-istio-pilot:1.24.0
+  type: image
+- source: istio/pilot:1.24.0-distroless
+  target: registry.suse.com/rancher/charts/mirrored-istio-pilot:1.24.0-distroless
+  type: image
+- source: istio/pilot:1.24.1
+  target: registry.suse.com/rancher/charts/mirrored-istio-pilot:1.24.1
+  type: image
+- source: istio/pilot:1.24.1-distroless
+  target: registry.suse.com/rancher/charts/mirrored-istio-pilot:1.24.1-distroless
+  type: image
+- source: istio/pilot:1.25.0
+  target: registry.suse.com/rancher/charts/mirrored-istio-pilot:1.25.0
+  type: image
+- source: istio/pilot:1.25.0-distroless
+  target: registry.suse.com/rancher/charts/mirrored-istio-pilot:1.25.0-distroless
+  type: image
+- source: istio/pilot:1.26.2
+  target: registry.suse.com/rancher/charts/mirrored-istio-pilot:1.26.2
+  type: image
+- source: istio/pilot:1.26.2-distroless
+  target: registry.suse.com/rancher/charts/mirrored-istio-pilot:1.26.2-distroless
+  type: image
+- source: istio/pilot:1.5.9
+  target: registry.suse.com/rancher/charts/mirrored-istio-pilot:1.5.9
+  type: image
+- source: istio/pilot:1.7.8
+  target: registry.suse.com/rancher/charts/mirrored-istio-pilot:1.7.8
+  type: image
+- source: istio/pilot:1.8.3
+  target: registry.suse.com/rancher/charts/mirrored-istio-pilot:1.8.3
+  type: image
+- source: istio/pilot:1.8.4
+  target: registry.suse.com/rancher/charts/mirrored-istio-pilot:1.8.4
+  type: image
+- source: istio/pilot:1.8.5
+  target: registry.suse.com/rancher/charts/mirrored-istio-pilot:1.8.5
+  type: image
+- source: istio/pilot:1.8.6
+  target: registry.suse.com/rancher/charts/mirrored-istio-pilot:1.8.6
+  type: image
+- source: istio/pilot:1.9.1
+  target: registry.suse.com/rancher/charts/mirrored-istio-pilot:1.9.1
+  type: image
+- source: istio/pilot:1.9.2
+  target: registry.suse.com/rancher/charts/mirrored-istio-pilot:1.9.2
+  type: image
+- source: istio/pilot:1.9.3
+  target: registry.suse.com/rancher/charts/mirrored-istio-pilot:1.9.3
+  type: image
+- source: istio/pilot:1.9.5
+  target: registry.suse.com/rancher/charts/mirrored-istio-pilot:1.9.5
+  type: image
+- source: istio/pilot:1.9.6
+  target: registry.suse.com/rancher/charts/mirrored-istio-pilot:1.9.6
+  type: image
+- source: istio/pilot:1.9.8
+  target: registry.suse.com/rancher/charts/mirrored-istio-pilot:1.9.8
+  type: image
+- source: istio/pilot:1.10.0
   target: stgregistry.suse.com/rancher/mirrored-istio-pilot:1.10.0
   type: image
 - source: istio/pilot:1.10.1
@@ -3755,6 +6061,180 @@ sync:
 - source: istio/pilot:1.9.8
   target: stgregistry.suse.com/rancher/mirrored-istio-pilot:1.9.8
   type: image
+- source: istio/pilot:1.10.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-pilot:1.10.0
+  type: image
+- source: istio/pilot:1.10.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-pilot:1.10.1
+  type: image
+- source: istio/pilot:1.10.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-pilot:1.10.2
+  type: image
+- source: istio/pilot:1.10.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-pilot:1.10.4
+  type: image
+- source: istio/pilot:1.11.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-pilot:1.11.2
+  type: image
+- source: istio/pilot:1.11.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-pilot:1.11.4
+  type: image
+- source: istio/pilot:1.11.7
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-pilot:1.11.7
+  type: image
+- source: istio/pilot:1.11.8
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-pilot:1.11.8
+  type: image
+- source: istio/pilot:1.12.6
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-pilot:1.12.6
+  type: image
+- source: istio/pilot:1.13.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-pilot:1.13.3
+  type: image
+- source: istio/pilot:1.14.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-pilot:1.14.1
+  type: image
+- source: istio/pilot:1.14.1-distroless
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-pilot:1.14.1-distroless
+  type: image
+- source: istio/pilot:1.14.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-pilot:1.14.3
+  type: image
+- source: istio/pilot:1.14.3-distroless
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-pilot:1.14.3-distroless
+  type: image
+- source: istio/pilot:1.15.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-pilot:1.15.2
+  type: image
+- source: istio/pilot:1.15.2-distroless
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-pilot:1.15.2-distroless
+  type: image
+- source: istio/pilot:1.15.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-pilot:1.15.3
+  type: image
+- source: istio/pilot:1.15.3-distroless
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-pilot:1.15.3-distroless
+  type: image
+- source: istio/pilot:1.16.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-pilot:1.16.3
+  type: image
+- source: istio/pilot:1.16.3-distroless
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-pilot:1.16.3-distroless
+  type: image
+- source: istio/pilot:1.17.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-pilot:1.17.2
+  type: image
+- source: istio/pilot:1.17.2-distroless
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-pilot:1.17.2-distroless
+  type: image
+- source: istio/pilot:1.18.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-pilot:1.18.2
+  type: image
+- source: istio/pilot:1.18.2-distroless
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-pilot:1.18.2-distroless
+  type: image
+- source: istio/pilot:1.19.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-pilot:1.19.0
+  type: image
+- source: istio/pilot:1.19.0-distroless
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-pilot:1.19.0-distroless
+  type: image
+- source: istio/pilot:1.19.5
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-pilot:1.19.5
+  type: image
+- source: istio/pilot:1.19.5-distroless
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-pilot:1.19.5-distroless
+  type: image
+- source: istio/pilot:1.19.6
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-pilot:1.19.6
+  type: image
+- source: istio/pilot:1.19.6-distroless
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-pilot:1.19.6-distroless
+  type: image
+- source: istio/pilot:1.20.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-pilot:1.20.3
+  type: image
+- source: istio/pilot:1.20.3-distroless
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-pilot:1.20.3-distroless
+  type: image
+- source: istio/pilot:1.21.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-pilot:1.21.1
+  type: image
+- source: istio/pilot:1.21.1-distroless
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-pilot:1.21.1-distroless
+  type: image
+- source: istio/pilot:1.22.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-pilot:1.22.1
+  type: image
+- source: istio/pilot:1.22.1-distroless
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-pilot:1.22.1-distroless
+  type: image
+- source: istio/pilot:1.23.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-pilot:1.23.2
+  type: image
+- source: istio/pilot:1.23.2-distroless
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-pilot:1.23.2-distroless
+  type: image
+- source: istio/pilot:1.24.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-pilot:1.24.0
+  type: image
+- source: istio/pilot:1.24.0-distroless
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-pilot:1.24.0-distroless
+  type: image
+- source: istio/pilot:1.24.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-pilot:1.24.1
+  type: image
+- source: istio/pilot:1.24.1-distroless
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-pilot:1.24.1-distroless
+  type: image
+- source: istio/pilot:1.25.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-pilot:1.25.0
+  type: image
+- source: istio/pilot:1.25.0-distroless
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-pilot:1.25.0-distroless
+  type: image
+- source: istio/pilot:1.26.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-pilot:1.26.2
+  type: image
+- source: istio/pilot:1.26.2-distroless
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-pilot:1.26.2-distroless
+  type: image
+- source: istio/pilot:1.5.9
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-pilot:1.5.9
+  type: image
+- source: istio/pilot:1.7.8
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-pilot:1.7.8
+  type: image
+- source: istio/pilot:1.8.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-pilot:1.8.3
+  type: image
+- source: istio/pilot:1.8.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-pilot:1.8.4
+  type: image
+- source: istio/pilot:1.8.5
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-pilot:1.8.5
+  type: image
+- source: istio/pilot:1.8.6
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-pilot:1.8.6
+  type: image
+- source: istio/pilot:1.9.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-pilot:1.9.1
+  type: image
+- source: istio/pilot:1.9.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-pilot:1.9.2
+  type: image
+- source: istio/pilot:1.9.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-pilot:1.9.3
+  type: image
+- source: istio/pilot:1.9.5
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-pilot:1.9.5
+  type: image
+- source: istio/pilot:1.9.6
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-pilot:1.9.6
+  type: image
+- source: istio/pilot:1.9.8
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-pilot:1.9.8
+  type: image
 - source: istio/proxyv2:1.7.0
   target: docker.io/rancher/istio-proxyv2:1.7.0
   type: image
@@ -3792,6 +6272,24 @@ sync:
   target: registry.suse.com/rancher/istio-proxyv2:1.8.3
   type: image
 - source: istio/proxyv2:1.7.0
+  target: registry.suse.com/rancher/charts/istio-proxyv2:1.7.0
+  type: image
+- source: istio/proxyv2:1.7.1
+  target: registry.suse.com/rancher/charts/istio-proxyv2:1.7.1
+  type: image
+- source: istio/proxyv2:1.7.3
+  target: registry.suse.com/rancher/charts/istio-proxyv2:1.7.3
+  type: image
+- source: istio/proxyv2:1.7.6
+  target: registry.suse.com/rancher/charts/istio-proxyv2:1.7.6
+  type: image
+- source: istio/proxyv2:1.8.1
+  target: registry.suse.com/rancher/charts/istio-proxyv2:1.8.1
+  type: image
+- source: istio/proxyv2:1.8.3
+  target: registry.suse.com/rancher/charts/istio-proxyv2:1.8.3
+  type: image
+- source: istio/proxyv2:1.7.0
   target: stgregistry.suse.com/rancher/istio-proxyv2:1.7.0
   type: image
 - source: istio/proxyv2:1.7.1
@@ -3808,6 +6306,24 @@ sync:
   type: image
 - source: istio/proxyv2:1.8.3
   target: stgregistry.suse.com/rancher/istio-proxyv2:1.8.3
+  type: image
+- source: istio/proxyv2:1.7.0
+  target: stgregistry.suse.com/rancher/charts/istio-proxyv2:1.7.0
+  type: image
+- source: istio/proxyv2:1.7.1
+  target: stgregistry.suse.com/rancher/charts/istio-proxyv2:1.7.1
+  type: image
+- source: istio/proxyv2:1.7.3
+  target: stgregistry.suse.com/rancher/charts/istio-proxyv2:1.7.3
+  type: image
+- source: istio/proxyv2:1.7.6
+  target: stgregistry.suse.com/rancher/charts/istio-proxyv2:1.7.6
+  type: image
+- source: istio/proxyv2:1.8.1
+  target: stgregistry.suse.com/rancher/charts/istio-proxyv2:1.8.1
+  type: image
+- source: istio/proxyv2:1.8.3
+  target: stgregistry.suse.com/rancher/charts/istio-proxyv2:1.8.3
   type: image
 - source: istio/proxyv2:1.10.0
   target: docker.io/rancher/mirrored-istio-proxyv2:1.10.0
@@ -4158,6 +6674,180 @@ sync:
   target: registry.suse.com/rancher/mirrored-istio-proxyv2:1.9.8
   type: image
 - source: istio/proxyv2:1.10.0
+  target: registry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.10.0
+  type: image
+- source: istio/proxyv2:1.10.1
+  target: registry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.10.1
+  type: image
+- source: istio/proxyv2:1.10.2
+  target: registry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.10.2
+  type: image
+- source: istio/proxyv2:1.10.4
+  target: registry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.10.4
+  type: image
+- source: istio/proxyv2:1.11.2
+  target: registry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.11.2
+  type: image
+- source: istio/proxyv2:1.11.4
+  target: registry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.11.4
+  type: image
+- source: istio/proxyv2:1.11.7
+  target: registry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.11.7
+  type: image
+- source: istio/proxyv2:1.11.8
+  target: registry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.11.8
+  type: image
+- source: istio/proxyv2:1.12.6
+  target: registry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.12.6
+  type: image
+- source: istio/proxyv2:1.13.3
+  target: registry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.13.3
+  type: image
+- source: istio/proxyv2:1.14.1
+  target: registry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.14.1
+  type: image
+- source: istio/proxyv2:1.14.1-distroless
+  target: registry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.14.1-distroless
+  type: image
+- source: istio/proxyv2:1.14.3
+  target: registry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.14.3
+  type: image
+- source: istio/proxyv2:1.14.3-distroless
+  target: registry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.14.3-distroless
+  type: image
+- source: istio/proxyv2:1.15.2
+  target: registry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.15.2
+  type: image
+- source: istio/proxyv2:1.15.2-distroless
+  target: registry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.15.2-distroless
+  type: image
+- source: istio/proxyv2:1.15.3
+  target: registry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.15.3
+  type: image
+- source: istio/proxyv2:1.15.3-distroless
+  target: registry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.15.3-distroless
+  type: image
+- source: istio/proxyv2:1.16.3
+  target: registry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.16.3
+  type: image
+- source: istio/proxyv2:1.16.3-distroless
+  target: registry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.16.3-distroless
+  type: image
+- source: istio/proxyv2:1.17.2
+  target: registry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.17.2
+  type: image
+- source: istio/proxyv2:1.17.2-distroless
+  target: registry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.17.2-distroless
+  type: image
+- source: istio/proxyv2:1.18.2
+  target: registry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.18.2
+  type: image
+- source: istio/proxyv2:1.18.2-distroless
+  target: registry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.18.2-distroless
+  type: image
+- source: istio/proxyv2:1.19.0
+  target: registry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.19.0
+  type: image
+- source: istio/proxyv2:1.19.0-distroless
+  target: registry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.19.0-distroless
+  type: image
+- source: istio/proxyv2:1.19.5
+  target: registry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.19.5
+  type: image
+- source: istio/proxyv2:1.19.5-distroless
+  target: registry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.19.5-distroless
+  type: image
+- source: istio/proxyv2:1.19.6
+  target: registry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.19.6
+  type: image
+- source: istio/proxyv2:1.19.6-distroless
+  target: registry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.19.6-distroless
+  type: image
+- source: istio/proxyv2:1.20.3
+  target: registry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.20.3
+  type: image
+- source: istio/proxyv2:1.20.3-distroless
+  target: registry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.20.3-distroless
+  type: image
+- source: istio/proxyv2:1.21.1
+  target: registry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.21.1
+  type: image
+- source: istio/proxyv2:1.21.1-distroless
+  target: registry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.21.1-distroless
+  type: image
+- source: istio/proxyv2:1.22.1
+  target: registry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.22.1
+  type: image
+- source: istio/proxyv2:1.22.1-distroless
+  target: registry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.22.1-distroless
+  type: image
+- source: istio/proxyv2:1.23.2
+  target: registry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.23.2
+  type: image
+- source: istio/proxyv2:1.23.2-distroless
+  target: registry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.23.2-distroless
+  type: image
+- source: istio/proxyv2:1.24.0
+  target: registry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.24.0
+  type: image
+- source: istio/proxyv2:1.24.0-distroless
+  target: registry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.24.0-distroless
+  type: image
+- source: istio/proxyv2:1.24.1
+  target: registry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.24.1
+  type: image
+- source: istio/proxyv2:1.24.1-distroless
+  target: registry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.24.1-distroless
+  type: image
+- source: istio/proxyv2:1.25.0
+  target: registry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.25.0
+  type: image
+- source: istio/proxyv2:1.25.0-distroless
+  target: registry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.25.0-distroless
+  type: image
+- source: istio/proxyv2:1.26.2
+  target: registry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.26.2
+  type: image
+- source: istio/proxyv2:1.26.2-distroless
+  target: registry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.26.2-distroless
+  type: image
+- source: istio/proxyv2:1.5.9
+  target: registry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.5.9
+  type: image
+- source: istio/proxyv2:1.7.8
+  target: registry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.7.8
+  type: image
+- source: istio/proxyv2:1.8.3
+  target: registry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.8.3
+  type: image
+- source: istio/proxyv2:1.8.4
+  target: registry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.8.4
+  type: image
+- source: istio/proxyv2:1.8.5
+  target: registry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.8.5
+  type: image
+- source: istio/proxyv2:1.8.6
+  target: registry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.8.6
+  type: image
+- source: istio/proxyv2:1.9.1
+  target: registry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.9.1
+  type: image
+- source: istio/proxyv2:1.9.2
+  target: registry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.9.2
+  type: image
+- source: istio/proxyv2:1.9.3
+  target: registry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.9.3
+  type: image
+- source: istio/proxyv2:1.9.5
+  target: registry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.9.5
+  type: image
+- source: istio/proxyv2:1.9.6
+  target: registry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.9.6
+  type: image
+- source: istio/proxyv2:1.9.8
+  target: registry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.9.8
+  type: image
+- source: istio/proxyv2:1.10.0
   target: stgregistry.suse.com/rancher/mirrored-istio-proxyv2:1.10.0
   type: image
 - source: istio/proxyv2:1.10.1
@@ -4331,6 +7021,180 @@ sync:
 - source: istio/proxyv2:1.9.8
   target: stgregistry.suse.com/rancher/mirrored-istio-proxyv2:1.9.8
   type: image
+- source: istio/proxyv2:1.10.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.10.0
+  type: image
+- source: istio/proxyv2:1.10.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.10.1
+  type: image
+- source: istio/proxyv2:1.10.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.10.2
+  type: image
+- source: istio/proxyv2:1.10.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.10.4
+  type: image
+- source: istio/proxyv2:1.11.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.11.2
+  type: image
+- source: istio/proxyv2:1.11.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.11.4
+  type: image
+- source: istio/proxyv2:1.11.7
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.11.7
+  type: image
+- source: istio/proxyv2:1.11.8
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.11.8
+  type: image
+- source: istio/proxyv2:1.12.6
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.12.6
+  type: image
+- source: istio/proxyv2:1.13.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.13.3
+  type: image
+- source: istio/proxyv2:1.14.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.14.1
+  type: image
+- source: istio/proxyv2:1.14.1-distroless
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.14.1-distroless
+  type: image
+- source: istio/proxyv2:1.14.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.14.3
+  type: image
+- source: istio/proxyv2:1.14.3-distroless
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.14.3-distroless
+  type: image
+- source: istio/proxyv2:1.15.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.15.2
+  type: image
+- source: istio/proxyv2:1.15.2-distroless
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.15.2-distroless
+  type: image
+- source: istio/proxyv2:1.15.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.15.3
+  type: image
+- source: istio/proxyv2:1.15.3-distroless
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.15.3-distroless
+  type: image
+- source: istio/proxyv2:1.16.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.16.3
+  type: image
+- source: istio/proxyv2:1.16.3-distroless
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.16.3-distroless
+  type: image
+- source: istio/proxyv2:1.17.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.17.2
+  type: image
+- source: istio/proxyv2:1.17.2-distroless
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.17.2-distroless
+  type: image
+- source: istio/proxyv2:1.18.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.18.2
+  type: image
+- source: istio/proxyv2:1.18.2-distroless
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.18.2-distroless
+  type: image
+- source: istio/proxyv2:1.19.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.19.0
+  type: image
+- source: istio/proxyv2:1.19.0-distroless
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.19.0-distroless
+  type: image
+- source: istio/proxyv2:1.19.5
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.19.5
+  type: image
+- source: istio/proxyv2:1.19.5-distroless
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.19.5-distroless
+  type: image
+- source: istio/proxyv2:1.19.6
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.19.6
+  type: image
+- source: istio/proxyv2:1.19.6-distroless
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.19.6-distroless
+  type: image
+- source: istio/proxyv2:1.20.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.20.3
+  type: image
+- source: istio/proxyv2:1.20.3-distroless
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.20.3-distroless
+  type: image
+- source: istio/proxyv2:1.21.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.21.1
+  type: image
+- source: istio/proxyv2:1.21.1-distroless
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.21.1-distroless
+  type: image
+- source: istio/proxyv2:1.22.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.22.1
+  type: image
+- source: istio/proxyv2:1.22.1-distroless
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.22.1-distroless
+  type: image
+- source: istio/proxyv2:1.23.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.23.2
+  type: image
+- source: istio/proxyv2:1.23.2-distroless
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.23.2-distroless
+  type: image
+- source: istio/proxyv2:1.24.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.24.0
+  type: image
+- source: istio/proxyv2:1.24.0-distroless
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.24.0-distroless
+  type: image
+- source: istio/proxyv2:1.24.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.24.1
+  type: image
+- source: istio/proxyv2:1.24.1-distroless
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.24.1-distroless
+  type: image
+- source: istio/proxyv2:1.25.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.25.0
+  type: image
+- source: istio/proxyv2:1.25.0-distroless
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.25.0-distroless
+  type: image
+- source: istio/proxyv2:1.26.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.26.2
+  type: image
+- source: istio/proxyv2:1.26.2-distroless
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.26.2-distroless
+  type: image
+- source: istio/proxyv2:1.5.9
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.5.9
+  type: image
+- source: istio/proxyv2:1.7.8
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.7.8
+  type: image
+- source: istio/proxyv2:1.8.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.8.3
+  type: image
+- source: istio/proxyv2:1.8.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.8.4
+  type: image
+- source: istio/proxyv2:1.8.5
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.8.5
+  type: image
+- source: istio/proxyv2:1.8.6
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.8.6
+  type: image
+- source: istio/proxyv2:1.9.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.9.1
+  type: image
+- source: istio/proxyv2:1.9.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.9.2
+  type: image
+- source: istio/proxyv2:1.9.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.9.3
+  type: image
+- source: istio/proxyv2:1.9.5
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.9.5
+  type: image
+- source: istio/proxyv2:1.9.6
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.9.6
+  type: image
+- source: istio/proxyv2:1.9.8
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.9.8
+  type: image
 - source: istio/sidecar_injector:1.5.9
   target: docker.io/rancher/mirrored-istio-sidecar_injector:1.5.9
   type: image
@@ -4338,7 +7202,13 @@ sync:
   target: registry.suse.com/rancher/mirrored-istio-sidecar_injector:1.5.9
   type: image
 - source: istio/sidecar_injector:1.5.9
+  target: registry.suse.com/rancher/charts/mirrored-istio-sidecar_injector:1.5.9
+  type: image
+- source: istio/sidecar_injector:1.5.9
   target: stgregistry.suse.com/rancher/mirrored-istio-sidecar_injector:1.5.9
+  type: image
+- source: istio/sidecar_injector:1.5.9
+  target: stgregistry.suse.com/rancher/charts/mirrored-istio-sidecar_injector:1.5.9
   type: image
 - source: jaegertracing/all-in-one:1.20.0
   target: docker.io/rancher/jaegertracing-all-in-one:1.20.0
@@ -4347,7 +7217,13 @@ sync:
   target: registry.suse.com/rancher/jaegertracing-all-in-one:1.20.0
   type: image
 - source: jaegertracing/all-in-one:1.20.0
+  target: registry.suse.com/rancher/charts/jaegertracing-all-in-one:1.20.0
+  type: image
+- source: jaegertracing/all-in-one:1.20.0
   target: stgregistry.suse.com/rancher/jaegertracing-all-in-one:1.20.0
+  type: image
+- source: jaegertracing/all-in-one:1.20.0
+  target: stgregistry.suse.com/rancher/charts/jaegertracing-all-in-one:1.20.0
   type: image
 - source: jaegertracing/all-in-one:1.14
   target: docker.io/rancher/mirrored-jaegertracing-all-in-one:1.14
@@ -4488,6 +7364,75 @@ sync:
   target: registry.suse.com/rancher/mirrored-jaegertracing-all-in-one:1.71.0
   type: image
 - source: jaegertracing/all-in-one:1.14
+  target: registry.suse.com/rancher/charts/mirrored-jaegertracing-all-in-one:1.14
+  type: image
+- source: jaegertracing/all-in-one:1.20.0
+  target: registry.suse.com/rancher/charts/mirrored-jaegertracing-all-in-one:1.20.0
+  type: image
+- source: jaegertracing/all-in-one:1.26.0
+  target: registry.suse.com/rancher/charts/mirrored-jaegertracing-all-in-one:1.26.0
+  type: image
+- source: jaegertracing/all-in-one:1.27.0
+  target: registry.suse.com/rancher/charts/mirrored-jaegertracing-all-in-one:1.27.0
+  type: image
+- source: jaegertracing/all-in-one:1.31.0
+  target: registry.suse.com/rancher/charts/mirrored-jaegertracing-all-in-one:1.31.0
+  type: image
+- source: jaegertracing/all-in-one:1.32.0
+  target: registry.suse.com/rancher/charts/mirrored-jaegertracing-all-in-one:1.32.0
+  type: image
+- source: jaegertracing/all-in-one:1.33.0
+  target: registry.suse.com/rancher/charts/mirrored-jaegertracing-all-in-one:1.33.0
+  type: image
+- source: jaegertracing/all-in-one:1.35.1
+  target: registry.suse.com/rancher/charts/mirrored-jaegertracing-all-in-one:1.35.1
+  type: image
+- source: jaegertracing/all-in-one:1.37.0
+  target: registry.suse.com/rancher/charts/mirrored-jaegertracing-all-in-one:1.37.0
+  type: image
+- source: jaegertracing/all-in-one:1.38.1
+  target: registry.suse.com/rancher/charts/mirrored-jaegertracing-all-in-one:1.38.1
+  type: image
+- source: jaegertracing/all-in-one:1.39.0
+  target: registry.suse.com/rancher/charts/mirrored-jaegertracing-all-in-one:1.39.0
+  type: image
+- source: jaegertracing/all-in-one:1.42.0
+  target: registry.suse.com/rancher/charts/mirrored-jaegertracing-all-in-one:1.42.0
+  type: image
+- source: jaegertracing/all-in-one:1.43.0
+  target: registry.suse.com/rancher/charts/mirrored-jaegertracing-all-in-one:1.43.0
+  type: image
+- source: jaegertracing/all-in-one:1.47.0
+  target: registry.suse.com/rancher/charts/mirrored-jaegertracing-all-in-one:1.47.0
+  type: image
+- source: jaegertracing/all-in-one:1.49.0
+  target: registry.suse.com/rancher/charts/mirrored-jaegertracing-all-in-one:1.49.0
+  type: image
+- source: jaegertracing/all-in-one:1.52.0
+  target: registry.suse.com/rancher/charts/mirrored-jaegertracing-all-in-one:1.52.0
+  type: image
+- source: jaegertracing/all-in-one:1.53.0
+  target: registry.suse.com/rancher/charts/mirrored-jaegertracing-all-in-one:1.53.0
+  type: image
+- source: jaegertracing/all-in-one:1.56.0
+  target: registry.suse.com/rancher/charts/mirrored-jaegertracing-all-in-one:1.56.0
+  type: image
+- source: jaegertracing/all-in-one:1.57.0
+  target: registry.suse.com/rancher/charts/mirrored-jaegertracing-all-in-one:1.57.0
+  type: image
+- source: jaegertracing/all-in-one:1.60.0
+  target: registry.suse.com/rancher/charts/mirrored-jaegertracing-all-in-one:1.60.0
+  type: image
+- source: jaegertracing/all-in-one:1.63.0
+  target: registry.suse.com/rancher/charts/mirrored-jaegertracing-all-in-one:1.63.0
+  type: image
+- source: jaegertracing/all-in-one:1.67.0
+  target: registry.suse.com/rancher/charts/mirrored-jaegertracing-all-in-one:1.67.0
+  type: image
+- source: jaegertracing/all-in-one:1.71.0
+  target: registry.suse.com/rancher/charts/mirrored-jaegertracing-all-in-one:1.71.0
+  type: image
+- source: jaegertracing/all-in-one:1.14
   target: stgregistry.suse.com/rancher/mirrored-jaegertracing-all-in-one:1.14
   type: image
 - source: jaegertracing/all-in-one:1.20.0
@@ -4556,6 +7501,75 @@ sync:
 - source: jaegertracing/all-in-one:1.71.0
   target: stgregistry.suse.com/rancher/mirrored-jaegertracing-all-in-one:1.71.0
   type: image
+- source: jaegertracing/all-in-one:1.14
+  target: stgregistry.suse.com/rancher/charts/mirrored-jaegertracing-all-in-one:1.14
+  type: image
+- source: jaegertracing/all-in-one:1.20.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-jaegertracing-all-in-one:1.20.0
+  type: image
+- source: jaegertracing/all-in-one:1.26.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-jaegertracing-all-in-one:1.26.0
+  type: image
+- source: jaegertracing/all-in-one:1.27.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-jaegertracing-all-in-one:1.27.0
+  type: image
+- source: jaegertracing/all-in-one:1.31.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-jaegertracing-all-in-one:1.31.0
+  type: image
+- source: jaegertracing/all-in-one:1.32.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-jaegertracing-all-in-one:1.32.0
+  type: image
+- source: jaegertracing/all-in-one:1.33.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-jaegertracing-all-in-one:1.33.0
+  type: image
+- source: jaegertracing/all-in-one:1.35.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-jaegertracing-all-in-one:1.35.1
+  type: image
+- source: jaegertracing/all-in-one:1.37.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-jaegertracing-all-in-one:1.37.0
+  type: image
+- source: jaegertracing/all-in-one:1.38.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-jaegertracing-all-in-one:1.38.1
+  type: image
+- source: jaegertracing/all-in-one:1.39.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-jaegertracing-all-in-one:1.39.0
+  type: image
+- source: jaegertracing/all-in-one:1.42.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-jaegertracing-all-in-one:1.42.0
+  type: image
+- source: jaegertracing/all-in-one:1.43.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-jaegertracing-all-in-one:1.43.0
+  type: image
+- source: jaegertracing/all-in-one:1.47.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-jaegertracing-all-in-one:1.47.0
+  type: image
+- source: jaegertracing/all-in-one:1.49.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-jaegertracing-all-in-one:1.49.0
+  type: image
+- source: jaegertracing/all-in-one:1.52.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-jaegertracing-all-in-one:1.52.0
+  type: image
+- source: jaegertracing/all-in-one:1.53.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-jaegertracing-all-in-one:1.53.0
+  type: image
+- source: jaegertracing/all-in-one:1.56.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-jaegertracing-all-in-one:1.56.0
+  type: image
+- source: jaegertracing/all-in-one:1.57.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-jaegertracing-all-in-one:1.57.0
+  type: image
+- source: jaegertracing/all-in-one:1.60.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-jaegertracing-all-in-one:1.60.0
+  type: image
+- source: jaegertracing/all-in-one:1.63.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-jaegertracing-all-in-one:1.63.0
+  type: image
+- source: jaegertracing/all-in-one:1.67.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-jaegertracing-all-in-one:1.67.0
+  type: image
+- source: jaegertracing/all-in-one:1.71.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-jaegertracing-all-in-one:1.71.0
+  type: image
 - source: jenkins/jnlp-slave:3.35-4
   target: docker.io/rancher/mirrored-jenkins-jnlp-slave:3.35-4
   type: image
@@ -4569,10 +7583,22 @@ sync:
   target: registry.suse.com/rancher/mirrored-jenkins-jnlp-slave:4.7-1
   type: image
 - source: jenkins/jnlp-slave:3.35-4
+  target: registry.suse.com/rancher/charts/mirrored-jenkins-jnlp-slave:3.35-4
+  type: image
+- source: jenkins/jnlp-slave:4.7-1
+  target: registry.suse.com/rancher/charts/mirrored-jenkins-jnlp-slave:4.7-1
+  type: image
+- source: jenkins/jnlp-slave:3.35-4
   target: stgregistry.suse.com/rancher/mirrored-jenkins-jnlp-slave:3.35-4
   type: image
 - source: jenkins/jnlp-slave:4.7-1
   target: stgregistry.suse.com/rancher/mirrored-jenkins-jnlp-slave:4.7-1
+  type: image
+- source: jenkins/jnlp-slave:3.35-4
+  target: stgregistry.suse.com/rancher/charts/mirrored-jenkins-jnlp-slave:3.35-4
+  type: image
+- source: jenkins/jnlp-slave:4.7-1
+  target: stgregistry.suse.com/rancher/charts/mirrored-jenkins-jnlp-slave:4.7-1
   type: image
 - source: jettech/kube-webhook-certgen:v1.2.1
   target: docker.io/rancher/jettech-kube-webhook-certgen:v1.2.1
@@ -4587,10 +7613,22 @@ sync:
   target: registry.suse.com/rancher/jettech-kube-webhook-certgen:v1.5.0
   type: image
 - source: jettech/kube-webhook-certgen:v1.2.1
+  target: registry.suse.com/rancher/charts/jettech-kube-webhook-certgen:v1.2.1
+  type: image
+- source: jettech/kube-webhook-certgen:v1.5.0
+  target: registry.suse.com/rancher/charts/jettech-kube-webhook-certgen:v1.5.0
+  type: image
+- source: jettech/kube-webhook-certgen:v1.2.1
   target: stgregistry.suse.com/rancher/jettech-kube-webhook-certgen:v1.2.1
   type: image
 - source: jettech/kube-webhook-certgen:v1.5.0
   target: stgregistry.suse.com/rancher/jettech-kube-webhook-certgen:v1.5.0
+  type: image
+- source: jettech/kube-webhook-certgen:v1.2.1
+  target: stgregistry.suse.com/rancher/charts/jettech-kube-webhook-certgen:v1.2.1
+  type: image
+- source: jettech/kube-webhook-certgen:v1.5.0
+  target: stgregistry.suse.com/rancher/charts/jettech-kube-webhook-certgen:v1.5.0
   type: image
 - source: jettech/kube-webhook-certgen:v1.2.1
   target: docker.io/rancher/mirrored-jettech-kube-webhook-certgen:v1.2.1
@@ -4617,6 +7655,18 @@ sync:
   target: registry.suse.com/rancher/mirrored-jettech-kube-webhook-certgen:v1.5.2
   type: image
 - source: jettech/kube-webhook-certgen:v1.2.1
+  target: registry.suse.com/rancher/charts/mirrored-jettech-kube-webhook-certgen:v1.2.1
+  type: image
+- source: jettech/kube-webhook-certgen:v1.5.0
+  target: registry.suse.com/rancher/charts/mirrored-jettech-kube-webhook-certgen:v1.5.0
+  type: image
+- source: jettech/kube-webhook-certgen:v1.5.1
+  target: registry.suse.com/rancher/charts/mirrored-jettech-kube-webhook-certgen:v1.5.1
+  type: image
+- source: jettech/kube-webhook-certgen:v1.5.2
+  target: registry.suse.com/rancher/charts/mirrored-jettech-kube-webhook-certgen:v1.5.2
+  type: image
+- source: jettech/kube-webhook-certgen:v1.2.1
   target: stgregistry.suse.com/rancher/mirrored-jettech-kube-webhook-certgen:v1.2.1
   type: image
 - source: jettech/kube-webhook-certgen:v1.5.0
@@ -4627,6 +7677,18 @@ sync:
   type: image
 - source: jettech/kube-webhook-certgen:v1.5.2
   target: stgregistry.suse.com/rancher/mirrored-jettech-kube-webhook-certgen:v1.5.2
+  type: image
+- source: jettech/kube-webhook-certgen:v1.2.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-jettech-kube-webhook-certgen:v1.2.1
+  type: image
+- source: jettech/kube-webhook-certgen:v1.5.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-jettech-kube-webhook-certgen:v1.5.0
+  type: image
+- source: jettech/kube-webhook-certgen:v1.5.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-jettech-kube-webhook-certgen:v1.5.1
+  type: image
+- source: jettech/kube-webhook-certgen:v1.5.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-jettech-kube-webhook-certgen:v1.5.2
   type: image
 - source: jimmidyson/configmap-reload:v0.3.0
   target: docker.io/rancher/jimmidyson-configmap-reload:v0.3.0
@@ -4641,10 +7703,22 @@ sync:
   target: registry.suse.com/rancher/jimmidyson-configmap-reload:v0.4.0
   type: image
 - source: jimmidyson/configmap-reload:v0.3.0
+  target: registry.suse.com/rancher/charts/jimmidyson-configmap-reload:v0.3.0
+  type: image
+- source: jimmidyson/configmap-reload:v0.4.0
+  target: registry.suse.com/rancher/charts/jimmidyson-configmap-reload:v0.4.0
+  type: image
+- source: jimmidyson/configmap-reload:v0.3.0
   target: stgregistry.suse.com/rancher/jimmidyson-configmap-reload:v0.3.0
   type: image
 - source: jimmidyson/configmap-reload:v0.4.0
   target: stgregistry.suse.com/rancher/jimmidyson-configmap-reload:v0.4.0
+  type: image
+- source: jimmidyson/configmap-reload:v0.3.0
+  target: stgregistry.suse.com/rancher/charts/jimmidyson-configmap-reload:v0.3.0
+  type: image
+- source: jimmidyson/configmap-reload:v0.4.0
+  target: stgregistry.suse.com/rancher/charts/jimmidyson-configmap-reload:v0.4.0
   type: image
 - source: jimmidyson/configmap-reload:v0.3.0
   target: docker.io/rancher/mirrored-jimmidyson-configmap-reload:v0.3.0
@@ -4665,6 +7739,15 @@ sync:
   target: registry.suse.com/rancher/mirrored-jimmidyson-configmap-reload:v0.8.0
   type: image
 - source: jimmidyson/configmap-reload:v0.3.0
+  target: registry.suse.com/rancher/charts/mirrored-jimmidyson-configmap-reload:v0.3.0
+  type: image
+- source: jimmidyson/configmap-reload:v0.4.0
+  target: registry.suse.com/rancher/charts/mirrored-jimmidyson-configmap-reload:v0.4.0
+  type: image
+- source: jimmidyson/configmap-reload:v0.8.0
+  target: registry.suse.com/rancher/charts/mirrored-jimmidyson-configmap-reload:v0.8.0
+  type: image
+- source: jimmidyson/configmap-reload:v0.3.0
   target: stgregistry.suse.com/rancher/mirrored-jimmidyson-configmap-reload:v0.3.0
   type: image
 - source: jimmidyson/configmap-reload:v0.4.0
@@ -4672,6 +7755,15 @@ sync:
   type: image
 - source: jimmidyson/configmap-reload:v0.8.0
   target: stgregistry.suse.com/rancher/mirrored-jimmidyson-configmap-reload:v0.8.0
+  type: image
+- source: jimmidyson/configmap-reload:v0.3.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-jimmidyson-configmap-reload:v0.3.0
+  type: image
+- source: jimmidyson/configmap-reload:v0.4.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-jimmidyson-configmap-reload:v0.4.0
+  type: image
+- source: jimmidyson/configmap-reload:v0.8.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-jimmidyson-configmap-reload:v0.8.0
   type: image
 - source: kiwigrid/k8s-sidecar:0.1.151
   target: docker.io/rancher/kiwigrid-k8s-sidecar:0.1.151
@@ -4686,10 +7778,22 @@ sync:
   target: registry.suse.com/rancher/kiwigrid-k8s-sidecar:1.1.0
   type: image
 - source: kiwigrid/k8s-sidecar:0.1.151
+  target: registry.suse.com/rancher/charts/kiwigrid-k8s-sidecar:0.1.151
+  type: image
+- source: kiwigrid/k8s-sidecar:1.1.0
+  target: registry.suse.com/rancher/charts/kiwigrid-k8s-sidecar:1.1.0
+  type: image
+- source: kiwigrid/k8s-sidecar:0.1.151
   target: stgregistry.suse.com/rancher/kiwigrid-k8s-sidecar:0.1.151
   type: image
 - source: kiwigrid/k8s-sidecar:1.1.0
   target: stgregistry.suse.com/rancher/kiwigrid-k8s-sidecar:1.1.0
+  type: image
+- source: kiwigrid/k8s-sidecar:0.1.151
+  target: stgregistry.suse.com/rancher/charts/kiwigrid-k8s-sidecar:0.1.151
+  type: image
+- source: kiwigrid/k8s-sidecar:1.1.0
+  target: stgregistry.suse.com/rancher/charts/kiwigrid-k8s-sidecar:1.1.0
   type: image
 - source: kiwigrid/k8s-sidecar:0.1.151
   target: docker.io/rancher/mirrored-kiwigrid-k8s-sidecar:0.1.151
@@ -4704,10 +7808,22 @@ sync:
   target: registry.suse.com/rancher/mirrored-kiwigrid-k8s-sidecar:1.27.4
   type: image
 - source: kiwigrid/k8s-sidecar:0.1.151
+  target: registry.suse.com/rancher/charts/mirrored-kiwigrid-k8s-sidecar:0.1.151
+  type: image
+- source: kiwigrid/k8s-sidecar:1.27.4
+  target: registry.suse.com/rancher/charts/mirrored-kiwigrid-k8s-sidecar:1.27.4
+  type: image
+- source: kiwigrid/k8s-sidecar:0.1.151
   target: stgregistry.suse.com/rancher/mirrored-kiwigrid-k8s-sidecar:0.1.151
   type: image
 - source: kiwigrid/k8s-sidecar:1.27.4
   target: stgregistry.suse.com/rancher/mirrored-kiwigrid-k8s-sidecar:1.27.4
+  type: image
+- source: kiwigrid/k8s-sidecar:0.1.151
+  target: stgregistry.suse.com/rancher/charts/mirrored-kiwigrid-k8s-sidecar:0.1.151
+  type: image
+- source: kiwigrid/k8s-sidecar:1.27.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-kiwigrid-k8s-sidecar:1.27.4
   type: image
 - source: library/busybox:1.31.1
   target: docker.io/rancher/library-busybox:1.31.1
@@ -4722,10 +7838,22 @@ sync:
   target: registry.suse.com/rancher/library-busybox:1.32.1
   type: image
 - source: library/busybox:1.31.1
+  target: registry.suse.com/rancher/charts/library-busybox:1.31.1
+  type: image
+- source: library/busybox:1.32.1
+  target: registry.suse.com/rancher/charts/library-busybox:1.32.1
+  type: image
+- source: library/busybox:1.31.1
   target: stgregistry.suse.com/rancher/library-busybox:1.31.1
   type: image
 - source: library/busybox:1.32.1
   target: stgregistry.suse.com/rancher/library-busybox:1.32.1
+  type: image
+- source: library/busybox:1.31.1
+  target: stgregistry.suse.com/rancher/charts/library-busybox:1.31.1
+  type: image
+- source: library/busybox:1.32.1
+  target: stgregistry.suse.com/rancher/charts/library-busybox:1.32.1
   type: image
 - source: library/busybox:1.31.1
   target: docker.io/rancher/mirrored-library-busybox:1.31.1
@@ -4758,6 +7886,21 @@ sync:
   target: registry.suse.com/rancher/mirrored-library-busybox:1.37.0
   type: image
 - source: library/busybox:1.31.1
+  target: registry.suse.com/rancher/charts/mirrored-library-busybox:1.31.1
+  type: image
+- source: library/busybox:1.32.1
+  target: registry.suse.com/rancher/charts/mirrored-library-busybox:1.32.1
+  type: image
+- source: library/busybox:1.34.1
+  target: registry.suse.com/rancher/charts/mirrored-library-busybox:1.34.1
+  type: image
+- source: library/busybox:1.36.1
+  target: registry.suse.com/rancher/charts/mirrored-library-busybox:1.36.1
+  type: image
+- source: library/busybox:1.37.0
+  target: registry.suse.com/rancher/charts/mirrored-library-busybox:1.37.0
+  type: image
+- source: library/busybox:1.31.1
   target: stgregistry.suse.com/rancher/mirrored-library-busybox:1.31.1
   type: image
 - source: library/busybox:1.32.1
@@ -4772,6 +7915,21 @@ sync:
 - source: library/busybox:1.37.0
   target: stgregistry.suse.com/rancher/mirrored-library-busybox:1.37.0
   type: image
+- source: library/busybox:1.31.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-library-busybox:1.31.1
+  type: image
+- source: library/busybox:1.32.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-library-busybox:1.32.1
+  type: image
+- source: library/busybox:1.34.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-library-busybox:1.34.1
+  type: image
+- source: library/busybox:1.36.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-library-busybox:1.36.1
+  type: image
+- source: library/busybox:1.37.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-library-busybox:1.37.0
+  type: image
 - source: library/nginx:1.19.2-alpine
   target: docker.io/rancher/library-nginx:1.19.2-alpine
   type: image
@@ -4779,7 +7937,13 @@ sync:
   target: registry.suse.com/rancher/library-nginx:1.19.2-alpine
   type: image
 - source: library/nginx:1.19.2-alpine
+  target: registry.suse.com/rancher/charts/library-nginx:1.19.2-alpine
+  type: image
+- source: library/nginx:1.19.2-alpine
   target: stgregistry.suse.com/rancher/library-nginx:1.19.2-alpine
+  type: image
+- source: library/nginx:1.19.2-alpine
+  target: stgregistry.suse.com/rancher/charts/library-nginx:1.19.2-alpine
   type: image
 - source: library/nginx:1.19.2-alpine
   target: docker.io/rancher/mirrored-library-nginx:1.19.2-alpine
@@ -4842,6 +8006,36 @@ sync:
   target: registry.suse.com/rancher/mirrored-library-nginx:1.29.1-alpine
   type: image
 - source: library/nginx:1.19.2-alpine
+  target: registry.suse.com/rancher/charts/mirrored-library-nginx:1.19.2-alpine
+  type: image
+- source: library/nginx:1.19.9-alpine
+  target: registry.suse.com/rancher/charts/mirrored-library-nginx:1.19.9-alpine
+  type: image
+- source: library/nginx:1.21.0-alpine
+  target: registry.suse.com/rancher/charts/mirrored-library-nginx:1.21.0-alpine
+  type: image
+- source: library/nginx:1.21.1-alpine
+  target: registry.suse.com/rancher/charts/mirrored-library-nginx:1.21.1-alpine
+  type: image
+- source: library/nginx:1.21.6-alpine
+  target: registry.suse.com/rancher/charts/mirrored-library-nginx:1.21.6-alpine
+  type: image
+- source: library/nginx:1.23.0-alpine
+  target: registry.suse.com/rancher/charts/mirrored-library-nginx:1.23.0-alpine
+  type: image
+- source: library/nginx:1.23.2-alpine
+  target: registry.suse.com/rancher/charts/mirrored-library-nginx:1.23.2-alpine
+  type: image
+- source: library/nginx:1.24.0-alpine
+  target: registry.suse.com/rancher/charts/mirrored-library-nginx:1.24.0-alpine
+  type: image
+- source: library/nginx:1.27.2-alpine
+  target: registry.suse.com/rancher/charts/mirrored-library-nginx:1.27.2-alpine
+  type: image
+- source: library/nginx:1.29.1-alpine
+  target: registry.suse.com/rancher/charts/mirrored-library-nginx:1.29.1-alpine
+  type: image
+- source: library/nginx:1.19.2-alpine
   target: stgregistry.suse.com/rancher/mirrored-library-nginx:1.19.2-alpine
   type: image
 - source: library/nginx:1.19.9-alpine
@@ -4871,6 +8065,36 @@ sync:
 - source: library/nginx:1.29.1-alpine
   target: stgregistry.suse.com/rancher/mirrored-library-nginx:1.29.1-alpine
   type: image
+- source: library/nginx:1.19.2-alpine
+  target: stgregistry.suse.com/rancher/charts/mirrored-library-nginx:1.19.2-alpine
+  type: image
+- source: library/nginx:1.19.9-alpine
+  target: stgregistry.suse.com/rancher/charts/mirrored-library-nginx:1.19.9-alpine
+  type: image
+- source: library/nginx:1.21.0-alpine
+  target: stgregistry.suse.com/rancher/charts/mirrored-library-nginx:1.21.0-alpine
+  type: image
+- source: library/nginx:1.21.1-alpine
+  target: stgregistry.suse.com/rancher/charts/mirrored-library-nginx:1.21.1-alpine
+  type: image
+- source: library/nginx:1.21.6-alpine
+  target: stgregistry.suse.com/rancher/charts/mirrored-library-nginx:1.21.6-alpine
+  type: image
+- source: library/nginx:1.23.0-alpine
+  target: stgregistry.suse.com/rancher/charts/mirrored-library-nginx:1.23.0-alpine
+  type: image
+- source: library/nginx:1.23.2-alpine
+  target: stgregistry.suse.com/rancher/charts/mirrored-library-nginx:1.23.2-alpine
+  type: image
+- source: library/nginx:1.24.0-alpine
+  target: stgregistry.suse.com/rancher/charts/mirrored-library-nginx:1.24.0-alpine
+  type: image
+- source: library/nginx:1.27.2-alpine
+  target: stgregistry.suse.com/rancher/charts/mirrored-library-nginx:1.27.2-alpine
+  type: image
+- source: library/nginx:1.29.1-alpine
+  target: stgregistry.suse.com/rancher/charts/mirrored-library-nginx:1.29.1-alpine
+  type: image
 - source: library/redis:7.2.9
   target: docker.io/rancher/mirrored-library-redis:7.2.9
   type: image
@@ -4878,7 +8102,13 @@ sync:
   target: registry.suse.com/rancher/mirrored-library-redis:7.2.9
   type: image
 - source: library/redis:7.2.9
+  target: registry.suse.com/rancher/charts/mirrored-library-redis:7.2.9
+  type: image
+- source: library/redis:7.2.9
   target: stgregistry.suse.com/rancher/mirrored-library-redis:7.2.9
+  type: image
+- source: library/redis:7.2.9
+  target: stgregistry.suse.com/rancher/charts/mirrored-library-redis:7.2.9
   type: image
 - source: library/registry:2.7.1
   target: docker.io/rancher/mirrored-library-registry:2.7.1
@@ -4893,10 +8123,22 @@ sync:
   target: registry.suse.com/rancher/mirrored-library-registry:2.8.1
   type: image
 - source: library/registry:2.7.1
+  target: registry.suse.com/rancher/charts/mirrored-library-registry:2.7.1
+  type: image
+- source: library/registry:2.8.1
+  target: registry.suse.com/rancher/charts/mirrored-library-registry:2.8.1
+  type: image
+- source: library/registry:2.7.1
   target: stgregistry.suse.com/rancher/mirrored-library-registry:2.7.1
   type: image
 - source: library/registry:2.8.1
   target: stgregistry.suse.com/rancher/mirrored-library-registry:2.8.1
+  type: image
+- source: library/registry:2.7.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-library-registry:2.7.1
+  type: image
+- source: library/registry:2.8.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-library-registry:2.8.1
   type: image
 - source: library/traefik:2.4.2
   target: docker.io/rancher/library-traefik:2.4.2
@@ -4917,6 +8159,15 @@ sync:
   target: registry.suse.com/rancher/library-traefik:2.4.9
   type: image
 - source: library/traefik:2.4.2
+  target: registry.suse.com/rancher/charts/library-traefik:2.4.2
+  type: image
+- source: library/traefik:2.4.8
+  target: registry.suse.com/rancher/charts/library-traefik:2.4.8
+  type: image
+- source: library/traefik:2.4.9
+  target: registry.suse.com/rancher/charts/library-traefik:2.4.9
+  type: image
+- source: library/traefik:2.4.2
   target: stgregistry.suse.com/rancher/library-traefik:2.4.2
   type: image
 - source: library/traefik:2.4.8
@@ -4924,6 +8175,15 @@ sync:
   type: image
 - source: library/traefik:2.4.9
   target: stgregistry.suse.com/rancher/library-traefik:2.4.9
+  type: image
+- source: library/traefik:2.4.2
+  target: stgregistry.suse.com/rancher/charts/library-traefik:2.4.2
+  type: image
+- source: library/traefik:2.4.8
+  target: stgregistry.suse.com/rancher/charts/library-traefik:2.4.8
+  type: image
+- source: library/traefik:2.4.9
+  target: stgregistry.suse.com/rancher/charts/library-traefik:2.4.9
   type: image
 - source: library/traefik:2.10.5
   target: docker.io/rancher/mirrored-library-traefik:2.10.5
@@ -5094,6 +8354,90 @@ sync:
   target: registry.suse.com/rancher/mirrored-library-traefik:3.5.3
   type: image
 - source: library/traefik:2.10.5
+  target: registry.suse.com/rancher/charts/mirrored-library-traefik:2.10.5
+  type: image
+- source: library/traefik:2.10.7
+  target: registry.suse.com/rancher/charts/mirrored-library-traefik:2.10.7
+  type: image
+- source: library/traefik:2.11.10
+  target: registry.suse.com/rancher/charts/mirrored-library-traefik:2.11.10
+  type: image
+- source: library/traefik:2.11.11
+  target: registry.suse.com/rancher/charts/mirrored-library-traefik:2.11.11
+  type: image
+- source: library/traefik:2.11.16
+  target: registry.suse.com/rancher/charts/mirrored-library-traefik:2.11.16
+  type: image
+- source: library/traefik:2.11.17
+  target: registry.suse.com/rancher/charts/mirrored-library-traefik:2.11.17
+  type: image
+- source: library/traefik:2.11.18
+  target: registry.suse.com/rancher/charts/mirrored-library-traefik:2.11.18
+  type: image
+- source: library/traefik:2.11.20
+  target: registry.suse.com/rancher/charts/mirrored-library-traefik:2.11.20
+  type: image
+- source: library/traefik:2.11.22
+  target: registry.suse.com/rancher/charts/mirrored-library-traefik:2.11.22
+  type: image
+- source: library/traefik:2.11.24
+  target: registry.suse.com/rancher/charts/mirrored-library-traefik:2.11.24
+  type: image
+- source: library/traefik:2.11.29
+  target: registry.suse.com/rancher/charts/mirrored-library-traefik:2.11.29
+  type: image
+- source: library/traefik:2.11.8
+  target: registry.suse.com/rancher/charts/mirrored-library-traefik:2.11.8
+  type: image
+- source: library/traefik:2.4.8
+  target: registry.suse.com/rancher/charts/mirrored-library-traefik:2.4.8
+  type: image
+- source: library/traefik:2.5.0
+  target: registry.suse.com/rancher/charts/mirrored-library-traefik:2.5.0
+  type: image
+- source: library/traefik:2.5.6
+  target: registry.suse.com/rancher/charts/mirrored-library-traefik:2.5.6
+  type: image
+- source: library/traefik:2.6.0
+  target: registry.suse.com/rancher/charts/mirrored-library-traefik:2.6.0
+  type: image
+- source: library/traefik:2.6.1
+  target: registry.suse.com/rancher/charts/mirrored-library-traefik:2.6.1
+  type: image
+- source: library/traefik:2.6.2
+  target: registry.suse.com/rancher/charts/mirrored-library-traefik:2.6.2
+  type: image
+- source: library/traefik:2.8.7
+  target: registry.suse.com/rancher/charts/mirrored-library-traefik:2.8.7
+  type: image
+- source: library/traefik:2.9.1
+  target: registry.suse.com/rancher/charts/mirrored-library-traefik:2.9.1
+  type: image
+- source: library/traefik:2.9.10
+  target: registry.suse.com/rancher/charts/mirrored-library-traefik:2.9.10
+  type: image
+- source: library/traefik:2.9.4
+  target: registry.suse.com/rancher/charts/mirrored-library-traefik:2.9.4
+  type: image
+- source: library/traefik:3.3.2
+  target: registry.suse.com/rancher/charts/mirrored-library-traefik:3.3.2
+  type: image
+- source: library/traefik:3.3.3
+  target: registry.suse.com/rancher/charts/mirrored-library-traefik:3.3.3
+  type: image
+- source: library/traefik:3.3.5
+  target: registry.suse.com/rancher/charts/mirrored-library-traefik:3.3.5
+  type: image
+- source: library/traefik:3.3.6
+  target: registry.suse.com/rancher/charts/mirrored-library-traefik:3.3.6
+  type: image
+- source: library/traefik:3.5.1
+  target: registry.suse.com/rancher/charts/mirrored-library-traefik:3.5.1
+  type: image
+- source: library/traefik:3.5.3
+  target: registry.suse.com/rancher/charts/mirrored-library-traefik:3.5.3
+  type: image
+- source: library/traefik:2.10.5
   target: stgregistry.suse.com/rancher/mirrored-library-traefik:2.10.5
   type: image
 - source: library/traefik:2.10.7
@@ -5177,6 +8521,90 @@ sync:
 - source: library/traefik:3.5.3
   target: stgregistry.suse.com/rancher/mirrored-library-traefik:3.5.3
   type: image
+- source: library/traefik:2.10.5
+  target: stgregistry.suse.com/rancher/charts/mirrored-library-traefik:2.10.5
+  type: image
+- source: library/traefik:2.10.7
+  target: stgregistry.suse.com/rancher/charts/mirrored-library-traefik:2.10.7
+  type: image
+- source: library/traefik:2.11.10
+  target: stgregistry.suse.com/rancher/charts/mirrored-library-traefik:2.11.10
+  type: image
+- source: library/traefik:2.11.11
+  target: stgregistry.suse.com/rancher/charts/mirrored-library-traefik:2.11.11
+  type: image
+- source: library/traefik:2.11.16
+  target: stgregistry.suse.com/rancher/charts/mirrored-library-traefik:2.11.16
+  type: image
+- source: library/traefik:2.11.17
+  target: stgregistry.suse.com/rancher/charts/mirrored-library-traefik:2.11.17
+  type: image
+- source: library/traefik:2.11.18
+  target: stgregistry.suse.com/rancher/charts/mirrored-library-traefik:2.11.18
+  type: image
+- source: library/traefik:2.11.20
+  target: stgregistry.suse.com/rancher/charts/mirrored-library-traefik:2.11.20
+  type: image
+- source: library/traefik:2.11.22
+  target: stgregistry.suse.com/rancher/charts/mirrored-library-traefik:2.11.22
+  type: image
+- source: library/traefik:2.11.24
+  target: stgregistry.suse.com/rancher/charts/mirrored-library-traefik:2.11.24
+  type: image
+- source: library/traefik:2.11.29
+  target: stgregistry.suse.com/rancher/charts/mirrored-library-traefik:2.11.29
+  type: image
+- source: library/traefik:2.11.8
+  target: stgregistry.suse.com/rancher/charts/mirrored-library-traefik:2.11.8
+  type: image
+- source: library/traefik:2.4.8
+  target: stgregistry.suse.com/rancher/charts/mirrored-library-traefik:2.4.8
+  type: image
+- source: library/traefik:2.5.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-library-traefik:2.5.0
+  type: image
+- source: library/traefik:2.5.6
+  target: stgregistry.suse.com/rancher/charts/mirrored-library-traefik:2.5.6
+  type: image
+- source: library/traefik:2.6.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-library-traefik:2.6.0
+  type: image
+- source: library/traefik:2.6.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-library-traefik:2.6.1
+  type: image
+- source: library/traefik:2.6.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-library-traefik:2.6.2
+  type: image
+- source: library/traefik:2.8.7
+  target: stgregistry.suse.com/rancher/charts/mirrored-library-traefik:2.8.7
+  type: image
+- source: library/traefik:2.9.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-library-traefik:2.9.1
+  type: image
+- source: library/traefik:2.9.10
+  target: stgregistry.suse.com/rancher/charts/mirrored-library-traefik:2.9.10
+  type: image
+- source: library/traefik:2.9.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-library-traefik:2.9.4
+  type: image
+- source: library/traefik:3.3.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-library-traefik:3.3.2
+  type: image
+- source: library/traefik:3.3.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-library-traefik:3.3.3
+  type: image
+- source: library/traefik:3.3.5
+  target: stgregistry.suse.com/rancher/charts/mirrored-library-traefik:3.3.5
+  type: image
+- source: library/traefik:3.3.6
+  target: stgregistry.suse.com/rancher/charts/mirrored-library-traefik:3.3.6
+  type: image
+- source: library/traefik:3.5.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-library-traefik:3.5.1
+  type: image
+- source: library/traefik:3.5.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-library-traefik:3.5.3
+  type: image
 - source: longhornio/backing-image-manager:v1_20210422
   target: docker.io/rancher/longhornio-backing-image-manager:v1_20210422
   type: image
@@ -5214,6 +8642,24 @@ sync:
   target: registry.suse.com/rancher/longhornio-backing-image-manager:v3_20220808
   type: image
 - source: longhornio/backing-image-manager:v1_20210422
+  target: registry.suse.com/rancher/charts/longhornio-backing-image-manager:v1_20210422
+  type: image
+- source: longhornio/backing-image-manager:v1_20210422_patch1
+  target: registry.suse.com/rancher/charts/longhornio-backing-image-manager:v1_20210422_patch1
+  type: image
+- source: longhornio/backing-image-manager:v2_20210820
+  target: registry.suse.com/rancher/charts/longhornio-backing-image-manager:v2_20210820
+  type: image
+- source: longhornio/backing-image-manager:v2_20210820_patch1
+  target: registry.suse.com/rancher/charts/longhornio-backing-image-manager:v2_20210820_patch1
+  type: image
+- source: longhornio/backing-image-manager:v3_20220609
+  target: registry.suse.com/rancher/charts/longhornio-backing-image-manager:v3_20220609
+  type: image
+- source: longhornio/backing-image-manager:v3_20220808
+  target: registry.suse.com/rancher/charts/longhornio-backing-image-manager:v3_20220808
+  type: image
+- source: longhornio/backing-image-manager:v1_20210422
   target: stgregistry.suse.com/rancher/longhornio-backing-image-manager:v1_20210422
   type: image
 - source: longhornio/backing-image-manager:v1_20210422_patch1
@@ -5230,6 +8676,24 @@ sync:
   type: image
 - source: longhornio/backing-image-manager:v3_20220808
   target: stgregistry.suse.com/rancher/longhornio-backing-image-manager:v3_20220808
+  type: image
+- source: longhornio/backing-image-manager:v1_20210422
+  target: stgregistry.suse.com/rancher/charts/longhornio-backing-image-manager:v1_20210422
+  type: image
+- source: longhornio/backing-image-manager:v1_20210422_patch1
+  target: stgregistry.suse.com/rancher/charts/longhornio-backing-image-manager:v1_20210422_patch1
+  type: image
+- source: longhornio/backing-image-manager:v2_20210820
+  target: stgregistry.suse.com/rancher/charts/longhornio-backing-image-manager:v2_20210820
+  type: image
+- source: longhornio/backing-image-manager:v2_20210820_patch1
+  target: stgregistry.suse.com/rancher/charts/longhornio-backing-image-manager:v2_20210820_patch1
+  type: image
+- source: longhornio/backing-image-manager:v3_20220609
+  target: stgregistry.suse.com/rancher/charts/longhornio-backing-image-manager:v3_20220609
+  type: image
+- source: longhornio/backing-image-manager:v3_20220808
+  target: stgregistry.suse.com/rancher/charts/longhornio-backing-image-manager:v3_20220808
   type: image
 - source: longhornio/backing-image-manager:v1.4.0
   target: docker.io/rancher/mirrored-longhornio-backing-image-manager:v1.4.0
@@ -5430,6 +8894,105 @@ sync:
   target: registry.suse.com/rancher/mirrored-longhornio-backing-image-manager:v3_20230320
   type: image
 - source: longhornio/backing-image-manager:v1.4.0
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v1.4.0
+  type: image
+- source: longhornio/backing-image-manager:v1.4.1
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v1.4.1
+  type: image
+- source: longhornio/backing-image-manager:v1.4.2
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v1.4.2
+  type: image
+- source: longhornio/backing-image-manager:v1.4.3
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v1.4.3
+  type: image
+- source: longhornio/backing-image-manager:v1.4.4
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v1.4.4
+  type: image
+- source: longhornio/backing-image-manager:v1.5.0
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v1.5.0
+  type: image
+- source: longhornio/backing-image-manager:v1.5.1
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v1.5.1
+  type: image
+- source: longhornio/backing-image-manager:v1.5.2
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v1.5.2
+  type: image
+- source: longhornio/backing-image-manager:v1.5.3
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v1.5.3
+  type: image
+- source: longhornio/backing-image-manager:v1.5.4
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v1.5.4
+  type: image
+- source: longhornio/backing-image-manager:v1.5.5
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v1.5.5
+  type: image
+- source: longhornio/backing-image-manager:v1.6.0
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v1.6.0
+  type: image
+- source: longhornio/backing-image-manager:v1.6.1
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v1.6.1
+  type: image
+- source: longhornio/backing-image-manager:v1.6.2
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v1.6.2
+  type: image
+- source: longhornio/backing-image-manager:v1.6.3
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v1.6.3
+  type: image
+- source: longhornio/backing-image-manager:v1.6.4
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v1.6.4
+  type: image
+- source: longhornio/backing-image-manager:v1.7.0
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v1.7.0
+  type: image
+- source: longhornio/backing-image-manager:v1.7.1
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v1.7.1
+  type: image
+- source: longhornio/backing-image-manager:v1.7.2
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v1.7.2
+  type: image
+- source: longhornio/backing-image-manager:v1.7.3
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v1.7.3
+  type: image
+- source: longhornio/backing-image-manager:v1.8.1
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v1.8.1
+  type: image
+- source: longhornio/backing-image-manager:v1.8.2
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v1.8.2
+  type: image
+- source: longhornio/backing-image-manager:v1.9.1
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v1.9.1
+  type: image
+- source: longhornio/backing-image-manager:v1.9.2
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v1.9.2
+  type: image
+- source: longhornio/backing-image-manager:v1_20210422
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v1_20210422
+  type: image
+- source: longhornio/backing-image-manager:v1_20210422_patch1
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v1_20210422_patch1
+  type: image
+- source: longhornio/backing-image-manager:v2_20210820
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v2_20210820
+  type: image
+- source: longhornio/backing-image-manager:v2_20210820_patch1
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v2_20210820_patch1
+  type: image
+- source: longhornio/backing-image-manager:v2_20221027
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v2_20221027
+  type: image
+- source: longhornio/backing-image-manager:v3_20220609
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v3_20220609
+  type: image
+- source: longhornio/backing-image-manager:v3_20220808
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v3_20220808
+  type: image
+- source: longhornio/backing-image-manager:v3_20221003
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v3_20221003
+  type: image
+- source: longhornio/backing-image-manager:v3_20230320
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v3_20230320
+  type: image
+- source: longhornio/backing-image-manager:v1.4.0
   target: stgregistry.suse.com/rancher/mirrored-longhornio-backing-image-manager:v1.4.0
   type: image
 - source: longhornio/backing-image-manager:v1.4.1
@@ -5528,6 +9091,105 @@ sync:
 - source: longhornio/backing-image-manager:v3_20230320
   target: stgregistry.suse.com/rancher/mirrored-longhornio-backing-image-manager:v3_20230320
   type: image
+- source: longhornio/backing-image-manager:v1.4.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v1.4.0
+  type: image
+- source: longhornio/backing-image-manager:v1.4.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v1.4.1
+  type: image
+- source: longhornio/backing-image-manager:v1.4.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v1.4.2
+  type: image
+- source: longhornio/backing-image-manager:v1.4.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v1.4.3
+  type: image
+- source: longhornio/backing-image-manager:v1.4.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v1.4.4
+  type: image
+- source: longhornio/backing-image-manager:v1.5.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v1.5.0
+  type: image
+- source: longhornio/backing-image-manager:v1.5.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v1.5.1
+  type: image
+- source: longhornio/backing-image-manager:v1.5.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v1.5.2
+  type: image
+- source: longhornio/backing-image-manager:v1.5.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v1.5.3
+  type: image
+- source: longhornio/backing-image-manager:v1.5.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v1.5.4
+  type: image
+- source: longhornio/backing-image-manager:v1.5.5
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v1.5.5
+  type: image
+- source: longhornio/backing-image-manager:v1.6.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v1.6.0
+  type: image
+- source: longhornio/backing-image-manager:v1.6.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v1.6.1
+  type: image
+- source: longhornio/backing-image-manager:v1.6.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v1.6.2
+  type: image
+- source: longhornio/backing-image-manager:v1.6.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v1.6.3
+  type: image
+- source: longhornio/backing-image-manager:v1.6.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v1.6.4
+  type: image
+- source: longhornio/backing-image-manager:v1.7.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v1.7.0
+  type: image
+- source: longhornio/backing-image-manager:v1.7.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v1.7.1
+  type: image
+- source: longhornio/backing-image-manager:v1.7.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v1.7.2
+  type: image
+- source: longhornio/backing-image-manager:v1.7.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v1.7.3
+  type: image
+- source: longhornio/backing-image-manager:v1.8.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v1.8.1
+  type: image
+- source: longhornio/backing-image-manager:v1.8.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v1.8.2
+  type: image
+- source: longhornio/backing-image-manager:v1.9.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v1.9.1
+  type: image
+- source: longhornio/backing-image-manager:v1.9.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v1.9.2
+  type: image
+- source: longhornio/backing-image-manager:v1_20210422
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v1_20210422
+  type: image
+- source: longhornio/backing-image-manager:v1_20210422_patch1
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v1_20210422_patch1
+  type: image
+- source: longhornio/backing-image-manager:v2_20210820
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v2_20210820
+  type: image
+- source: longhornio/backing-image-manager:v2_20210820_patch1
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v2_20210820_patch1
+  type: image
+- source: longhornio/backing-image-manager:v2_20221027
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v2_20221027
+  type: image
+- source: longhornio/backing-image-manager:v3_20220609
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v3_20220609
+  type: image
+- source: longhornio/backing-image-manager:v3_20220808
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v3_20220808
+  type: image
+- source: longhornio/backing-image-manager:v3_20221003
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v3_20221003
+  type: image
+- source: longhornio/backing-image-manager:v3_20230320
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v3_20230320
+  type: image
 - source: longhornio/csi-attacher:v2.0.0
   target: docker.io/rancher/longhornio-csi-attacher:v2.0.0
   type: image
@@ -5559,6 +9221,21 @@ sync:
   target: registry.suse.com/rancher/longhornio-csi-attacher:v3.4.0
   type: image
 - source: longhornio/csi-attacher:v2.0.0
+  target: registry.suse.com/rancher/charts/longhornio-csi-attacher:v2.0.0
+  type: image
+- source: longhornio/csi-attacher:v2.2.1-lh1
+  target: registry.suse.com/rancher/charts/longhornio-csi-attacher:v2.2.1-lh1
+  type: image
+- source: longhornio/csi-attacher:v2.2.1-lh2
+  target: registry.suse.com/rancher/charts/longhornio-csi-attacher:v2.2.1-lh2
+  type: image
+- source: longhornio/csi-attacher:v3.2.1
+  target: registry.suse.com/rancher/charts/longhornio-csi-attacher:v3.2.1
+  type: image
+- source: longhornio/csi-attacher:v3.4.0
+  target: registry.suse.com/rancher/charts/longhornio-csi-attacher:v3.4.0
+  type: image
+- source: longhornio/csi-attacher:v2.0.0
   target: stgregistry.suse.com/rancher/longhornio-csi-attacher:v2.0.0
   type: image
 - source: longhornio/csi-attacher:v2.2.1-lh1
@@ -5572,6 +9249,21 @@ sync:
   type: image
 - source: longhornio/csi-attacher:v3.4.0
   target: stgregistry.suse.com/rancher/longhornio-csi-attacher:v3.4.0
+  type: image
+- source: longhornio/csi-attacher:v2.0.0
+  target: stgregistry.suse.com/rancher/charts/longhornio-csi-attacher:v2.0.0
+  type: image
+- source: longhornio/csi-attacher:v2.2.1-lh1
+  target: stgregistry.suse.com/rancher/charts/longhornio-csi-attacher:v2.2.1-lh1
+  type: image
+- source: longhornio/csi-attacher:v2.2.1-lh2
+  target: stgregistry.suse.com/rancher/charts/longhornio-csi-attacher:v2.2.1-lh2
+  type: image
+- source: longhornio/csi-attacher:v3.2.1
+  target: stgregistry.suse.com/rancher/charts/longhornio-csi-attacher:v3.2.1
+  type: image
+- source: longhornio/csi-attacher:v3.4.0
+  target: stgregistry.suse.com/rancher/charts/longhornio-csi-attacher:v3.4.0
   type: image
 - source: longhornio/csi-attacher:v2.2.1-lh1
   target: docker.io/rancher/mirrored-longhornio-csi-attacher:v2.2.1-lh1
@@ -5658,6 +9350,48 @@ sync:
   target: registry.suse.com/rancher/mirrored-longhornio-csi-attacher:v4.9.0-20250709
   type: image
 - source: longhornio/csi-attacher:v2.2.1-lh1
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-attacher:v2.2.1-lh1
+  type: image
+- source: longhornio/csi-attacher:v2.2.1-lh2
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-attacher:v2.2.1-lh2
+  type: image
+- source: longhornio/csi-attacher:v3.2.1
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-attacher:v3.2.1
+  type: image
+- source: longhornio/csi-attacher:v3.4.0
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-attacher:v3.4.0
+  type: image
+- source: longhornio/csi-attacher:v4.2.0
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-attacher:v4.2.0
+  type: image
+- source: longhornio/csi-attacher:v4.4.2
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-attacher:v4.4.2
+  type: image
+- source: longhornio/csi-attacher:v4.5.1
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-attacher:v4.5.1
+  type: image
+- source: longhornio/csi-attacher:v4.6.1
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-attacher:v4.6.1
+  type: image
+- source: longhornio/csi-attacher:v4.7.0
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-attacher:v4.7.0
+  type: image
+- source: longhornio/csi-attacher:v4.7.0-20241219
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-attacher:v4.7.0-20241219
+  type: image
+- source: longhornio/csi-attacher:v4.8.0
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-attacher:v4.8.0
+  type: image
+- source: longhornio/csi-attacher:v4.8.1
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-attacher:v4.8.1
+  type: image
+- source: longhornio/csi-attacher:v4.9.0
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-attacher:v4.9.0
+  type: image
+- source: longhornio/csi-attacher:v4.9.0-20250709
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-attacher:v4.9.0-20250709
+  type: image
+- source: longhornio/csi-attacher:v2.2.1-lh1
   target: stgregistry.suse.com/rancher/mirrored-longhornio-csi-attacher:v2.2.1-lh1
   type: image
 - source: longhornio/csi-attacher:v2.2.1-lh2
@@ -5699,6 +9433,48 @@ sync:
 - source: longhornio/csi-attacher:v4.9.0-20250709
   target: stgregistry.suse.com/rancher/mirrored-longhornio-csi-attacher:v4.9.0-20250709
   type: image
+- source: longhornio/csi-attacher:v2.2.1-lh1
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-attacher:v2.2.1-lh1
+  type: image
+- source: longhornio/csi-attacher:v2.2.1-lh2
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-attacher:v2.2.1-lh2
+  type: image
+- source: longhornio/csi-attacher:v3.2.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-attacher:v3.2.1
+  type: image
+- source: longhornio/csi-attacher:v3.4.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-attacher:v3.4.0
+  type: image
+- source: longhornio/csi-attacher:v4.2.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-attacher:v4.2.0
+  type: image
+- source: longhornio/csi-attacher:v4.4.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-attacher:v4.4.2
+  type: image
+- source: longhornio/csi-attacher:v4.5.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-attacher:v4.5.1
+  type: image
+- source: longhornio/csi-attacher:v4.6.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-attacher:v4.6.1
+  type: image
+- source: longhornio/csi-attacher:v4.7.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-attacher:v4.7.0
+  type: image
+- source: longhornio/csi-attacher:v4.7.0-20241219
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-attacher:v4.7.0-20241219
+  type: image
+- source: longhornio/csi-attacher:v4.8.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-attacher:v4.8.0
+  type: image
+- source: longhornio/csi-attacher:v4.8.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-attacher:v4.8.1
+  type: image
+- source: longhornio/csi-attacher:v4.9.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-attacher:v4.9.0
+  type: image
+- source: longhornio/csi-attacher:v4.9.0-20250709
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-attacher:v4.9.0-20250709
+  type: image
 - source: longhornio/csi-node-driver-registrar:v1.2.0
   target: docker.io/rancher/longhornio-csi-node-driver-registrar:v1.2.0
   type: image
@@ -5724,6 +9500,18 @@ sync:
   target: registry.suse.com/rancher/longhornio-csi-node-driver-registrar:v2.5.0
   type: image
 - source: longhornio/csi-node-driver-registrar:v1.2.0
+  target: registry.suse.com/rancher/charts/longhornio-csi-node-driver-registrar:v1.2.0
+  type: image
+- source: longhornio/csi-node-driver-registrar:v1.2.0-lh1
+  target: registry.suse.com/rancher/charts/longhornio-csi-node-driver-registrar:v1.2.0-lh1
+  type: image
+- source: longhornio/csi-node-driver-registrar:v2.3.0
+  target: registry.suse.com/rancher/charts/longhornio-csi-node-driver-registrar:v2.3.0
+  type: image
+- source: longhornio/csi-node-driver-registrar:v2.5.0
+  target: registry.suse.com/rancher/charts/longhornio-csi-node-driver-registrar:v2.5.0
+  type: image
+- source: longhornio/csi-node-driver-registrar:v1.2.0
   target: stgregistry.suse.com/rancher/longhornio-csi-node-driver-registrar:v1.2.0
   type: image
 - source: longhornio/csi-node-driver-registrar:v1.2.0-lh1
@@ -5734,6 +9522,18 @@ sync:
   type: image
 - source: longhornio/csi-node-driver-registrar:v2.5.0
   target: stgregistry.suse.com/rancher/longhornio-csi-node-driver-registrar:v2.5.0
+  type: image
+- source: longhornio/csi-node-driver-registrar:v1.2.0
+  target: stgregistry.suse.com/rancher/charts/longhornio-csi-node-driver-registrar:v1.2.0
+  type: image
+- source: longhornio/csi-node-driver-registrar:v1.2.0-lh1
+  target: stgregistry.suse.com/rancher/charts/longhornio-csi-node-driver-registrar:v1.2.0-lh1
+  type: image
+- source: longhornio/csi-node-driver-registrar:v2.3.0
+  target: stgregistry.suse.com/rancher/charts/longhornio-csi-node-driver-registrar:v2.3.0
+  type: image
+- source: longhornio/csi-node-driver-registrar:v2.5.0
+  target: stgregistry.suse.com/rancher/charts/longhornio-csi-node-driver-registrar:v2.5.0
   type: image
 - source: longhornio/csi-node-driver-registrar:v1.2.0-lh1
   target: docker.io/rancher/mirrored-longhornio-csi-node-driver-registrar:v1.2.0-lh1
@@ -5802,6 +9602,39 @@ sync:
   target: registry.suse.com/rancher/mirrored-longhornio-csi-node-driver-registrar:v2.9.2
   type: image
 - source: longhornio/csi-node-driver-registrar:v1.2.0-lh1
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-node-driver-registrar:v1.2.0-lh1
+  type: image
+- source: longhornio/csi-node-driver-registrar:v2.11.1
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-node-driver-registrar:v2.11.1
+  type: image
+- source: longhornio/csi-node-driver-registrar:v2.12.0
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-node-driver-registrar:v2.12.0
+  type: image
+- source: longhornio/csi-node-driver-registrar:v2.12.0-20241219
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-node-driver-registrar:v2.12.0-20241219
+  type: image
+- source: longhornio/csi-node-driver-registrar:v2.13.0
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-node-driver-registrar:v2.13.0
+  type: image
+- source: longhornio/csi-node-driver-registrar:v2.14.0
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-node-driver-registrar:v2.14.0
+  type: image
+- source: longhornio/csi-node-driver-registrar:v2.14.0-20250709
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-node-driver-registrar:v2.14.0-20250709
+  type: image
+- source: longhornio/csi-node-driver-registrar:v2.3.0
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-node-driver-registrar:v2.3.0
+  type: image
+- source: longhornio/csi-node-driver-registrar:v2.5.0
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-node-driver-registrar:v2.5.0
+  type: image
+- source: longhornio/csi-node-driver-registrar:v2.7.0
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-node-driver-registrar:v2.7.0
+  type: image
+- source: longhornio/csi-node-driver-registrar:v2.9.2
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-node-driver-registrar:v2.9.2
+  type: image
+- source: longhornio/csi-node-driver-registrar:v1.2.0-lh1
   target: stgregistry.suse.com/rancher/mirrored-longhornio-csi-node-driver-registrar:v1.2.0-lh1
   type: image
 - source: longhornio/csi-node-driver-registrar:v2.11.1
@@ -5834,6 +9667,39 @@ sync:
 - source: longhornio/csi-node-driver-registrar:v2.9.2
   target: stgregistry.suse.com/rancher/mirrored-longhornio-csi-node-driver-registrar:v2.9.2
   type: image
+- source: longhornio/csi-node-driver-registrar:v1.2.0-lh1
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-node-driver-registrar:v1.2.0-lh1
+  type: image
+- source: longhornio/csi-node-driver-registrar:v2.11.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-node-driver-registrar:v2.11.1
+  type: image
+- source: longhornio/csi-node-driver-registrar:v2.12.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-node-driver-registrar:v2.12.0
+  type: image
+- source: longhornio/csi-node-driver-registrar:v2.12.0-20241219
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-node-driver-registrar:v2.12.0-20241219
+  type: image
+- source: longhornio/csi-node-driver-registrar:v2.13.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-node-driver-registrar:v2.13.0
+  type: image
+- source: longhornio/csi-node-driver-registrar:v2.14.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-node-driver-registrar:v2.14.0
+  type: image
+- source: longhornio/csi-node-driver-registrar:v2.14.0-20250709
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-node-driver-registrar:v2.14.0-20250709
+  type: image
+- source: longhornio/csi-node-driver-registrar:v2.3.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-node-driver-registrar:v2.3.0
+  type: image
+- source: longhornio/csi-node-driver-registrar:v2.5.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-node-driver-registrar:v2.5.0
+  type: image
+- source: longhornio/csi-node-driver-registrar:v2.7.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-node-driver-registrar:v2.7.0
+  type: image
+- source: longhornio/csi-node-driver-registrar:v2.9.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-node-driver-registrar:v2.9.2
+  type: image
 - source: longhornio/csi-provisioner:v1.4.0
   target: docker.io/rancher/longhornio-csi-provisioner:v1.4.0
   type: image
@@ -5859,6 +9725,18 @@ sync:
   target: registry.suse.com/rancher/longhornio-csi-provisioner:v2.1.2
   type: image
 - source: longhornio/csi-provisioner:v1.4.0
+  target: registry.suse.com/rancher/charts/longhornio-csi-provisioner:v1.4.0
+  type: image
+- source: longhornio/csi-provisioner:v1.6.0-lh1
+  target: registry.suse.com/rancher/charts/longhornio-csi-provisioner:v1.6.0-lh1
+  type: image
+- source: longhornio/csi-provisioner:v1.6.0-lh2
+  target: registry.suse.com/rancher/charts/longhornio-csi-provisioner:v1.6.0-lh2
+  type: image
+- source: longhornio/csi-provisioner:v2.1.2
+  target: registry.suse.com/rancher/charts/longhornio-csi-provisioner:v2.1.2
+  type: image
+- source: longhornio/csi-provisioner:v1.4.0
   target: stgregistry.suse.com/rancher/longhornio-csi-provisioner:v1.4.0
   type: image
 - source: longhornio/csi-provisioner:v1.6.0-lh1
@@ -5869,6 +9747,18 @@ sync:
   type: image
 - source: longhornio/csi-provisioner:v2.1.2
   target: stgregistry.suse.com/rancher/longhornio-csi-provisioner:v2.1.2
+  type: image
+- source: longhornio/csi-provisioner:v1.4.0
+  target: stgregistry.suse.com/rancher/charts/longhornio-csi-provisioner:v1.4.0
+  type: image
+- source: longhornio/csi-provisioner:v1.6.0-lh1
+  target: stgregistry.suse.com/rancher/charts/longhornio-csi-provisioner:v1.6.0-lh1
+  type: image
+- source: longhornio/csi-provisioner:v1.6.0-lh2
+  target: stgregistry.suse.com/rancher/charts/longhornio-csi-provisioner:v1.6.0-lh2
+  type: image
+- source: longhornio/csi-provisioner:v2.1.2
+  target: stgregistry.suse.com/rancher/charts/longhornio-csi-provisioner:v2.1.2
   type: image
 - source: longhornio/csi-provisioner:v1.6.0-lh1
   target: docker.io/rancher/mirrored-longhornio-csi-provisioner:v1.6.0-lh1
@@ -5955,6 +9845,48 @@ sync:
   target: registry.suse.com/rancher/mirrored-longhornio-csi-provisioner:v5.3.0-20250709
   type: image
 - source: longhornio/csi-provisioner:v1.6.0-lh1
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-provisioner:v1.6.0-lh1
+  type: image
+- source: longhornio/csi-provisioner:v1.6.0-lh2
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-provisioner:v1.6.0-lh2
+  type: image
+- source: longhornio/csi-provisioner:v2.1.2
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-provisioner:v2.1.2
+  type: image
+- source: longhornio/csi-provisioner:v3.4.1
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-provisioner:v3.4.1
+  type: image
+- source: longhornio/csi-provisioner:v3.6.2
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-provisioner:v3.6.2
+  type: image
+- source: longhornio/csi-provisioner:v3.6.4
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-provisioner:v3.6.4
+  type: image
+- source: longhornio/csi-provisioner:v3.6.4-20241219
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-provisioner:v3.6.4-20241219
+  type: image
+- source: longhornio/csi-provisioner:v4.0.1
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-provisioner:v4.0.1
+  type: image
+- source: longhornio/csi-provisioner:v4.0.1-20241007
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-provisioner:v4.0.1-20241007
+  type: image
+- source: longhornio/csi-provisioner:v4.0.1-20250204
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-provisioner:v4.0.1-20250204
+  type: image
+- source: longhornio/csi-provisioner:v5.1.0-20241220
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-provisioner:v5.1.0-20241220
+  type: image
+- source: longhornio/csi-provisioner:v5.2.0
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-provisioner:v5.2.0
+  type: image
+- source: longhornio/csi-provisioner:v5.3.0
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-provisioner:v5.3.0
+  type: image
+- source: longhornio/csi-provisioner:v5.3.0-20250709
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-provisioner:v5.3.0-20250709
+  type: image
+- source: longhornio/csi-provisioner:v1.6.0-lh1
   target: stgregistry.suse.com/rancher/mirrored-longhornio-csi-provisioner:v1.6.0-lh1
   type: image
 - source: longhornio/csi-provisioner:v1.6.0-lh2
@@ -5996,6 +9928,48 @@ sync:
 - source: longhornio/csi-provisioner:v5.3.0-20250709
   target: stgregistry.suse.com/rancher/mirrored-longhornio-csi-provisioner:v5.3.0-20250709
   type: image
+- source: longhornio/csi-provisioner:v1.6.0-lh1
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-provisioner:v1.6.0-lh1
+  type: image
+- source: longhornio/csi-provisioner:v1.6.0-lh2
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-provisioner:v1.6.0-lh2
+  type: image
+- source: longhornio/csi-provisioner:v2.1.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-provisioner:v2.1.2
+  type: image
+- source: longhornio/csi-provisioner:v3.4.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-provisioner:v3.4.1
+  type: image
+- source: longhornio/csi-provisioner:v3.6.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-provisioner:v3.6.2
+  type: image
+- source: longhornio/csi-provisioner:v3.6.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-provisioner:v3.6.4
+  type: image
+- source: longhornio/csi-provisioner:v3.6.4-20241219
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-provisioner:v3.6.4-20241219
+  type: image
+- source: longhornio/csi-provisioner:v4.0.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-provisioner:v4.0.1
+  type: image
+- source: longhornio/csi-provisioner:v4.0.1-20241007
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-provisioner:v4.0.1-20241007
+  type: image
+- source: longhornio/csi-provisioner:v4.0.1-20250204
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-provisioner:v4.0.1-20250204
+  type: image
+- source: longhornio/csi-provisioner:v5.1.0-20241220
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-provisioner:v5.1.0-20241220
+  type: image
+- source: longhornio/csi-provisioner:v5.2.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-provisioner:v5.2.0
+  type: image
+- source: longhornio/csi-provisioner:v5.3.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-provisioner:v5.3.0
+  type: image
+- source: longhornio/csi-provisioner:v5.3.0-20250709
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-provisioner:v5.3.0-20250709
+  type: image
 - source: longhornio/csi-resizer:v0.3.0
   target: docker.io/rancher/longhornio-csi-resizer:v0.3.0
   type: image
@@ -6021,6 +9995,18 @@ sync:
   target: registry.suse.com/rancher/longhornio-csi-resizer:v1.2.0
   type: image
 - source: longhornio/csi-resizer:v0.3.0
+  target: registry.suse.com/rancher/charts/longhornio-csi-resizer:v0.3.0
+  type: image
+- source: longhornio/csi-resizer:v0.5.1-lh1
+  target: registry.suse.com/rancher/charts/longhornio-csi-resizer:v0.5.1-lh1
+  type: image
+- source: longhornio/csi-resizer:v0.5.1-lh2
+  target: registry.suse.com/rancher/charts/longhornio-csi-resizer:v0.5.1-lh2
+  type: image
+- source: longhornio/csi-resizer:v1.2.0
+  target: registry.suse.com/rancher/charts/longhornio-csi-resizer:v1.2.0
+  type: image
+- source: longhornio/csi-resizer:v0.3.0
   target: stgregistry.suse.com/rancher/longhornio-csi-resizer:v0.3.0
   type: image
 - source: longhornio/csi-resizer:v0.5.1-lh1
@@ -6031,6 +10017,18 @@ sync:
   type: image
 - source: longhornio/csi-resizer:v1.2.0
   target: stgregistry.suse.com/rancher/longhornio-csi-resizer:v1.2.0
+  type: image
+- source: longhornio/csi-resizer:v0.3.0
+  target: stgregistry.suse.com/rancher/charts/longhornio-csi-resizer:v0.3.0
+  type: image
+- source: longhornio/csi-resizer:v0.5.1-lh1
+  target: stgregistry.suse.com/rancher/charts/longhornio-csi-resizer:v0.5.1-lh1
+  type: image
+- source: longhornio/csi-resizer:v0.5.1-lh2
+  target: stgregistry.suse.com/rancher/charts/longhornio-csi-resizer:v0.5.1-lh2
+  type: image
+- source: longhornio/csi-resizer:v1.2.0
+  target: stgregistry.suse.com/rancher/charts/longhornio-csi-resizer:v1.2.0
   type: image
 - source: longhornio/csi-resizer:v0.5.1-lh1
   target: docker.io/rancher/mirrored-longhornio-csi-resizer:v0.5.1-lh1
@@ -6111,6 +10109,45 @@ sync:
   target: registry.suse.com/rancher/mirrored-longhornio-csi-resizer:v1.9.2
   type: image
 - source: longhornio/csi-resizer:v0.5.1-lh1
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-resizer:v0.5.1-lh1
+  type: image
+- source: longhornio/csi-resizer:v0.5.1-lh2
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-resizer:v0.5.1-lh2
+  type: image
+- source: longhornio/csi-resizer:v1.10.1
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-resizer:v1.10.1
+  type: image
+- source: longhornio/csi-resizer:v1.11.1
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-resizer:v1.11.1
+  type: image
+- source: longhornio/csi-resizer:v1.12.0
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-resizer:v1.12.0
+  type: image
+- source: longhornio/csi-resizer:v1.12.0-20241219
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-resizer:v1.12.0-20241219
+  type: image
+- source: longhornio/csi-resizer:v1.13.1
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-resizer:v1.13.1
+  type: image
+- source: longhornio/csi-resizer:v1.13.2
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-resizer:v1.13.2
+  type: image
+- source: longhornio/csi-resizer:v1.14.0-20250709
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-resizer:v1.14.0-20250709
+  type: image
+- source: longhornio/csi-resizer:v1.2.0
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-resizer:v1.2.0
+  type: image
+- source: longhornio/csi-resizer:v1.3.0
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-resizer:v1.3.0
+  type: image
+- source: longhornio/csi-resizer:v1.7.0
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-resizer:v1.7.0
+  type: image
+- source: longhornio/csi-resizer:v1.9.2
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-resizer:v1.9.2
+  type: image
+- source: longhornio/csi-resizer:v0.5.1-lh1
   target: stgregistry.suse.com/rancher/mirrored-longhornio-csi-resizer:v0.5.1-lh1
   type: image
 - source: longhornio/csi-resizer:v0.5.1-lh2
@@ -6149,6 +10186,45 @@ sync:
 - source: longhornio/csi-resizer:v1.9.2
   target: stgregistry.suse.com/rancher/mirrored-longhornio-csi-resizer:v1.9.2
   type: image
+- source: longhornio/csi-resizer:v0.5.1-lh1
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-resizer:v0.5.1-lh1
+  type: image
+- source: longhornio/csi-resizer:v0.5.1-lh2
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-resizer:v0.5.1-lh2
+  type: image
+- source: longhornio/csi-resizer:v1.10.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-resizer:v1.10.1
+  type: image
+- source: longhornio/csi-resizer:v1.11.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-resizer:v1.11.1
+  type: image
+- source: longhornio/csi-resizer:v1.12.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-resizer:v1.12.0
+  type: image
+- source: longhornio/csi-resizer:v1.12.0-20241219
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-resizer:v1.12.0-20241219
+  type: image
+- source: longhornio/csi-resizer:v1.13.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-resizer:v1.13.1
+  type: image
+- source: longhornio/csi-resizer:v1.13.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-resizer:v1.13.2
+  type: image
+- source: longhornio/csi-resizer:v1.14.0-20250709
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-resizer:v1.14.0-20250709
+  type: image
+- source: longhornio/csi-resizer:v1.2.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-resizer:v1.2.0
+  type: image
+- source: longhornio/csi-resizer:v1.3.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-resizer:v1.3.0
+  type: image
+- source: longhornio/csi-resizer:v1.7.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-resizer:v1.7.0
+  type: image
+- source: longhornio/csi-resizer:v1.9.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-resizer:v1.9.2
+  type: image
 - source: longhornio/csi-snapshotter:v2.1.1-lh1
   target: docker.io/rancher/longhornio-csi-snapshotter:v2.1.1-lh1
   type: image
@@ -6168,6 +10244,15 @@ sync:
   target: registry.suse.com/rancher/longhornio-csi-snapshotter:v3.0.3
   type: image
 - source: longhornio/csi-snapshotter:v2.1.1-lh1
+  target: registry.suse.com/rancher/charts/longhornio-csi-snapshotter:v2.1.1-lh1
+  type: image
+- source: longhornio/csi-snapshotter:v2.1.1-lh2
+  target: registry.suse.com/rancher/charts/longhornio-csi-snapshotter:v2.1.1-lh2
+  type: image
+- source: longhornio/csi-snapshotter:v3.0.3
+  target: registry.suse.com/rancher/charts/longhornio-csi-snapshotter:v3.0.3
+  type: image
+- source: longhornio/csi-snapshotter:v2.1.1-lh1
   target: stgregistry.suse.com/rancher/longhornio-csi-snapshotter:v2.1.1-lh1
   type: image
 - source: longhornio/csi-snapshotter:v2.1.1-lh2
@@ -6175,6 +10260,15 @@ sync:
   type: image
 - source: longhornio/csi-snapshotter:v3.0.3
   target: stgregistry.suse.com/rancher/longhornio-csi-snapshotter:v3.0.3
+  type: image
+- source: longhornio/csi-snapshotter:v2.1.1-lh1
+  target: stgregistry.suse.com/rancher/charts/longhornio-csi-snapshotter:v2.1.1-lh1
+  type: image
+- source: longhornio/csi-snapshotter:v2.1.1-lh2
+  target: stgregistry.suse.com/rancher/charts/longhornio-csi-snapshotter:v2.1.1-lh2
+  type: image
+- source: longhornio/csi-snapshotter:v3.0.3
+  target: stgregistry.suse.com/rancher/charts/longhornio-csi-snapshotter:v3.0.3
   type: image
 - source: longhornio/csi-snapshotter:v2.1.1-lh1
   target: docker.io/rancher/mirrored-longhornio-csi-snapshotter:v2.1.1-lh1
@@ -6255,6 +10349,45 @@ sync:
   target: registry.suse.com/rancher/mirrored-longhornio-csi-snapshotter:v8.3.0-20250709
   type: image
 - source: longhornio/csi-snapshotter:v2.1.1-lh1
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-snapshotter:v2.1.1-lh1
+  type: image
+- source: longhornio/csi-snapshotter:v2.1.1-lh2
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-snapshotter:v2.1.1-lh2
+  type: image
+- source: longhornio/csi-snapshotter:v3.0.3
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-snapshotter:v3.0.3
+  type: image
+- source: longhornio/csi-snapshotter:v5.0.1
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-snapshotter:v5.0.1
+  type: image
+- source: longhornio/csi-snapshotter:v6.2.1
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-snapshotter:v6.2.1
+  type: image
+- source: longhornio/csi-snapshotter:v6.3.2
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-snapshotter:v6.3.2
+  type: image
+- source: longhornio/csi-snapshotter:v6.3.4
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-snapshotter:v6.3.4
+  type: image
+- source: longhornio/csi-snapshotter:v6.3.4-20241219
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-snapshotter:v6.3.4-20241219
+  type: image
+- source: longhornio/csi-snapshotter:v7.0.2
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-snapshotter:v7.0.2
+  type: image
+- source: longhornio/csi-snapshotter:v7.0.2-20241007
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-snapshotter:v7.0.2-20241007
+  type: image
+- source: longhornio/csi-snapshotter:v7.0.2-20250204
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-snapshotter:v7.0.2-20250204
+  type: image
+- source: longhornio/csi-snapshotter:v8.2.0
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-snapshotter:v8.2.0
+  type: image
+- source: longhornio/csi-snapshotter:v8.3.0-20250709
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-snapshotter:v8.3.0-20250709
+  type: image
+- source: longhornio/csi-snapshotter:v2.1.1-lh1
   target: stgregistry.suse.com/rancher/mirrored-longhornio-csi-snapshotter:v2.1.1-lh1
   type: image
 - source: longhornio/csi-snapshotter:v2.1.1-lh2
@@ -6292,6 +10425,45 @@ sync:
   type: image
 - source: longhornio/csi-snapshotter:v8.3.0-20250709
   target: stgregistry.suse.com/rancher/mirrored-longhornio-csi-snapshotter:v8.3.0-20250709
+  type: image
+- source: longhornio/csi-snapshotter:v2.1.1-lh1
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-snapshotter:v2.1.1-lh1
+  type: image
+- source: longhornio/csi-snapshotter:v2.1.1-lh2
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-snapshotter:v2.1.1-lh2
+  type: image
+- source: longhornio/csi-snapshotter:v3.0.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-snapshotter:v3.0.3
+  type: image
+- source: longhornio/csi-snapshotter:v5.0.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-snapshotter:v5.0.1
+  type: image
+- source: longhornio/csi-snapshotter:v6.2.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-snapshotter:v6.2.1
+  type: image
+- source: longhornio/csi-snapshotter:v6.3.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-snapshotter:v6.3.2
+  type: image
+- source: longhornio/csi-snapshotter:v6.3.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-snapshotter:v6.3.4
+  type: image
+- source: longhornio/csi-snapshotter:v6.3.4-20241219
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-snapshotter:v6.3.4-20241219
+  type: image
+- source: longhornio/csi-snapshotter:v7.0.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-snapshotter:v7.0.2
+  type: image
+- source: longhornio/csi-snapshotter:v7.0.2-20241007
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-snapshotter:v7.0.2-20241007
+  type: image
+- source: longhornio/csi-snapshotter:v7.0.2-20250204
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-snapshotter:v7.0.2-20250204
+  type: image
+- source: longhornio/csi-snapshotter:v8.2.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-snapshotter:v8.2.0
+  type: image
+- source: longhornio/csi-snapshotter:v8.3.0-20250709
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-snapshotter:v8.3.0-20250709
   type: image
 - source: longhornio/livenessprobe:v2.11.0
   target: docker.io/rancher/mirrored-longhornio-livenessprobe:v2.11.0
@@ -6354,6 +10526,36 @@ sync:
   target: registry.suse.com/rancher/mirrored-longhornio-livenessprobe:v2.9.0
   type: image
 - source: longhornio/livenessprobe:v2.11.0
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-livenessprobe:v2.11.0
+  type: image
+- source: longhornio/livenessprobe:v2.12.0
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-livenessprobe:v2.12.0
+  type: image
+- source: longhornio/livenessprobe:v2.13.1
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-livenessprobe:v2.13.1
+  type: image
+- source: longhornio/livenessprobe:v2.14.0
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-livenessprobe:v2.14.0
+  type: image
+- source: longhornio/livenessprobe:v2.14.0-20241219
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-livenessprobe:v2.14.0-20241219
+  type: image
+- source: longhornio/livenessprobe:v2.15.0
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-livenessprobe:v2.15.0
+  type: image
+- source: longhornio/livenessprobe:v2.16.0
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-livenessprobe:v2.16.0
+  type: image
+- source: longhornio/livenessprobe:v2.16.0-20250709
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-livenessprobe:v2.16.0-20250709
+  type: image
+- source: longhornio/livenessprobe:v2.8.0
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-livenessprobe:v2.8.0
+  type: image
+- source: longhornio/livenessprobe:v2.9.0
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-livenessprobe:v2.9.0
+  type: image
+- source: longhornio/livenessprobe:v2.11.0
   target: stgregistry.suse.com/rancher/mirrored-longhornio-livenessprobe:v2.11.0
   type: image
 - source: longhornio/livenessprobe:v2.12.0
@@ -6382,6 +10584,36 @@ sync:
   type: image
 - source: longhornio/livenessprobe:v2.9.0
   target: stgregistry.suse.com/rancher/mirrored-longhornio-livenessprobe:v2.9.0
+  type: image
+- source: longhornio/livenessprobe:v2.11.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-livenessprobe:v2.11.0
+  type: image
+- source: longhornio/livenessprobe:v2.12.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-livenessprobe:v2.12.0
+  type: image
+- source: longhornio/livenessprobe:v2.13.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-livenessprobe:v2.13.1
+  type: image
+- source: longhornio/livenessprobe:v2.14.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-livenessprobe:v2.14.0
+  type: image
+- source: longhornio/livenessprobe:v2.14.0-20241219
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-livenessprobe:v2.14.0-20241219
+  type: image
+- source: longhornio/livenessprobe:v2.15.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-livenessprobe:v2.15.0
+  type: image
+- source: longhornio/livenessprobe:v2.16.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-livenessprobe:v2.16.0
+  type: image
+- source: longhornio/livenessprobe:v2.16.0-20250709
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-livenessprobe:v2.16.0-20250709
+  type: image
+- source: longhornio/livenessprobe:v2.8.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-livenessprobe:v2.8.0
+  type: image
+- source: longhornio/livenessprobe:v2.9.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-livenessprobe:v2.9.0
   type: image
 - source: longhornio/longhorn-cli:v1.7.0
   target: docker.io/rancher/mirrored-longhornio-longhorn-cli:v1.7.0
@@ -6432,6 +10664,30 @@ sync:
   target: registry.suse.com/rancher/mirrored-longhornio-longhorn-cli:v1.9.2
   type: image
 - source: longhornio/longhorn-cli:v1.7.0
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-cli:v1.7.0
+  type: image
+- source: longhornio/longhorn-cli:v1.7.1
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-cli:v1.7.1
+  type: image
+- source: longhornio/longhorn-cli:v1.7.2
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-cli:v1.7.2
+  type: image
+- source: longhornio/longhorn-cli:v1.7.3
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-cli:v1.7.3
+  type: image
+- source: longhornio/longhorn-cli:v1.8.1
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-cli:v1.8.1
+  type: image
+- source: longhornio/longhorn-cli:v1.8.2
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-cli:v1.8.2
+  type: image
+- source: longhornio/longhorn-cli:v1.9.1
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-cli:v1.9.1
+  type: image
+- source: longhornio/longhorn-cli:v1.9.2
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-cli:v1.9.2
+  type: image
+- source: longhornio/longhorn-cli:v1.7.0
   target: stgregistry.suse.com/rancher/mirrored-longhornio-longhorn-cli:v1.7.0
   type: image
 - source: longhornio/longhorn-cli:v1.7.1
@@ -6454,6 +10710,30 @@ sync:
   type: image
 - source: longhornio/longhorn-cli:v1.9.2
   target: stgregistry.suse.com/rancher/mirrored-longhornio-longhorn-cli:v1.9.2
+  type: image
+- source: longhornio/longhorn-cli:v1.7.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-cli:v1.7.0
+  type: image
+- source: longhornio/longhorn-cli:v1.7.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-cli:v1.7.1
+  type: image
+- source: longhornio/longhorn-cli:v1.7.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-cli:v1.7.2
+  type: image
+- source: longhornio/longhorn-cli:v1.7.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-cli:v1.7.3
+  type: image
+- source: longhornio/longhorn-cli:v1.8.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-cli:v1.8.1
+  type: image
+- source: longhornio/longhorn-cli:v1.8.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-cli:v1.8.2
+  type: image
+- source: longhornio/longhorn-cli:v1.9.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-cli:v1.9.1
+  type: image
+- source: longhornio/longhorn-cli:v1.9.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-cli:v1.9.2
   type: image
 - source: longhornio/longhorn-engine:v1.0.2
   target: docker.io/rancher/longhornio-longhorn-engine:v1.0.2
@@ -6534,6 +10814,45 @@ sync:
   target: registry.suse.com/rancher/longhornio-longhorn-engine:v1.3.1
   type: image
 - source: longhornio/longhorn-engine:v1.0.2
+  target: registry.suse.com/rancher/charts/longhornio-longhorn-engine:v1.0.2
+  type: image
+- source: longhornio/longhorn-engine:v1.1.0
+  target: registry.suse.com/rancher/charts/longhornio-longhorn-engine:v1.1.0
+  type: image
+- source: longhornio/longhorn-engine:v1.1.1
+  target: registry.suse.com/rancher/charts/longhornio-longhorn-engine:v1.1.1
+  type: image
+- source: longhornio/longhorn-engine:v1.1.2
+  target: registry.suse.com/rancher/charts/longhornio-longhorn-engine:v1.1.2
+  type: image
+- source: longhornio/longhorn-engine:v1.1.3
+  target: registry.suse.com/rancher/charts/longhornio-longhorn-engine:v1.1.3
+  type: image
+- source: longhornio/longhorn-engine:v1.2.0
+  target: registry.suse.com/rancher/charts/longhornio-longhorn-engine:v1.2.0
+  type: image
+- source: longhornio/longhorn-engine:v1.2.1
+  target: registry.suse.com/rancher/charts/longhornio-longhorn-engine:v1.2.1
+  type: image
+- source: longhornio/longhorn-engine:v1.2.2
+  target: registry.suse.com/rancher/charts/longhornio-longhorn-engine:v1.2.2
+  type: image
+- source: longhornio/longhorn-engine:v1.2.3
+  target: registry.suse.com/rancher/charts/longhornio-longhorn-engine:v1.2.3
+  type: image
+- source: longhornio/longhorn-engine:v1.2.4
+  target: registry.suse.com/rancher/charts/longhornio-longhorn-engine:v1.2.4
+  type: image
+- source: longhornio/longhorn-engine:v1.2.5
+  target: registry.suse.com/rancher/charts/longhornio-longhorn-engine:v1.2.5
+  type: image
+- source: longhornio/longhorn-engine:v1.3.0
+  target: registry.suse.com/rancher/charts/longhornio-longhorn-engine:v1.3.0
+  type: image
+- source: longhornio/longhorn-engine:v1.3.1
+  target: registry.suse.com/rancher/charts/longhornio-longhorn-engine:v1.3.1
+  type: image
+- source: longhornio/longhorn-engine:v1.0.2
   target: stgregistry.suse.com/rancher/longhornio-longhorn-engine:v1.0.2
   type: image
 - source: longhornio/longhorn-engine:v1.1.0
@@ -6571,6 +10890,45 @@ sync:
   type: image
 - source: longhornio/longhorn-engine:v1.3.1
   target: stgregistry.suse.com/rancher/longhornio-longhorn-engine:v1.3.1
+  type: image
+- source: longhornio/longhorn-engine:v1.0.2
+  target: stgregistry.suse.com/rancher/charts/longhornio-longhorn-engine:v1.0.2
+  type: image
+- source: longhornio/longhorn-engine:v1.1.0
+  target: stgregistry.suse.com/rancher/charts/longhornio-longhorn-engine:v1.1.0
+  type: image
+- source: longhornio/longhorn-engine:v1.1.1
+  target: stgregistry.suse.com/rancher/charts/longhornio-longhorn-engine:v1.1.1
+  type: image
+- source: longhornio/longhorn-engine:v1.1.2
+  target: stgregistry.suse.com/rancher/charts/longhornio-longhorn-engine:v1.1.2
+  type: image
+- source: longhornio/longhorn-engine:v1.1.3
+  target: stgregistry.suse.com/rancher/charts/longhornio-longhorn-engine:v1.1.3
+  type: image
+- source: longhornio/longhorn-engine:v1.2.0
+  target: stgregistry.suse.com/rancher/charts/longhornio-longhorn-engine:v1.2.0
+  type: image
+- source: longhornio/longhorn-engine:v1.2.1
+  target: stgregistry.suse.com/rancher/charts/longhornio-longhorn-engine:v1.2.1
+  type: image
+- source: longhornio/longhorn-engine:v1.2.2
+  target: stgregistry.suse.com/rancher/charts/longhornio-longhorn-engine:v1.2.2
+  type: image
+- source: longhornio/longhorn-engine:v1.2.3
+  target: stgregistry.suse.com/rancher/charts/longhornio-longhorn-engine:v1.2.3
+  type: image
+- source: longhornio/longhorn-engine:v1.2.4
+  target: stgregistry.suse.com/rancher/charts/longhornio-longhorn-engine:v1.2.4
+  type: image
+- source: longhornio/longhorn-engine:v1.2.5
+  target: stgregistry.suse.com/rancher/charts/longhornio-longhorn-engine:v1.2.5
+  type: image
+- source: longhornio/longhorn-engine:v1.3.0
+  target: stgregistry.suse.com/rancher/charts/longhornio-longhorn-engine:v1.3.0
+  type: image
+- source: longhornio/longhorn-engine:v1.3.1
+  target: stgregistry.suse.com/rancher/charts/longhornio-longhorn-engine:v1.3.1
   type: image
 - source: longhornio/longhorn-engine:v1.1.0
   target: docker.io/rancher/mirrored-longhornio-longhorn-engine:v1.1.0
@@ -6807,6 +11165,123 @@ sync:
   target: registry.suse.com/rancher/mirrored-longhornio-longhorn-engine:v1.9.2
   type: image
 - source: longhornio/longhorn-engine:v1.1.0
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.1.0
+  type: image
+- source: longhornio/longhorn-engine:v1.1.1
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.1.1
+  type: image
+- source: longhornio/longhorn-engine:v1.1.2
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.1.2
+  type: image
+- source: longhornio/longhorn-engine:v1.1.3
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.1.3
+  type: image
+- source: longhornio/longhorn-engine:v1.2.0
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.2.0
+  type: image
+- source: longhornio/longhorn-engine:v1.2.1
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.2.1
+  type: image
+- source: longhornio/longhorn-engine:v1.2.2
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.2.2
+  type: image
+- source: longhornio/longhorn-engine:v1.2.3
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.2.3
+  type: image
+- source: longhornio/longhorn-engine:v1.2.4
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.2.4
+  type: image
+- source: longhornio/longhorn-engine:v1.2.5
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.2.5
+  type: image
+- source: longhornio/longhorn-engine:v1.2.6
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.2.6
+  type: image
+- source: longhornio/longhorn-engine:v1.3.0
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.3.0
+  type: image
+- source: longhornio/longhorn-engine:v1.3.1
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.3.1
+  type: image
+- source: longhornio/longhorn-engine:v1.3.2
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.3.2
+  type: image
+- source: longhornio/longhorn-engine:v1.3.3
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.3.3
+  type: image
+- source: longhornio/longhorn-engine:v1.4.0
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.4.0
+  type: image
+- source: longhornio/longhorn-engine:v1.4.1
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.4.1
+  type: image
+- source: longhornio/longhorn-engine:v1.4.2
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.4.2
+  type: image
+- source: longhornio/longhorn-engine:v1.4.3
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.4.3
+  type: image
+- source: longhornio/longhorn-engine:v1.4.4
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.4.4
+  type: image
+- source: longhornio/longhorn-engine:v1.5.0
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.5.0
+  type: image
+- source: longhornio/longhorn-engine:v1.5.1
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.5.1
+  type: image
+- source: longhornio/longhorn-engine:v1.5.2
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.5.2
+  type: image
+- source: longhornio/longhorn-engine:v1.5.3
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.5.3
+  type: image
+- source: longhornio/longhorn-engine:v1.5.4
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.5.4
+  type: image
+- source: longhornio/longhorn-engine:v1.5.5
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.5.5
+  type: image
+- source: longhornio/longhorn-engine:v1.6.0
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.6.0
+  type: image
+- source: longhornio/longhorn-engine:v1.6.1
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.6.1
+  type: image
+- source: longhornio/longhorn-engine:v1.6.2
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.6.2
+  type: image
+- source: longhornio/longhorn-engine:v1.6.3
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.6.3
+  type: image
+- source: longhornio/longhorn-engine:v1.6.4
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.6.4
+  type: image
+- source: longhornio/longhorn-engine:v1.7.0
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.7.0
+  type: image
+- source: longhornio/longhorn-engine:v1.7.1
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.7.1
+  type: image
+- source: longhornio/longhorn-engine:v1.7.2
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.7.2
+  type: image
+- source: longhornio/longhorn-engine:v1.7.3
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.7.3
+  type: image
+- source: longhornio/longhorn-engine:v1.8.1
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.8.1
+  type: image
+- source: longhornio/longhorn-engine:v1.8.2
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.8.2
+  type: image
+- source: longhornio/longhorn-engine:v1.9.1
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.9.1
+  type: image
+- source: longhornio/longhorn-engine:v1.9.2
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.9.2
+  type: image
+- source: longhornio/longhorn-engine:v1.1.0
   target: stgregistry.suse.com/rancher/mirrored-longhornio-longhorn-engine:v1.1.0
   type: image
 - source: longhornio/longhorn-engine:v1.1.1
@@ -6923,6 +11398,123 @@ sync:
 - source: longhornio/longhorn-engine:v1.9.2
   target: stgregistry.suse.com/rancher/mirrored-longhornio-longhorn-engine:v1.9.2
   type: image
+- source: longhornio/longhorn-engine:v1.1.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.1.0
+  type: image
+- source: longhornio/longhorn-engine:v1.1.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.1.1
+  type: image
+- source: longhornio/longhorn-engine:v1.1.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.1.2
+  type: image
+- source: longhornio/longhorn-engine:v1.1.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.1.3
+  type: image
+- source: longhornio/longhorn-engine:v1.2.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.2.0
+  type: image
+- source: longhornio/longhorn-engine:v1.2.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.2.1
+  type: image
+- source: longhornio/longhorn-engine:v1.2.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.2.2
+  type: image
+- source: longhornio/longhorn-engine:v1.2.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.2.3
+  type: image
+- source: longhornio/longhorn-engine:v1.2.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.2.4
+  type: image
+- source: longhornio/longhorn-engine:v1.2.5
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.2.5
+  type: image
+- source: longhornio/longhorn-engine:v1.2.6
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.2.6
+  type: image
+- source: longhornio/longhorn-engine:v1.3.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.3.0
+  type: image
+- source: longhornio/longhorn-engine:v1.3.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.3.1
+  type: image
+- source: longhornio/longhorn-engine:v1.3.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.3.2
+  type: image
+- source: longhornio/longhorn-engine:v1.3.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.3.3
+  type: image
+- source: longhornio/longhorn-engine:v1.4.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.4.0
+  type: image
+- source: longhornio/longhorn-engine:v1.4.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.4.1
+  type: image
+- source: longhornio/longhorn-engine:v1.4.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.4.2
+  type: image
+- source: longhornio/longhorn-engine:v1.4.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.4.3
+  type: image
+- source: longhornio/longhorn-engine:v1.4.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.4.4
+  type: image
+- source: longhornio/longhorn-engine:v1.5.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.5.0
+  type: image
+- source: longhornio/longhorn-engine:v1.5.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.5.1
+  type: image
+- source: longhornio/longhorn-engine:v1.5.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.5.2
+  type: image
+- source: longhornio/longhorn-engine:v1.5.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.5.3
+  type: image
+- source: longhornio/longhorn-engine:v1.5.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.5.4
+  type: image
+- source: longhornio/longhorn-engine:v1.5.5
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.5.5
+  type: image
+- source: longhornio/longhorn-engine:v1.6.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.6.0
+  type: image
+- source: longhornio/longhorn-engine:v1.6.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.6.1
+  type: image
+- source: longhornio/longhorn-engine:v1.6.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.6.2
+  type: image
+- source: longhornio/longhorn-engine:v1.6.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.6.3
+  type: image
+- source: longhornio/longhorn-engine:v1.6.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.6.4
+  type: image
+- source: longhornio/longhorn-engine:v1.7.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.7.0
+  type: image
+- source: longhornio/longhorn-engine:v1.7.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.7.1
+  type: image
+- source: longhornio/longhorn-engine:v1.7.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.7.2
+  type: image
+- source: longhornio/longhorn-engine:v1.7.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.7.3
+  type: image
+- source: longhornio/longhorn-engine:v1.8.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.8.1
+  type: image
+- source: longhornio/longhorn-engine:v1.8.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.8.2
+  type: image
+- source: longhornio/longhorn-engine:v1.9.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.9.1
+  type: image
+- source: longhornio/longhorn-engine:v1.9.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.9.2
+  type: image
 - source: longhornio/longhorn-instance-manager:v1_20200514
   target: docker.io/rancher/longhornio-longhorn-instance-manager:v1_20200514
   type: image
@@ -6978,6 +11570,33 @@ sync:
   target: registry.suse.com/rancher/longhornio-longhorn-instance-manager:v1_20220808
   type: image
 - source: longhornio/longhorn-instance-manager:v1_20200514
+  target: registry.suse.com/rancher/charts/longhornio-longhorn-instance-manager:v1_20200514
+  type: image
+- source: longhornio/longhorn-instance-manager:v1_20201216
+  target: registry.suse.com/rancher/charts/longhornio-longhorn-instance-manager:v1_20201216
+  type: image
+- source: longhornio/longhorn-instance-manager:v1_20210621
+  target: registry.suse.com/rancher/charts/longhornio-longhorn-instance-manager:v1_20210621
+  type: image
+- source: longhornio/longhorn-instance-manager:v1_20210731
+  target: registry.suse.com/rancher/charts/longhornio-longhorn-instance-manager:v1_20210731
+  type: image
+- source: longhornio/longhorn-instance-manager:v1_20211210
+  target: registry.suse.com/rancher/charts/longhornio-longhorn-instance-manager:v1_20211210
+  type: image
+- source: longhornio/longhorn-instance-manager:v1_20220303
+  target: registry.suse.com/rancher/charts/longhornio-longhorn-instance-manager:v1_20220303
+  type: image
+- source: longhornio/longhorn-instance-manager:v1_20220303_patch1
+  target: registry.suse.com/rancher/charts/longhornio-longhorn-instance-manager:v1_20220303_patch1
+  type: image
+- source: longhornio/longhorn-instance-manager:v1_20220611
+  target: registry.suse.com/rancher/charts/longhornio-longhorn-instance-manager:v1_20220611
+  type: image
+- source: longhornio/longhorn-instance-manager:v1_20220808
+  target: registry.suse.com/rancher/charts/longhornio-longhorn-instance-manager:v1_20220808
+  type: image
+- source: longhornio/longhorn-instance-manager:v1_20200514
   target: stgregistry.suse.com/rancher/longhornio-longhorn-instance-manager:v1_20200514
   type: image
 - source: longhornio/longhorn-instance-manager:v1_20201216
@@ -7003,6 +11622,33 @@ sync:
   type: image
 - source: longhornio/longhorn-instance-manager:v1_20220808
   target: stgregistry.suse.com/rancher/longhornio-longhorn-instance-manager:v1_20220808
+  type: image
+- source: longhornio/longhorn-instance-manager:v1_20200514
+  target: stgregistry.suse.com/rancher/charts/longhornio-longhorn-instance-manager:v1_20200514
+  type: image
+- source: longhornio/longhorn-instance-manager:v1_20201216
+  target: stgregistry.suse.com/rancher/charts/longhornio-longhorn-instance-manager:v1_20201216
+  type: image
+- source: longhornio/longhorn-instance-manager:v1_20210621
+  target: stgregistry.suse.com/rancher/charts/longhornio-longhorn-instance-manager:v1_20210621
+  type: image
+- source: longhornio/longhorn-instance-manager:v1_20210731
+  target: stgregistry.suse.com/rancher/charts/longhornio-longhorn-instance-manager:v1_20210731
+  type: image
+- source: longhornio/longhorn-instance-manager:v1_20211210
+  target: stgregistry.suse.com/rancher/charts/longhornio-longhorn-instance-manager:v1_20211210
+  type: image
+- source: longhornio/longhorn-instance-manager:v1_20220303
+  target: stgregistry.suse.com/rancher/charts/longhornio-longhorn-instance-manager:v1_20220303
+  type: image
+- source: longhornio/longhorn-instance-manager:v1_20220303_patch1
+  target: stgregistry.suse.com/rancher/charts/longhornio-longhorn-instance-manager:v1_20220303_patch1
+  type: image
+- source: longhornio/longhorn-instance-manager:v1_20220611
+  target: stgregistry.suse.com/rancher/charts/longhornio-longhorn-instance-manager:v1_20220611
+  type: image
+- source: longhornio/longhorn-instance-manager:v1_20220808
+  target: stgregistry.suse.com/rancher/charts/longhornio-longhorn-instance-manager:v1_20220808
   type: image
 - source: longhornio/longhorn-instance-manager:v1.4.0
   target: docker.io/rancher/mirrored-longhornio-longhorn-instance-manager:v1.4.0
@@ -7215,6 +11861,111 @@ sync:
   target: registry.suse.com/rancher/mirrored-longhornio-longhorn-instance-manager:v1_20230407
   type: image
 - source: longhornio/longhorn-instance-manager:v1.4.0
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1.4.0
+  type: image
+- source: longhornio/longhorn-instance-manager:v1.4.1
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1.4.1
+  type: image
+- source: longhornio/longhorn-instance-manager:v1.4.2
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1.4.2
+  type: image
+- source: longhornio/longhorn-instance-manager:v1.4.3
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1.4.3
+  type: image
+- source: longhornio/longhorn-instance-manager:v1.4.4
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1.4.4
+  type: image
+- source: longhornio/longhorn-instance-manager:v1.5.0
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1.5.0
+  type: image
+- source: longhornio/longhorn-instance-manager:v1.5.1
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1.5.1
+  type: image
+- source: longhornio/longhorn-instance-manager:v1.5.2
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1.5.2
+  type: image
+- source: longhornio/longhorn-instance-manager:v1.5.3
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1.5.3
+  type: image
+- source: longhornio/longhorn-instance-manager:v1.5.4
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1.5.4
+  type: image
+- source: longhornio/longhorn-instance-manager:v1.5.5
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1.5.5
+  type: image
+- source: longhornio/longhorn-instance-manager:v1.6.0
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1.6.0
+  type: image
+- source: longhornio/longhorn-instance-manager:v1.6.1
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1.6.1
+  type: image
+- source: longhornio/longhorn-instance-manager:v1.6.2
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1.6.2
+  type: image
+- source: longhornio/longhorn-instance-manager:v1.6.3
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1.6.3
+  type: image
+- source: longhornio/longhorn-instance-manager:v1.6.4
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1.6.4
+  type: image
+- source: longhornio/longhorn-instance-manager:v1.7.0
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1.7.0
+  type: image
+- source: longhornio/longhorn-instance-manager:v1.7.1
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1.7.1
+  type: image
+- source: longhornio/longhorn-instance-manager:v1.7.2
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1.7.2
+  type: image
+- source: longhornio/longhorn-instance-manager:v1.7.3
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1.7.3
+  type: image
+- source: longhornio/longhorn-instance-manager:v1.8.1
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1.8.1
+  type: image
+- source: longhornio/longhorn-instance-manager:v1.8.2
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1.8.2
+  type: image
+- source: longhornio/longhorn-instance-manager:v1.9.1
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1.9.1
+  type: image
+- source: longhornio/longhorn-instance-manager:v1.9.2
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1.9.2
+  type: image
+- source: longhornio/longhorn-instance-manager:v1_20201216
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1_20201216
+  type: image
+- source: longhornio/longhorn-instance-manager:v1_20210621
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1_20210621
+  type: image
+- source: longhornio/longhorn-instance-manager:v1_20210731
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1_20210731
+  type: image
+- source: longhornio/longhorn-instance-manager:v1_20211210
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1_20211210
+  type: image
+- source: longhornio/longhorn-instance-manager:v1_20220303
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1_20220303
+  type: image
+- source: longhornio/longhorn-instance-manager:v1_20220303_patch1
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1_20220303_patch1
+  type: image
+- source: longhornio/longhorn-instance-manager:v1_20220303_patch2
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1_20220303_patch2
+  type: image
+- source: longhornio/longhorn-instance-manager:v1_20220611
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1_20220611
+  type: image
+- source: longhornio/longhorn-instance-manager:v1_20220808
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1_20220808
+  type: image
+- source: longhornio/longhorn-instance-manager:v1_20221003
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1_20221003
+  type: image
+- source: longhornio/longhorn-instance-manager:v1_20230407
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1_20230407
+  type: image
+- source: longhornio/longhorn-instance-manager:v1.4.0
   target: stgregistry.suse.com/rancher/mirrored-longhornio-longhorn-instance-manager:v1.4.0
   type: image
 - source: longhornio/longhorn-instance-manager:v1.4.1
@@ -7319,6 +12070,111 @@ sync:
 - source: longhornio/longhorn-instance-manager:v1_20230407
   target: stgregistry.suse.com/rancher/mirrored-longhornio-longhorn-instance-manager:v1_20230407
   type: image
+- source: longhornio/longhorn-instance-manager:v1.4.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1.4.0
+  type: image
+- source: longhornio/longhorn-instance-manager:v1.4.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1.4.1
+  type: image
+- source: longhornio/longhorn-instance-manager:v1.4.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1.4.2
+  type: image
+- source: longhornio/longhorn-instance-manager:v1.4.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1.4.3
+  type: image
+- source: longhornio/longhorn-instance-manager:v1.4.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1.4.4
+  type: image
+- source: longhornio/longhorn-instance-manager:v1.5.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1.5.0
+  type: image
+- source: longhornio/longhorn-instance-manager:v1.5.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1.5.1
+  type: image
+- source: longhornio/longhorn-instance-manager:v1.5.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1.5.2
+  type: image
+- source: longhornio/longhorn-instance-manager:v1.5.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1.5.3
+  type: image
+- source: longhornio/longhorn-instance-manager:v1.5.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1.5.4
+  type: image
+- source: longhornio/longhorn-instance-manager:v1.5.5
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1.5.5
+  type: image
+- source: longhornio/longhorn-instance-manager:v1.6.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1.6.0
+  type: image
+- source: longhornio/longhorn-instance-manager:v1.6.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1.6.1
+  type: image
+- source: longhornio/longhorn-instance-manager:v1.6.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1.6.2
+  type: image
+- source: longhornio/longhorn-instance-manager:v1.6.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1.6.3
+  type: image
+- source: longhornio/longhorn-instance-manager:v1.6.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1.6.4
+  type: image
+- source: longhornio/longhorn-instance-manager:v1.7.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1.7.0
+  type: image
+- source: longhornio/longhorn-instance-manager:v1.7.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1.7.1
+  type: image
+- source: longhornio/longhorn-instance-manager:v1.7.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1.7.2
+  type: image
+- source: longhornio/longhorn-instance-manager:v1.7.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1.7.3
+  type: image
+- source: longhornio/longhorn-instance-manager:v1.8.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1.8.1
+  type: image
+- source: longhornio/longhorn-instance-manager:v1.8.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1.8.2
+  type: image
+- source: longhornio/longhorn-instance-manager:v1.9.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1.9.1
+  type: image
+- source: longhornio/longhorn-instance-manager:v1.9.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1.9.2
+  type: image
+- source: longhornio/longhorn-instance-manager:v1_20201216
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1_20201216
+  type: image
+- source: longhornio/longhorn-instance-manager:v1_20210621
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1_20210621
+  type: image
+- source: longhornio/longhorn-instance-manager:v1_20210731
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1_20210731
+  type: image
+- source: longhornio/longhorn-instance-manager:v1_20211210
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1_20211210
+  type: image
+- source: longhornio/longhorn-instance-manager:v1_20220303
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1_20220303
+  type: image
+- source: longhornio/longhorn-instance-manager:v1_20220303_patch1
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1_20220303_patch1
+  type: image
+- source: longhornio/longhorn-instance-manager:v1_20220303_patch2
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1_20220303_patch2
+  type: image
+- source: longhornio/longhorn-instance-manager:v1_20220611
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1_20220611
+  type: image
+- source: longhornio/longhorn-instance-manager:v1_20220808
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1_20220808
+  type: image
+- source: longhornio/longhorn-instance-manager:v1_20221003
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1_20221003
+  type: image
+- source: longhornio/longhorn-instance-manager:v1_20230407
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1_20230407
+  type: image
 - source: longhornio/longhorn-manager:v1.0.2
   target: docker.io/rancher/longhornio-longhorn-manager:v1.0.2
   type: image
@@ -7398,6 +12254,45 @@ sync:
   target: registry.suse.com/rancher/longhornio-longhorn-manager:v1.3.1
   type: image
 - source: longhornio/longhorn-manager:v1.0.2
+  target: registry.suse.com/rancher/charts/longhornio-longhorn-manager:v1.0.2
+  type: image
+- source: longhornio/longhorn-manager:v1.1.0
+  target: registry.suse.com/rancher/charts/longhornio-longhorn-manager:v1.1.0
+  type: image
+- source: longhornio/longhorn-manager:v1.1.1
+  target: registry.suse.com/rancher/charts/longhornio-longhorn-manager:v1.1.1
+  type: image
+- source: longhornio/longhorn-manager:v1.1.2
+  target: registry.suse.com/rancher/charts/longhornio-longhorn-manager:v1.1.2
+  type: image
+- source: longhornio/longhorn-manager:v1.1.3
+  target: registry.suse.com/rancher/charts/longhornio-longhorn-manager:v1.1.3
+  type: image
+- source: longhornio/longhorn-manager:v1.2.0
+  target: registry.suse.com/rancher/charts/longhornio-longhorn-manager:v1.2.0
+  type: image
+- source: longhornio/longhorn-manager:v1.2.1
+  target: registry.suse.com/rancher/charts/longhornio-longhorn-manager:v1.2.1
+  type: image
+- source: longhornio/longhorn-manager:v1.2.2
+  target: registry.suse.com/rancher/charts/longhornio-longhorn-manager:v1.2.2
+  type: image
+- source: longhornio/longhorn-manager:v1.2.3
+  target: registry.suse.com/rancher/charts/longhornio-longhorn-manager:v1.2.3
+  type: image
+- source: longhornio/longhorn-manager:v1.2.4
+  target: registry.suse.com/rancher/charts/longhornio-longhorn-manager:v1.2.4
+  type: image
+- source: longhornio/longhorn-manager:v1.2.5
+  target: registry.suse.com/rancher/charts/longhornio-longhorn-manager:v1.2.5
+  type: image
+- source: longhornio/longhorn-manager:v1.3.0
+  target: registry.suse.com/rancher/charts/longhornio-longhorn-manager:v1.3.0
+  type: image
+- source: longhornio/longhorn-manager:v1.3.1
+  target: registry.suse.com/rancher/charts/longhornio-longhorn-manager:v1.3.1
+  type: image
+- source: longhornio/longhorn-manager:v1.0.2
   target: stgregistry.suse.com/rancher/longhornio-longhorn-manager:v1.0.2
   type: image
 - source: longhornio/longhorn-manager:v1.1.0
@@ -7435,6 +12330,45 @@ sync:
   type: image
 - source: longhornio/longhorn-manager:v1.3.1
   target: stgregistry.suse.com/rancher/longhornio-longhorn-manager:v1.3.1
+  type: image
+- source: longhornio/longhorn-manager:v1.0.2
+  target: stgregistry.suse.com/rancher/charts/longhornio-longhorn-manager:v1.0.2
+  type: image
+- source: longhornio/longhorn-manager:v1.1.0
+  target: stgregistry.suse.com/rancher/charts/longhornio-longhorn-manager:v1.1.0
+  type: image
+- source: longhornio/longhorn-manager:v1.1.1
+  target: stgregistry.suse.com/rancher/charts/longhornio-longhorn-manager:v1.1.1
+  type: image
+- source: longhornio/longhorn-manager:v1.1.2
+  target: stgregistry.suse.com/rancher/charts/longhornio-longhorn-manager:v1.1.2
+  type: image
+- source: longhornio/longhorn-manager:v1.1.3
+  target: stgregistry.suse.com/rancher/charts/longhornio-longhorn-manager:v1.1.3
+  type: image
+- source: longhornio/longhorn-manager:v1.2.0
+  target: stgregistry.suse.com/rancher/charts/longhornio-longhorn-manager:v1.2.0
+  type: image
+- source: longhornio/longhorn-manager:v1.2.1
+  target: stgregistry.suse.com/rancher/charts/longhornio-longhorn-manager:v1.2.1
+  type: image
+- source: longhornio/longhorn-manager:v1.2.2
+  target: stgregistry.suse.com/rancher/charts/longhornio-longhorn-manager:v1.2.2
+  type: image
+- source: longhornio/longhorn-manager:v1.2.3
+  target: stgregistry.suse.com/rancher/charts/longhornio-longhorn-manager:v1.2.3
+  type: image
+- source: longhornio/longhorn-manager:v1.2.4
+  target: stgregistry.suse.com/rancher/charts/longhornio-longhorn-manager:v1.2.4
+  type: image
+- source: longhornio/longhorn-manager:v1.2.5
+  target: stgregistry.suse.com/rancher/charts/longhornio-longhorn-manager:v1.2.5
+  type: image
+- source: longhornio/longhorn-manager:v1.3.0
+  target: stgregistry.suse.com/rancher/charts/longhornio-longhorn-manager:v1.3.0
+  type: image
+- source: longhornio/longhorn-manager:v1.3.1
+  target: stgregistry.suse.com/rancher/charts/longhornio-longhorn-manager:v1.3.1
   type: image
 - source: longhornio/longhorn-manager:v1.1.0
   target: docker.io/rancher/mirrored-longhornio-longhorn-manager:v1.1.0
@@ -7671,6 +12605,123 @@ sync:
   target: registry.suse.com/rancher/mirrored-longhornio-longhorn-manager:v1.9.2
   type: image
 - source: longhornio/longhorn-manager:v1.1.0
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.1.0
+  type: image
+- source: longhornio/longhorn-manager:v1.1.1
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.1.1
+  type: image
+- source: longhornio/longhorn-manager:v1.1.2
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.1.2
+  type: image
+- source: longhornio/longhorn-manager:v1.1.3
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.1.3
+  type: image
+- source: longhornio/longhorn-manager:v1.2.0
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.2.0
+  type: image
+- source: longhornio/longhorn-manager:v1.2.1
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.2.1
+  type: image
+- source: longhornio/longhorn-manager:v1.2.2
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.2.2
+  type: image
+- source: longhornio/longhorn-manager:v1.2.3
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.2.3
+  type: image
+- source: longhornio/longhorn-manager:v1.2.4
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.2.4
+  type: image
+- source: longhornio/longhorn-manager:v1.2.5
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.2.5
+  type: image
+- source: longhornio/longhorn-manager:v1.2.6
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.2.6
+  type: image
+- source: longhornio/longhorn-manager:v1.3.0
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.3.0
+  type: image
+- source: longhornio/longhorn-manager:v1.3.1
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.3.1
+  type: image
+- source: longhornio/longhorn-manager:v1.3.2
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.3.2
+  type: image
+- source: longhornio/longhorn-manager:v1.3.3
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.3.3
+  type: image
+- source: longhornio/longhorn-manager:v1.4.0
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.4.0
+  type: image
+- source: longhornio/longhorn-manager:v1.4.1
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.4.1
+  type: image
+- source: longhornio/longhorn-manager:v1.4.2
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.4.2
+  type: image
+- source: longhornio/longhorn-manager:v1.4.3
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.4.3
+  type: image
+- source: longhornio/longhorn-manager:v1.4.4
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.4.4
+  type: image
+- source: longhornio/longhorn-manager:v1.5.0
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.5.0
+  type: image
+- source: longhornio/longhorn-manager:v1.5.1
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.5.1
+  type: image
+- source: longhornio/longhorn-manager:v1.5.2
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.5.2
+  type: image
+- source: longhornio/longhorn-manager:v1.5.3
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.5.3
+  type: image
+- source: longhornio/longhorn-manager:v1.5.4
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.5.4
+  type: image
+- source: longhornio/longhorn-manager:v1.5.5
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.5.5
+  type: image
+- source: longhornio/longhorn-manager:v1.6.0
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.6.0
+  type: image
+- source: longhornio/longhorn-manager:v1.6.1
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.6.1
+  type: image
+- source: longhornio/longhorn-manager:v1.6.2
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.6.2
+  type: image
+- source: longhornio/longhorn-manager:v1.6.3
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.6.3
+  type: image
+- source: longhornio/longhorn-manager:v1.6.4
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.6.4
+  type: image
+- source: longhornio/longhorn-manager:v1.7.0
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.7.0
+  type: image
+- source: longhornio/longhorn-manager:v1.7.1
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.7.1
+  type: image
+- source: longhornio/longhorn-manager:v1.7.2
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.7.2
+  type: image
+- source: longhornio/longhorn-manager:v1.7.3
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.7.3
+  type: image
+- source: longhornio/longhorn-manager:v1.8.1
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.8.1
+  type: image
+- source: longhornio/longhorn-manager:v1.8.2
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.8.2
+  type: image
+- source: longhornio/longhorn-manager:v1.9.1
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.9.1
+  type: image
+- source: longhornio/longhorn-manager:v1.9.2
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.9.2
+  type: image
+- source: longhornio/longhorn-manager:v1.1.0
   target: stgregistry.suse.com/rancher/mirrored-longhornio-longhorn-manager:v1.1.0
   type: image
 - source: longhornio/longhorn-manager:v1.1.1
@@ -7787,6 +12838,123 @@ sync:
 - source: longhornio/longhorn-manager:v1.9.2
   target: stgregistry.suse.com/rancher/mirrored-longhornio-longhorn-manager:v1.9.2
   type: image
+- source: longhornio/longhorn-manager:v1.1.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.1.0
+  type: image
+- source: longhornio/longhorn-manager:v1.1.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.1.1
+  type: image
+- source: longhornio/longhorn-manager:v1.1.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.1.2
+  type: image
+- source: longhornio/longhorn-manager:v1.1.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.1.3
+  type: image
+- source: longhornio/longhorn-manager:v1.2.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.2.0
+  type: image
+- source: longhornio/longhorn-manager:v1.2.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.2.1
+  type: image
+- source: longhornio/longhorn-manager:v1.2.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.2.2
+  type: image
+- source: longhornio/longhorn-manager:v1.2.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.2.3
+  type: image
+- source: longhornio/longhorn-manager:v1.2.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.2.4
+  type: image
+- source: longhornio/longhorn-manager:v1.2.5
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.2.5
+  type: image
+- source: longhornio/longhorn-manager:v1.2.6
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.2.6
+  type: image
+- source: longhornio/longhorn-manager:v1.3.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.3.0
+  type: image
+- source: longhornio/longhorn-manager:v1.3.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.3.1
+  type: image
+- source: longhornio/longhorn-manager:v1.3.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.3.2
+  type: image
+- source: longhornio/longhorn-manager:v1.3.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.3.3
+  type: image
+- source: longhornio/longhorn-manager:v1.4.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.4.0
+  type: image
+- source: longhornio/longhorn-manager:v1.4.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.4.1
+  type: image
+- source: longhornio/longhorn-manager:v1.4.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.4.2
+  type: image
+- source: longhornio/longhorn-manager:v1.4.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.4.3
+  type: image
+- source: longhornio/longhorn-manager:v1.4.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.4.4
+  type: image
+- source: longhornio/longhorn-manager:v1.5.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.5.0
+  type: image
+- source: longhornio/longhorn-manager:v1.5.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.5.1
+  type: image
+- source: longhornio/longhorn-manager:v1.5.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.5.2
+  type: image
+- source: longhornio/longhorn-manager:v1.5.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.5.3
+  type: image
+- source: longhornio/longhorn-manager:v1.5.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.5.4
+  type: image
+- source: longhornio/longhorn-manager:v1.5.5
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.5.5
+  type: image
+- source: longhornio/longhorn-manager:v1.6.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.6.0
+  type: image
+- source: longhornio/longhorn-manager:v1.6.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.6.1
+  type: image
+- source: longhornio/longhorn-manager:v1.6.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.6.2
+  type: image
+- source: longhornio/longhorn-manager:v1.6.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.6.3
+  type: image
+- source: longhornio/longhorn-manager:v1.6.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.6.4
+  type: image
+- source: longhornio/longhorn-manager:v1.7.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.7.0
+  type: image
+- source: longhornio/longhorn-manager:v1.7.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.7.1
+  type: image
+- source: longhornio/longhorn-manager:v1.7.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.7.2
+  type: image
+- source: longhornio/longhorn-manager:v1.7.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.7.3
+  type: image
+- source: longhornio/longhorn-manager:v1.8.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.8.1
+  type: image
+- source: longhornio/longhorn-manager:v1.8.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.8.2
+  type: image
+- source: longhornio/longhorn-manager:v1.9.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.9.1
+  type: image
+- source: longhornio/longhorn-manager:v1.9.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.9.2
+  type: image
 - source: longhornio/longhorn-share-manager:v1_20201204
   target: docker.io/rancher/longhornio-longhorn-share-manager:v1_20201204
   type: image
@@ -7842,6 +13010,33 @@ sync:
   target: registry.suse.com/rancher/longhornio-longhorn-share-manager:v1_20220808
   type: image
 - source: longhornio/longhorn-share-manager:v1_20201204
+  target: registry.suse.com/rancher/charts/longhornio-longhorn-share-manager:v1_20201204
+  type: image
+- source: longhornio/longhorn-share-manager:v1_20210416
+  target: registry.suse.com/rancher/charts/longhornio-longhorn-share-manager:v1_20210416
+  type: image
+- source: longhornio/longhorn-share-manager:v1_20210416_patch1
+  target: registry.suse.com/rancher/charts/longhornio-longhorn-share-manager:v1_20210416_patch1
+  type: image
+- source: longhornio/longhorn-share-manager:v1_20210820
+  target: registry.suse.com/rancher/charts/longhornio-longhorn-share-manager:v1_20210820
+  type: image
+- source: longhornio/longhorn-share-manager:v1_20210914
+  target: registry.suse.com/rancher/charts/longhornio-longhorn-share-manager:v1_20210914
+  type: image
+- source: longhornio/longhorn-share-manager:v1_20211020
+  target: registry.suse.com/rancher/charts/longhornio-longhorn-share-manager:v1_20211020
+  type: image
+- source: longhornio/longhorn-share-manager:v1_20211020_patch1
+  target: registry.suse.com/rancher/charts/longhornio-longhorn-share-manager:v1_20211020_patch1
+  type: image
+- source: longhornio/longhorn-share-manager:v1_20220531
+  target: registry.suse.com/rancher/charts/longhornio-longhorn-share-manager:v1_20220531
+  type: image
+- source: longhornio/longhorn-share-manager:v1_20220808
+  target: registry.suse.com/rancher/charts/longhornio-longhorn-share-manager:v1_20220808
+  type: image
+- source: longhornio/longhorn-share-manager:v1_20201204
   target: stgregistry.suse.com/rancher/longhornio-longhorn-share-manager:v1_20201204
   type: image
 - source: longhornio/longhorn-share-manager:v1_20210416
@@ -7867,6 +13062,33 @@ sync:
   type: image
 - source: longhornio/longhorn-share-manager:v1_20220808
   target: stgregistry.suse.com/rancher/longhornio-longhorn-share-manager:v1_20220808
+  type: image
+- source: longhornio/longhorn-share-manager:v1_20201204
+  target: stgregistry.suse.com/rancher/charts/longhornio-longhorn-share-manager:v1_20201204
+  type: image
+- source: longhornio/longhorn-share-manager:v1_20210416
+  target: stgregistry.suse.com/rancher/charts/longhornio-longhorn-share-manager:v1_20210416
+  type: image
+- source: longhornio/longhorn-share-manager:v1_20210416_patch1
+  target: stgregistry.suse.com/rancher/charts/longhornio-longhorn-share-manager:v1_20210416_patch1
+  type: image
+- source: longhornio/longhorn-share-manager:v1_20210820
+  target: stgregistry.suse.com/rancher/charts/longhornio-longhorn-share-manager:v1_20210820
+  type: image
+- source: longhornio/longhorn-share-manager:v1_20210914
+  target: stgregistry.suse.com/rancher/charts/longhornio-longhorn-share-manager:v1_20210914
+  type: image
+- source: longhornio/longhorn-share-manager:v1_20211020
+  target: stgregistry.suse.com/rancher/charts/longhornio-longhorn-share-manager:v1_20211020
+  type: image
+- source: longhornio/longhorn-share-manager:v1_20211020_patch1
+  target: stgregistry.suse.com/rancher/charts/longhornio-longhorn-share-manager:v1_20211020_patch1
+  type: image
+- source: longhornio/longhorn-share-manager:v1_20220531
+  target: stgregistry.suse.com/rancher/charts/longhornio-longhorn-share-manager:v1_20220531
+  type: image
+- source: longhornio/longhorn-share-manager:v1_20220808
+  target: stgregistry.suse.com/rancher/charts/longhornio-longhorn-share-manager:v1_20220808
   type: image
 - source: longhornio/longhorn-share-manager:v1.4.0
   target: docker.io/rancher/mirrored-longhornio-longhorn-share-manager:v1.4.0
@@ -8085,6 +13307,114 @@ sync:
   target: registry.suse.com/rancher/mirrored-longhornio-longhorn-share-manager:v1_20230320
   type: image
 - source: longhornio/longhorn-share-manager:v1.4.0
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1.4.0
+  type: image
+- source: longhornio/longhorn-share-manager:v1.4.1
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1.4.1
+  type: image
+- source: longhornio/longhorn-share-manager:v1.4.2
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1.4.2
+  type: image
+- source: longhornio/longhorn-share-manager:v1.4.3
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1.4.3
+  type: image
+- source: longhornio/longhorn-share-manager:v1.4.4
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1.4.4
+  type: image
+- source: longhornio/longhorn-share-manager:v1.5.0
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1.5.0
+  type: image
+- source: longhornio/longhorn-share-manager:v1.5.1
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1.5.1
+  type: image
+- source: longhornio/longhorn-share-manager:v1.5.2
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1.5.2
+  type: image
+- source: longhornio/longhorn-share-manager:v1.5.3
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1.5.3
+  type: image
+- source: longhornio/longhorn-share-manager:v1.5.4
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1.5.4
+  type: image
+- source: longhornio/longhorn-share-manager:v1.5.5
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1.5.5
+  type: image
+- source: longhornio/longhorn-share-manager:v1.6.0
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1.6.0
+  type: image
+- source: longhornio/longhorn-share-manager:v1.6.1
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1.6.1
+  type: image
+- source: longhornio/longhorn-share-manager:v1.6.2
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1.6.2
+  type: image
+- source: longhornio/longhorn-share-manager:v1.6.3
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1.6.3
+  type: image
+- source: longhornio/longhorn-share-manager:v1.6.4
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1.6.4
+  type: image
+- source: longhornio/longhorn-share-manager:v1.7.0
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1.7.0
+  type: image
+- source: longhornio/longhorn-share-manager:v1.7.1
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1.7.1
+  type: image
+- source: longhornio/longhorn-share-manager:v1.7.2
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1.7.2
+  type: image
+- source: longhornio/longhorn-share-manager:v1.7.3
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1.7.3
+  type: image
+- source: longhornio/longhorn-share-manager:v1.8.1
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1.8.1
+  type: image
+- source: longhornio/longhorn-share-manager:v1.8.2
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1.8.2
+  type: image
+- source: longhornio/longhorn-share-manager:v1.9.1
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1.9.1
+  type: image
+- source: longhornio/longhorn-share-manager:v1.9.2
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1.9.2
+  type: image
+- source: longhornio/longhorn-share-manager:v1_20201204
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1_20201204
+  type: image
+- source: longhornio/longhorn-share-manager:v1_20210416
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1_20210416
+  type: image
+- source: longhornio/longhorn-share-manager:v1_20210416_patch1
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1_20210416_patch1
+  type: image
+- source: longhornio/longhorn-share-manager:v1_20210820
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1_20210820
+  type: image
+- source: longhornio/longhorn-share-manager:v1_20210914
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1_20210914
+  type: image
+- source: longhornio/longhorn-share-manager:v1_20211020
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1_20211020
+  type: image
+- source: longhornio/longhorn-share-manager:v1_20211020_patch1
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1_20211020_patch1
+  type: image
+- source: longhornio/longhorn-share-manager:v1_20211020_patch2
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1_20211020_patch2
+  type: image
+- source: longhornio/longhorn-share-manager:v1_20220531
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1_20220531
+  type: image
+- source: longhornio/longhorn-share-manager:v1_20220808
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1_20220808
+  type: image
+- source: longhornio/longhorn-share-manager:v1_20221003
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1_20221003
+  type: image
+- source: longhornio/longhorn-share-manager:v1_20230320
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1_20230320
+  type: image
+- source: longhornio/longhorn-share-manager:v1.4.0
   target: stgregistry.suse.com/rancher/mirrored-longhornio-longhorn-share-manager:v1.4.0
   type: image
 - source: longhornio/longhorn-share-manager:v1.4.1
@@ -8192,6 +13522,114 @@ sync:
 - source: longhornio/longhorn-share-manager:v1_20230320
   target: stgregistry.suse.com/rancher/mirrored-longhornio-longhorn-share-manager:v1_20230320
   type: image
+- source: longhornio/longhorn-share-manager:v1.4.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1.4.0
+  type: image
+- source: longhornio/longhorn-share-manager:v1.4.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1.4.1
+  type: image
+- source: longhornio/longhorn-share-manager:v1.4.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1.4.2
+  type: image
+- source: longhornio/longhorn-share-manager:v1.4.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1.4.3
+  type: image
+- source: longhornio/longhorn-share-manager:v1.4.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1.4.4
+  type: image
+- source: longhornio/longhorn-share-manager:v1.5.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1.5.0
+  type: image
+- source: longhornio/longhorn-share-manager:v1.5.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1.5.1
+  type: image
+- source: longhornio/longhorn-share-manager:v1.5.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1.5.2
+  type: image
+- source: longhornio/longhorn-share-manager:v1.5.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1.5.3
+  type: image
+- source: longhornio/longhorn-share-manager:v1.5.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1.5.4
+  type: image
+- source: longhornio/longhorn-share-manager:v1.5.5
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1.5.5
+  type: image
+- source: longhornio/longhorn-share-manager:v1.6.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1.6.0
+  type: image
+- source: longhornio/longhorn-share-manager:v1.6.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1.6.1
+  type: image
+- source: longhornio/longhorn-share-manager:v1.6.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1.6.2
+  type: image
+- source: longhornio/longhorn-share-manager:v1.6.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1.6.3
+  type: image
+- source: longhornio/longhorn-share-manager:v1.6.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1.6.4
+  type: image
+- source: longhornio/longhorn-share-manager:v1.7.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1.7.0
+  type: image
+- source: longhornio/longhorn-share-manager:v1.7.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1.7.1
+  type: image
+- source: longhornio/longhorn-share-manager:v1.7.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1.7.2
+  type: image
+- source: longhornio/longhorn-share-manager:v1.7.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1.7.3
+  type: image
+- source: longhornio/longhorn-share-manager:v1.8.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1.8.1
+  type: image
+- source: longhornio/longhorn-share-manager:v1.8.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1.8.2
+  type: image
+- source: longhornio/longhorn-share-manager:v1.9.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1.9.1
+  type: image
+- source: longhornio/longhorn-share-manager:v1.9.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1.9.2
+  type: image
+- source: longhornio/longhorn-share-manager:v1_20201204
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1_20201204
+  type: image
+- source: longhornio/longhorn-share-manager:v1_20210416
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1_20210416
+  type: image
+- source: longhornio/longhorn-share-manager:v1_20210416_patch1
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1_20210416_patch1
+  type: image
+- source: longhornio/longhorn-share-manager:v1_20210820
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1_20210820
+  type: image
+- source: longhornio/longhorn-share-manager:v1_20210914
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1_20210914
+  type: image
+- source: longhornio/longhorn-share-manager:v1_20211020
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1_20211020
+  type: image
+- source: longhornio/longhorn-share-manager:v1_20211020_patch1
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1_20211020_patch1
+  type: image
+- source: longhornio/longhorn-share-manager:v1_20211020_patch2
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1_20211020_patch2
+  type: image
+- source: longhornio/longhorn-share-manager:v1_20220531
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1_20220531
+  type: image
+- source: longhornio/longhorn-share-manager:v1_20220808
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1_20220808
+  type: image
+- source: longhornio/longhorn-share-manager:v1_20221003
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1_20221003
+  type: image
+- source: longhornio/longhorn-share-manager:v1_20230320
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1_20230320
+  type: image
 - source: longhornio/longhorn-ui:v1.0.2
   target: docker.io/rancher/longhornio-longhorn-ui:v1.0.2
   type: image
@@ -8271,6 +13709,45 @@ sync:
   target: registry.suse.com/rancher/longhornio-longhorn-ui:v1.3.1
   type: image
 - source: longhornio/longhorn-ui:v1.0.2
+  target: registry.suse.com/rancher/charts/longhornio-longhorn-ui:v1.0.2
+  type: image
+- source: longhornio/longhorn-ui:v1.1.0
+  target: registry.suse.com/rancher/charts/longhornio-longhorn-ui:v1.1.0
+  type: image
+- source: longhornio/longhorn-ui:v1.1.1
+  target: registry.suse.com/rancher/charts/longhornio-longhorn-ui:v1.1.1
+  type: image
+- source: longhornio/longhorn-ui:v1.1.2
+  target: registry.suse.com/rancher/charts/longhornio-longhorn-ui:v1.1.2
+  type: image
+- source: longhornio/longhorn-ui:v1.1.3
+  target: registry.suse.com/rancher/charts/longhornio-longhorn-ui:v1.1.3
+  type: image
+- source: longhornio/longhorn-ui:v1.2.0
+  target: registry.suse.com/rancher/charts/longhornio-longhorn-ui:v1.2.0
+  type: image
+- source: longhornio/longhorn-ui:v1.2.1
+  target: registry.suse.com/rancher/charts/longhornio-longhorn-ui:v1.2.1
+  type: image
+- source: longhornio/longhorn-ui:v1.2.2
+  target: registry.suse.com/rancher/charts/longhornio-longhorn-ui:v1.2.2
+  type: image
+- source: longhornio/longhorn-ui:v1.2.3
+  target: registry.suse.com/rancher/charts/longhornio-longhorn-ui:v1.2.3
+  type: image
+- source: longhornio/longhorn-ui:v1.2.4
+  target: registry.suse.com/rancher/charts/longhornio-longhorn-ui:v1.2.4
+  type: image
+- source: longhornio/longhorn-ui:v1.2.5
+  target: registry.suse.com/rancher/charts/longhornio-longhorn-ui:v1.2.5
+  type: image
+- source: longhornio/longhorn-ui:v1.3.0
+  target: registry.suse.com/rancher/charts/longhornio-longhorn-ui:v1.3.0
+  type: image
+- source: longhornio/longhorn-ui:v1.3.1
+  target: registry.suse.com/rancher/charts/longhornio-longhorn-ui:v1.3.1
+  type: image
+- source: longhornio/longhorn-ui:v1.0.2
   target: stgregistry.suse.com/rancher/longhornio-longhorn-ui:v1.0.2
   type: image
 - source: longhornio/longhorn-ui:v1.1.0
@@ -8308,6 +13785,45 @@ sync:
   type: image
 - source: longhornio/longhorn-ui:v1.3.1
   target: stgregistry.suse.com/rancher/longhornio-longhorn-ui:v1.3.1
+  type: image
+- source: longhornio/longhorn-ui:v1.0.2
+  target: stgregistry.suse.com/rancher/charts/longhornio-longhorn-ui:v1.0.2
+  type: image
+- source: longhornio/longhorn-ui:v1.1.0
+  target: stgregistry.suse.com/rancher/charts/longhornio-longhorn-ui:v1.1.0
+  type: image
+- source: longhornio/longhorn-ui:v1.1.1
+  target: stgregistry.suse.com/rancher/charts/longhornio-longhorn-ui:v1.1.1
+  type: image
+- source: longhornio/longhorn-ui:v1.1.2
+  target: stgregistry.suse.com/rancher/charts/longhornio-longhorn-ui:v1.1.2
+  type: image
+- source: longhornio/longhorn-ui:v1.1.3
+  target: stgregistry.suse.com/rancher/charts/longhornio-longhorn-ui:v1.1.3
+  type: image
+- source: longhornio/longhorn-ui:v1.2.0
+  target: stgregistry.suse.com/rancher/charts/longhornio-longhorn-ui:v1.2.0
+  type: image
+- source: longhornio/longhorn-ui:v1.2.1
+  target: stgregistry.suse.com/rancher/charts/longhornio-longhorn-ui:v1.2.1
+  type: image
+- source: longhornio/longhorn-ui:v1.2.2
+  target: stgregistry.suse.com/rancher/charts/longhornio-longhorn-ui:v1.2.2
+  type: image
+- source: longhornio/longhorn-ui:v1.2.3
+  target: stgregistry.suse.com/rancher/charts/longhornio-longhorn-ui:v1.2.3
+  type: image
+- source: longhornio/longhorn-ui:v1.2.4
+  target: stgregistry.suse.com/rancher/charts/longhornio-longhorn-ui:v1.2.4
+  type: image
+- source: longhornio/longhorn-ui:v1.2.5
+  target: stgregistry.suse.com/rancher/charts/longhornio-longhorn-ui:v1.2.5
+  type: image
+- source: longhornio/longhorn-ui:v1.3.0
+  target: stgregistry.suse.com/rancher/charts/longhornio-longhorn-ui:v1.3.0
+  type: image
+- source: longhornio/longhorn-ui:v1.3.1
+  target: stgregistry.suse.com/rancher/charts/longhornio-longhorn-ui:v1.3.1
   type: image
 - source: longhornio/longhorn-ui:v1.1.0
   target: docker.io/rancher/mirrored-longhornio-longhorn-ui:v1.1.0
@@ -8544,6 +14060,123 @@ sync:
   target: registry.suse.com/rancher/mirrored-longhornio-longhorn-ui:v1.9.2
   type: image
 - source: longhornio/longhorn-ui:v1.1.0
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.1.0
+  type: image
+- source: longhornio/longhorn-ui:v1.1.1
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.1.1
+  type: image
+- source: longhornio/longhorn-ui:v1.1.2
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.1.2
+  type: image
+- source: longhornio/longhorn-ui:v1.1.3
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.1.3
+  type: image
+- source: longhornio/longhorn-ui:v1.2.0
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.2.0
+  type: image
+- source: longhornio/longhorn-ui:v1.2.1
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.2.1
+  type: image
+- source: longhornio/longhorn-ui:v1.2.2
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.2.2
+  type: image
+- source: longhornio/longhorn-ui:v1.2.3
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.2.3
+  type: image
+- source: longhornio/longhorn-ui:v1.2.4
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.2.4
+  type: image
+- source: longhornio/longhorn-ui:v1.2.5
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.2.5
+  type: image
+- source: longhornio/longhorn-ui:v1.2.6
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.2.6
+  type: image
+- source: longhornio/longhorn-ui:v1.3.0
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.3.0
+  type: image
+- source: longhornio/longhorn-ui:v1.3.1
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.3.1
+  type: image
+- source: longhornio/longhorn-ui:v1.3.2
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.3.2
+  type: image
+- source: longhornio/longhorn-ui:v1.3.3
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.3.3
+  type: image
+- source: longhornio/longhorn-ui:v1.4.0
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.4.0
+  type: image
+- source: longhornio/longhorn-ui:v1.4.1
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.4.1
+  type: image
+- source: longhornio/longhorn-ui:v1.4.2
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.4.2
+  type: image
+- source: longhornio/longhorn-ui:v1.4.3
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.4.3
+  type: image
+- source: longhornio/longhorn-ui:v1.4.4
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.4.4
+  type: image
+- source: longhornio/longhorn-ui:v1.5.0
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.5.0
+  type: image
+- source: longhornio/longhorn-ui:v1.5.1
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.5.1
+  type: image
+- source: longhornio/longhorn-ui:v1.5.2
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.5.2
+  type: image
+- source: longhornio/longhorn-ui:v1.5.3
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.5.3
+  type: image
+- source: longhornio/longhorn-ui:v1.5.4
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.5.4
+  type: image
+- source: longhornio/longhorn-ui:v1.5.5
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.5.5
+  type: image
+- source: longhornio/longhorn-ui:v1.6.0
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.6.0
+  type: image
+- source: longhornio/longhorn-ui:v1.6.1
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.6.1
+  type: image
+- source: longhornio/longhorn-ui:v1.6.2
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.6.2
+  type: image
+- source: longhornio/longhorn-ui:v1.6.3
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.6.3
+  type: image
+- source: longhornio/longhorn-ui:v1.6.4
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.6.4
+  type: image
+- source: longhornio/longhorn-ui:v1.7.0
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.7.0
+  type: image
+- source: longhornio/longhorn-ui:v1.7.1
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.7.1
+  type: image
+- source: longhornio/longhorn-ui:v1.7.2
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.7.2
+  type: image
+- source: longhornio/longhorn-ui:v1.7.3
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.7.3
+  type: image
+- source: longhornio/longhorn-ui:v1.8.1
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.8.1
+  type: image
+- source: longhornio/longhorn-ui:v1.8.2
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.8.2
+  type: image
+- source: longhornio/longhorn-ui:v1.9.1
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.9.1
+  type: image
+- source: longhornio/longhorn-ui:v1.9.2
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.9.2
+  type: image
+- source: longhornio/longhorn-ui:v1.1.0
   target: stgregistry.suse.com/rancher/mirrored-longhornio-longhorn-ui:v1.1.0
   type: image
 - source: longhornio/longhorn-ui:v1.1.1
@@ -8660,6 +14293,123 @@ sync:
 - source: longhornio/longhorn-ui:v1.9.2
   target: stgregistry.suse.com/rancher/mirrored-longhornio-longhorn-ui:v1.9.2
   type: image
+- source: longhornio/longhorn-ui:v1.1.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.1.0
+  type: image
+- source: longhornio/longhorn-ui:v1.1.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.1.1
+  type: image
+- source: longhornio/longhorn-ui:v1.1.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.1.2
+  type: image
+- source: longhornio/longhorn-ui:v1.1.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.1.3
+  type: image
+- source: longhornio/longhorn-ui:v1.2.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.2.0
+  type: image
+- source: longhornio/longhorn-ui:v1.2.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.2.1
+  type: image
+- source: longhornio/longhorn-ui:v1.2.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.2.2
+  type: image
+- source: longhornio/longhorn-ui:v1.2.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.2.3
+  type: image
+- source: longhornio/longhorn-ui:v1.2.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.2.4
+  type: image
+- source: longhornio/longhorn-ui:v1.2.5
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.2.5
+  type: image
+- source: longhornio/longhorn-ui:v1.2.6
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.2.6
+  type: image
+- source: longhornio/longhorn-ui:v1.3.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.3.0
+  type: image
+- source: longhornio/longhorn-ui:v1.3.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.3.1
+  type: image
+- source: longhornio/longhorn-ui:v1.3.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.3.2
+  type: image
+- source: longhornio/longhorn-ui:v1.3.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.3.3
+  type: image
+- source: longhornio/longhorn-ui:v1.4.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.4.0
+  type: image
+- source: longhornio/longhorn-ui:v1.4.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.4.1
+  type: image
+- source: longhornio/longhorn-ui:v1.4.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.4.2
+  type: image
+- source: longhornio/longhorn-ui:v1.4.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.4.3
+  type: image
+- source: longhornio/longhorn-ui:v1.4.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.4.4
+  type: image
+- source: longhornio/longhorn-ui:v1.5.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.5.0
+  type: image
+- source: longhornio/longhorn-ui:v1.5.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.5.1
+  type: image
+- source: longhornio/longhorn-ui:v1.5.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.5.2
+  type: image
+- source: longhornio/longhorn-ui:v1.5.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.5.3
+  type: image
+- source: longhornio/longhorn-ui:v1.5.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.5.4
+  type: image
+- source: longhornio/longhorn-ui:v1.5.5
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.5.5
+  type: image
+- source: longhornio/longhorn-ui:v1.6.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.6.0
+  type: image
+- source: longhornio/longhorn-ui:v1.6.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.6.1
+  type: image
+- source: longhornio/longhorn-ui:v1.6.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.6.2
+  type: image
+- source: longhornio/longhorn-ui:v1.6.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.6.3
+  type: image
+- source: longhornio/longhorn-ui:v1.6.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.6.4
+  type: image
+- source: longhornio/longhorn-ui:v1.7.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.7.0
+  type: image
+- source: longhornio/longhorn-ui:v1.7.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.7.1
+  type: image
+- source: longhornio/longhorn-ui:v1.7.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.7.2
+  type: image
+- source: longhornio/longhorn-ui:v1.7.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.7.3
+  type: image
+- source: longhornio/longhorn-ui:v1.8.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.8.1
+  type: image
+- source: longhornio/longhorn-ui:v1.8.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.8.2
+  type: image
+- source: longhornio/longhorn-ui:v1.9.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.9.1
+  type: image
+- source: longhornio/longhorn-ui:v1.9.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.9.2
+  type: image
 - source: longhornio/openshift-origin-oauth-proxy:4.14
   target: docker.io/rancher/mirrored-longhornio-openshift-origin-oauth-proxy:4.14
   type: image
@@ -8673,10 +14423,22 @@ sync:
   target: registry.suse.com/rancher/mirrored-longhornio-openshift-origin-oauth-proxy:4.15
   type: image
 - source: longhornio/openshift-origin-oauth-proxy:4.14
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-openshift-origin-oauth-proxy:4.14
+  type: image
+- source: longhornio/openshift-origin-oauth-proxy:4.15
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-openshift-origin-oauth-proxy:4.15
+  type: image
+- source: longhornio/openshift-origin-oauth-proxy:4.14
   target: stgregistry.suse.com/rancher/mirrored-longhornio-openshift-origin-oauth-proxy:4.14
   type: image
 - source: longhornio/openshift-origin-oauth-proxy:4.15
   target: stgregistry.suse.com/rancher/mirrored-longhornio-openshift-origin-oauth-proxy:4.15
+  type: image
+- source: longhornio/openshift-origin-oauth-proxy:4.14
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-openshift-origin-oauth-proxy:4.14
+  type: image
+- source: longhornio/openshift-origin-oauth-proxy:4.15
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-openshift-origin-oauth-proxy:4.15
   type: image
 - source: longhornio/support-bundle-kit:v0.0.17
   target: docker.io/rancher/mirrored-longhornio-support-bundle-kit:v0.0.17
@@ -8793,6 +14555,63 @@ sync:
   target: registry.suse.com/rancher/mirrored-longhornio-support-bundle-kit:v0.0.69
   type: image
 - source: longhornio/support-bundle-kit:v0.0.17
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-support-bundle-kit:v0.0.17
+  type: image
+- source: longhornio/support-bundle-kit:v0.0.19
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-support-bundle-kit:v0.0.19
+  type: image
+- source: longhornio/support-bundle-kit:v0.0.24
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-support-bundle-kit:v0.0.24
+  type: image
+- source: longhornio/support-bundle-kit:v0.0.25
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-support-bundle-kit:v0.0.25
+  type: image
+- source: longhornio/support-bundle-kit:v0.0.27
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-support-bundle-kit:v0.0.27
+  type: image
+- source: longhornio/support-bundle-kit:v0.0.33
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-support-bundle-kit:v0.0.33
+  type: image
+- source: longhornio/support-bundle-kit:v0.0.36
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-support-bundle-kit:v0.0.36
+  type: image
+- source: longhornio/support-bundle-kit:v0.0.37
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-support-bundle-kit:v0.0.37
+  type: image
+- source: longhornio/support-bundle-kit:v0.0.41
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-support-bundle-kit:v0.0.41
+  type: image
+- source: longhornio/support-bundle-kit:v0.0.42
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-support-bundle-kit:v0.0.42
+  type: image
+- source: longhornio/support-bundle-kit:v0.0.43
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-support-bundle-kit:v0.0.43
+  type: image
+- source: longhornio/support-bundle-kit:v0.0.45
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-support-bundle-kit:v0.0.45
+  type: image
+- source: longhornio/support-bundle-kit:v0.0.48
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-support-bundle-kit:v0.0.48
+  type: image
+- source: longhornio/support-bundle-kit:v0.0.49
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-support-bundle-kit:v0.0.49
+  type: image
+- source: longhornio/support-bundle-kit:v0.0.51
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-support-bundle-kit:v0.0.51
+  type: image
+- source: longhornio/support-bundle-kit:v0.0.52
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-support-bundle-kit:v0.0.52
+  type: image
+- source: longhornio/support-bundle-kit:v0.0.56
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-support-bundle-kit:v0.0.56
+  type: image
+- source: longhornio/support-bundle-kit:v0.0.61
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-support-bundle-kit:v0.0.61
+  type: image
+- source: longhornio/support-bundle-kit:v0.0.69
+  target: registry.suse.com/rancher/charts/mirrored-longhornio-support-bundle-kit:v0.0.69
+  type: image
+- source: longhornio/support-bundle-kit:v0.0.17
   target: stgregistry.suse.com/rancher/mirrored-longhornio-support-bundle-kit:v0.0.17
   type: image
 - source: longhornio/support-bundle-kit:v0.0.19
@@ -8849,6 +14668,63 @@ sync:
 - source: longhornio/support-bundle-kit:v0.0.69
   target: stgregistry.suse.com/rancher/mirrored-longhornio-support-bundle-kit:v0.0.69
   type: image
+- source: longhornio/support-bundle-kit:v0.0.17
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-support-bundle-kit:v0.0.17
+  type: image
+- source: longhornio/support-bundle-kit:v0.0.19
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-support-bundle-kit:v0.0.19
+  type: image
+- source: longhornio/support-bundle-kit:v0.0.24
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-support-bundle-kit:v0.0.24
+  type: image
+- source: longhornio/support-bundle-kit:v0.0.25
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-support-bundle-kit:v0.0.25
+  type: image
+- source: longhornio/support-bundle-kit:v0.0.27
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-support-bundle-kit:v0.0.27
+  type: image
+- source: longhornio/support-bundle-kit:v0.0.33
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-support-bundle-kit:v0.0.33
+  type: image
+- source: longhornio/support-bundle-kit:v0.0.36
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-support-bundle-kit:v0.0.36
+  type: image
+- source: longhornio/support-bundle-kit:v0.0.37
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-support-bundle-kit:v0.0.37
+  type: image
+- source: longhornio/support-bundle-kit:v0.0.41
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-support-bundle-kit:v0.0.41
+  type: image
+- source: longhornio/support-bundle-kit:v0.0.42
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-support-bundle-kit:v0.0.42
+  type: image
+- source: longhornio/support-bundle-kit:v0.0.43
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-support-bundle-kit:v0.0.43
+  type: image
+- source: longhornio/support-bundle-kit:v0.0.45
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-support-bundle-kit:v0.0.45
+  type: image
+- source: longhornio/support-bundle-kit:v0.0.48
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-support-bundle-kit:v0.0.48
+  type: image
+- source: longhornio/support-bundle-kit:v0.0.49
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-support-bundle-kit:v0.0.49
+  type: image
+- source: longhornio/support-bundle-kit:v0.0.51
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-support-bundle-kit:v0.0.51
+  type: image
+- source: longhornio/support-bundle-kit:v0.0.52
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-support-bundle-kit:v0.0.52
+  type: image
+- source: longhornio/support-bundle-kit:v0.0.56
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-support-bundle-kit:v0.0.56
+  type: image
+- source: longhornio/support-bundle-kit:v0.0.61
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-support-bundle-kit:v0.0.61
+  type: image
+- source: longhornio/support-bundle-kit:v0.0.69
+  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-support-bundle-kit:v0.0.69
+  type: image
 - source: messagebird/sachet:0.2.3
   target: docker.io/rancher/mirrored-messagebird-sachet:0.2.3
   type: image
@@ -8868,6 +14744,15 @@ sync:
   target: registry.suse.com/rancher/mirrored-messagebird-sachet:0.3.1
   type: image
 - source: messagebird/sachet:0.2.3
+  target: registry.suse.com/rancher/charts/mirrored-messagebird-sachet:0.2.3
+  type: image
+- source: messagebird/sachet:0.2.6
+  target: registry.suse.com/rancher/charts/mirrored-messagebird-sachet:0.2.6
+  type: image
+- source: messagebird/sachet:0.3.1
+  target: registry.suse.com/rancher/charts/mirrored-messagebird-sachet:0.3.1
+  type: image
+- source: messagebird/sachet:0.2.3
   target: stgregistry.suse.com/rancher/mirrored-messagebird-sachet:0.2.3
   type: image
 - source: messagebird/sachet:0.2.6
@@ -8875,6 +14760,15 @@ sync:
   type: image
 - source: messagebird/sachet:0.3.1
   target: stgregistry.suse.com/rancher/mirrored-messagebird-sachet:0.3.1
+  type: image
+- source: messagebird/sachet:0.2.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-messagebird-sachet:0.2.3
+  type: image
+- source: messagebird/sachet:0.2.6
+  target: stgregistry.suse.com/rancher/charts/mirrored-messagebird-sachet:0.2.6
+  type: image
+- source: messagebird/sachet:0.3.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-messagebird-sachet:0.3.1
   type: image
 - source: minio/mc:RELEASE.2022-05-09T04-08-26Z
   target: docker.io/rancher/mirrored-minio-mc:RELEASE.2022-05-09T04-08-26Z
@@ -8913,6 +14807,24 @@ sync:
   target: registry.suse.com/rancher/mirrored-minio-mc:RELEASE.2023-06-28T21-54-17Z
   type: image
 - source: minio/mc:RELEASE.2022-05-09T04-08-26Z
+  target: registry.suse.com/rancher/charts/mirrored-minio-mc:RELEASE.2022-05-09T04-08-26Z
+  type: image
+- source: minio/mc:RELEASE.2022-09-16T09-16-47Z
+  target: registry.suse.com/rancher/charts/mirrored-minio-mc:RELEASE.2022-09-16T09-16-47Z
+  type: image
+- source: minio/mc:RELEASE.2022-11-07T23-47-39Z
+  target: registry.suse.com/rancher/charts/mirrored-minio-mc:RELEASE.2022-11-07T23-47-39Z
+  type: image
+- source: minio/mc:RELEASE.2022-12-13T00-23-28Z
+  target: registry.suse.com/rancher/charts/mirrored-minio-mc:RELEASE.2022-12-13T00-23-28Z
+  type: image
+- source: minio/mc:RELEASE.2023-01-28T20-29-38Z
+  target: registry.suse.com/rancher/charts/mirrored-minio-mc:RELEASE.2023-01-28T20-29-38Z
+  type: image
+- source: minio/mc:RELEASE.2023-06-28T21-54-17Z
+  target: registry.suse.com/rancher/charts/mirrored-minio-mc:RELEASE.2023-06-28T21-54-17Z
+  type: image
+- source: minio/mc:RELEASE.2022-05-09T04-08-26Z
   target: stgregistry.suse.com/rancher/mirrored-minio-mc:RELEASE.2022-05-09T04-08-26Z
   type: image
 - source: minio/mc:RELEASE.2022-09-16T09-16-47Z
@@ -8929,6 +14841,24 @@ sync:
   type: image
 - source: minio/mc:RELEASE.2023-06-28T21-54-17Z
   target: stgregistry.suse.com/rancher/mirrored-minio-mc:RELEASE.2023-06-28T21-54-17Z
+  type: image
+- source: minio/mc:RELEASE.2022-05-09T04-08-26Z
+  target: stgregistry.suse.com/rancher/charts/mirrored-minio-mc:RELEASE.2022-05-09T04-08-26Z
+  type: image
+- source: minio/mc:RELEASE.2022-09-16T09-16-47Z
+  target: stgregistry.suse.com/rancher/charts/mirrored-minio-mc:RELEASE.2022-09-16T09-16-47Z
+  type: image
+- source: minio/mc:RELEASE.2022-11-07T23-47-39Z
+  target: stgregistry.suse.com/rancher/charts/mirrored-minio-mc:RELEASE.2022-11-07T23-47-39Z
+  type: image
+- source: minio/mc:RELEASE.2022-12-13T00-23-28Z
+  target: stgregistry.suse.com/rancher/charts/mirrored-minio-mc:RELEASE.2022-12-13T00-23-28Z
+  type: image
+- source: minio/mc:RELEASE.2023-01-28T20-29-38Z
+  target: stgregistry.suse.com/rancher/charts/mirrored-minio-mc:RELEASE.2023-01-28T20-29-38Z
+  type: image
+- source: minio/mc:RELEASE.2023-06-28T21-54-17Z
+  target: stgregistry.suse.com/rancher/charts/mirrored-minio-mc:RELEASE.2023-06-28T21-54-17Z
   type: image
 - source: minio/minio:RELEASE.2020-07-13T18-09-56Z
   target: docker.io/rancher/mirrored-minio-minio:RELEASE.2020-07-13T18-09-56Z
@@ -8973,6 +14903,27 @@ sync:
   target: registry.suse.com/rancher/mirrored-minio-minio:RELEASE.2023-07-07T07-13-57Z
   type: image
 - source: minio/minio:RELEASE.2020-07-13T18-09-56Z
+  target: registry.suse.com/rancher/charts/mirrored-minio-minio:RELEASE.2020-07-13T18-09-56Z
+  type: image
+- source: minio/minio:RELEASE.2022-05-08T23-50-31Z
+  target: registry.suse.com/rancher/charts/mirrored-minio-minio:RELEASE.2022-05-08T23-50-31Z
+  type: image
+- source: minio/minio:RELEASE.2022-09-17T00-09-45Z
+  target: registry.suse.com/rancher/charts/mirrored-minio-minio:RELEASE.2022-09-17T00-09-45Z
+  type: image
+- source: minio/minio:RELEASE.2022-11-11T03-44-20Z
+  target: registry.suse.com/rancher/charts/mirrored-minio-minio:RELEASE.2022-11-11T03-44-20Z
+  type: image
+- source: minio/minio:RELEASE.2022-12-12T19-27-27Z
+  target: registry.suse.com/rancher/charts/mirrored-minio-minio:RELEASE.2022-12-12T19-27-27Z
+  type: image
+- source: minio/minio:RELEASE.2023-02-10T18-48-39Z
+  target: registry.suse.com/rancher/charts/mirrored-minio-minio:RELEASE.2023-02-10T18-48-39Z
+  type: image
+- source: minio/minio:RELEASE.2023-07-07T07-13-57Z
+  target: registry.suse.com/rancher/charts/mirrored-minio-minio:RELEASE.2023-07-07T07-13-57Z
+  type: image
+- source: minio/minio:RELEASE.2020-07-13T18-09-56Z
   target: stgregistry.suse.com/rancher/mirrored-minio-minio:RELEASE.2020-07-13T18-09-56Z
   type: image
 - source: minio/minio:RELEASE.2022-05-08T23-50-31Z
@@ -8993,6 +14944,27 @@ sync:
 - source: minio/minio:RELEASE.2023-07-07T07-13-57Z
   target: stgregistry.suse.com/rancher/mirrored-minio-minio:RELEASE.2023-07-07T07-13-57Z
   type: image
+- source: minio/minio:RELEASE.2020-07-13T18-09-56Z
+  target: stgregistry.suse.com/rancher/charts/mirrored-minio-minio:RELEASE.2020-07-13T18-09-56Z
+  type: image
+- source: minio/minio:RELEASE.2022-05-08T23-50-31Z
+  target: stgregistry.suse.com/rancher/charts/mirrored-minio-minio:RELEASE.2022-05-08T23-50-31Z
+  type: image
+- source: minio/minio:RELEASE.2022-09-17T00-09-45Z
+  target: stgregistry.suse.com/rancher/charts/mirrored-minio-minio:RELEASE.2022-09-17T00-09-45Z
+  type: image
+- source: minio/minio:RELEASE.2022-11-11T03-44-20Z
+  target: stgregistry.suse.com/rancher/charts/mirrored-minio-minio:RELEASE.2022-11-11T03-44-20Z
+  type: image
+- source: minio/minio:RELEASE.2022-12-12T19-27-27Z
+  target: stgregistry.suse.com/rancher/charts/mirrored-minio-minio:RELEASE.2022-12-12T19-27-27Z
+  type: image
+- source: minio/minio:RELEASE.2023-02-10T18-48-39Z
+  target: stgregistry.suse.com/rancher/charts/mirrored-minio-minio:RELEASE.2023-02-10T18-48-39Z
+  type: image
+- source: minio/minio:RELEASE.2023-07-07T07-13-57Z
+  target: stgregistry.suse.com/rancher/charts/mirrored-minio-minio:RELEASE.2023-07-07T07-13-57Z
+  type: image
 - source: neuvector/compliance-config:1.0.0
   target: docker.io/rancher/mirrored-neuvector-compliance-config:1.0.0
   type: image
@@ -9006,10 +14978,22 @@ sync:
   target: registry.suse.com/rancher/mirrored-neuvector-compliance-config:1.0.1
   type: image
 - source: neuvector/compliance-config:1.0.0
+  target: registry.suse.com/rancher/charts/mirrored-neuvector-compliance-config:1.0.0
+  type: image
+- source: neuvector/compliance-config:1.0.1
+  target: registry.suse.com/rancher/charts/mirrored-neuvector-compliance-config:1.0.1
+  type: image
+- source: neuvector/compliance-config:1.0.0
   target: stgregistry.suse.com/rancher/mirrored-neuvector-compliance-config:1.0.0
   type: image
 - source: neuvector/compliance-config:1.0.1
   target: stgregistry.suse.com/rancher/mirrored-neuvector-compliance-config:1.0.1
+  type: image
+- source: neuvector/compliance-config:1.0.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-compliance-config:1.0.0
+  type: image
+- source: neuvector/compliance-config:1.0.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-compliance-config:1.0.1
   type: image
 - source: neuvector/controller:5.0.0
   target: docker.io/rancher/mirrored-neuvector-controller:5.0.0
@@ -9162,6 +15146,81 @@ sync:
   target: registry.suse.com/rancher/mirrored-neuvector-controller:5.4.1
   type: image
 - source: neuvector/controller:5.0.0
+  target: registry.suse.com/rancher/charts/mirrored-neuvector-controller:5.0.0
+  type: image
+- source: neuvector/controller:5.0.0-b1
+  target: registry.suse.com/rancher/charts/mirrored-neuvector-controller:5.0.0-b1
+  type: image
+- source: neuvector/controller:5.0.0-b2
+  target: registry.suse.com/rancher/charts/mirrored-neuvector-controller:5.0.0-b2
+  type: image
+- source: neuvector/controller:5.0.1
+  target: registry.suse.com/rancher/charts/mirrored-neuvector-controller:5.0.1
+  type: image
+- source: neuvector/controller:5.0.2
+  target: registry.suse.com/rancher/charts/mirrored-neuvector-controller:5.0.2
+  type: image
+- source: neuvector/controller:5.0.3
+  target: registry.suse.com/rancher/charts/mirrored-neuvector-controller:5.0.3
+  type: image
+- source: neuvector/controller:5.0.4
+  target: registry.suse.com/rancher/charts/mirrored-neuvector-controller:5.0.4
+  type: image
+- source: neuvector/controller:5.1.0
+  target: registry.suse.com/rancher/charts/mirrored-neuvector-controller:5.1.0
+  type: image
+- source: neuvector/controller:5.1.1
+  target: registry.suse.com/rancher/charts/mirrored-neuvector-controller:5.1.1
+  type: image
+- source: neuvector/controller:5.1.2
+  target: registry.suse.com/rancher/charts/mirrored-neuvector-controller:5.1.2
+  type: image
+- source: neuvector/controller:5.1.3
+  target: registry.suse.com/rancher/charts/mirrored-neuvector-controller:5.1.3
+  type: image
+- source: neuvector/controller:5.2.0
+  target: registry.suse.com/rancher/charts/mirrored-neuvector-controller:5.2.0
+  type: image
+- source: neuvector/controller:5.2.0-s1
+  target: registry.suse.com/rancher/charts/mirrored-neuvector-controller:5.2.0-s1
+  type: image
+- source: neuvector/controller:5.2.1
+  target: registry.suse.com/rancher/charts/mirrored-neuvector-controller:5.2.1
+  type: image
+- source: neuvector/controller:5.2.2
+  target: registry.suse.com/rancher/charts/mirrored-neuvector-controller:5.2.2
+  type: image
+- source: neuvector/controller:5.2.2-s1
+  target: registry.suse.com/rancher/charts/mirrored-neuvector-controller:5.2.2-s1
+  type: image
+- source: neuvector/controller:5.2.3
+  target: registry.suse.com/rancher/charts/mirrored-neuvector-controller:5.2.3
+  type: image
+- source: neuvector/controller:5.2.4
+  target: registry.suse.com/rancher/charts/mirrored-neuvector-controller:5.2.4
+  type: image
+- source: neuvector/controller:5.2.4-s1
+  target: registry.suse.com/rancher/charts/mirrored-neuvector-controller:5.2.4-s1
+  type: image
+- source: neuvector/controller:5.3.0
+  target: registry.suse.com/rancher/charts/mirrored-neuvector-controller:5.3.0
+  type: image
+- source: neuvector/controller:5.3.2
+  target: registry.suse.com/rancher/charts/mirrored-neuvector-controller:5.3.2
+  type: image
+- source: neuvector/controller:5.3.3
+  target: registry.suse.com/rancher/charts/mirrored-neuvector-controller:5.3.3
+  type: image
+- source: neuvector/controller:5.3.4
+  target: registry.suse.com/rancher/charts/mirrored-neuvector-controller:5.3.4
+  type: image
+- source: neuvector/controller:5.4.0
+  target: registry.suse.com/rancher/charts/mirrored-neuvector-controller:5.4.0
+  type: image
+- source: neuvector/controller:5.4.1
+  target: registry.suse.com/rancher/charts/mirrored-neuvector-controller:5.4.1
+  type: image
+- source: neuvector/controller:5.0.0
   target: stgregistry.suse.com/rancher/mirrored-neuvector-controller:5.0.0
   type: image
 - source: neuvector/controller:5.0.0-b1
@@ -9235,6 +15294,81 @@ sync:
   type: image
 - source: neuvector/controller:5.4.1
   target: stgregistry.suse.com/rancher/mirrored-neuvector-controller:5.4.1
+  type: image
+- source: neuvector/controller:5.0.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-controller:5.0.0
+  type: image
+- source: neuvector/controller:5.0.0-b1
+  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-controller:5.0.0-b1
+  type: image
+- source: neuvector/controller:5.0.0-b2
+  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-controller:5.0.0-b2
+  type: image
+- source: neuvector/controller:5.0.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-controller:5.0.1
+  type: image
+- source: neuvector/controller:5.0.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-controller:5.0.2
+  type: image
+- source: neuvector/controller:5.0.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-controller:5.0.3
+  type: image
+- source: neuvector/controller:5.0.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-controller:5.0.4
+  type: image
+- source: neuvector/controller:5.1.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-controller:5.1.0
+  type: image
+- source: neuvector/controller:5.1.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-controller:5.1.1
+  type: image
+- source: neuvector/controller:5.1.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-controller:5.1.2
+  type: image
+- source: neuvector/controller:5.1.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-controller:5.1.3
+  type: image
+- source: neuvector/controller:5.2.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-controller:5.2.0
+  type: image
+- source: neuvector/controller:5.2.0-s1
+  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-controller:5.2.0-s1
+  type: image
+- source: neuvector/controller:5.2.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-controller:5.2.1
+  type: image
+- source: neuvector/controller:5.2.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-controller:5.2.2
+  type: image
+- source: neuvector/controller:5.2.2-s1
+  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-controller:5.2.2-s1
+  type: image
+- source: neuvector/controller:5.2.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-controller:5.2.3
+  type: image
+- source: neuvector/controller:5.2.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-controller:5.2.4
+  type: image
+- source: neuvector/controller:5.2.4-s1
+  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-controller:5.2.4-s1
+  type: image
+- source: neuvector/controller:5.3.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-controller:5.3.0
+  type: image
+- source: neuvector/controller:5.3.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-controller:5.3.2
+  type: image
+- source: neuvector/controller:5.3.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-controller:5.3.3
+  type: image
+- source: neuvector/controller:5.3.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-controller:5.3.4
+  type: image
+- source: neuvector/controller:5.4.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-controller:5.4.0
+  type: image
+- source: neuvector/controller:5.4.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-controller:5.4.1
   type: image
 - source: neuvector/enforcer:5.0.0
   target: docker.io/rancher/mirrored-neuvector-enforcer:5.0.0
@@ -9387,6 +15521,81 @@ sync:
   target: registry.suse.com/rancher/mirrored-neuvector-enforcer:5.4.1
   type: image
 - source: neuvector/enforcer:5.0.0
+  target: registry.suse.com/rancher/charts/mirrored-neuvector-enforcer:5.0.0
+  type: image
+- source: neuvector/enforcer:5.0.0-b1
+  target: registry.suse.com/rancher/charts/mirrored-neuvector-enforcer:5.0.0-b1
+  type: image
+- source: neuvector/enforcer:5.0.0-b2
+  target: registry.suse.com/rancher/charts/mirrored-neuvector-enforcer:5.0.0-b2
+  type: image
+- source: neuvector/enforcer:5.0.1
+  target: registry.suse.com/rancher/charts/mirrored-neuvector-enforcer:5.0.1
+  type: image
+- source: neuvector/enforcer:5.0.2
+  target: registry.suse.com/rancher/charts/mirrored-neuvector-enforcer:5.0.2
+  type: image
+- source: neuvector/enforcer:5.0.3
+  target: registry.suse.com/rancher/charts/mirrored-neuvector-enforcer:5.0.3
+  type: image
+- source: neuvector/enforcer:5.0.4
+  target: registry.suse.com/rancher/charts/mirrored-neuvector-enforcer:5.0.4
+  type: image
+- source: neuvector/enforcer:5.1.0
+  target: registry.suse.com/rancher/charts/mirrored-neuvector-enforcer:5.1.0
+  type: image
+- source: neuvector/enforcer:5.1.1
+  target: registry.suse.com/rancher/charts/mirrored-neuvector-enforcer:5.1.1
+  type: image
+- source: neuvector/enforcer:5.1.2
+  target: registry.suse.com/rancher/charts/mirrored-neuvector-enforcer:5.1.2
+  type: image
+- source: neuvector/enforcer:5.1.3
+  target: registry.suse.com/rancher/charts/mirrored-neuvector-enforcer:5.1.3
+  type: image
+- source: neuvector/enforcer:5.2.0
+  target: registry.suse.com/rancher/charts/mirrored-neuvector-enforcer:5.2.0
+  type: image
+- source: neuvector/enforcer:5.2.0-s1
+  target: registry.suse.com/rancher/charts/mirrored-neuvector-enforcer:5.2.0-s1
+  type: image
+- source: neuvector/enforcer:5.2.1
+  target: registry.suse.com/rancher/charts/mirrored-neuvector-enforcer:5.2.1
+  type: image
+- source: neuvector/enforcer:5.2.2
+  target: registry.suse.com/rancher/charts/mirrored-neuvector-enforcer:5.2.2
+  type: image
+- source: neuvector/enforcer:5.2.2-s1
+  target: registry.suse.com/rancher/charts/mirrored-neuvector-enforcer:5.2.2-s1
+  type: image
+- source: neuvector/enforcer:5.2.3
+  target: registry.suse.com/rancher/charts/mirrored-neuvector-enforcer:5.2.3
+  type: image
+- source: neuvector/enforcer:5.2.4
+  target: registry.suse.com/rancher/charts/mirrored-neuvector-enforcer:5.2.4
+  type: image
+- source: neuvector/enforcer:5.2.4-s1
+  target: registry.suse.com/rancher/charts/mirrored-neuvector-enforcer:5.2.4-s1
+  type: image
+- source: neuvector/enforcer:5.3.0
+  target: registry.suse.com/rancher/charts/mirrored-neuvector-enforcer:5.3.0
+  type: image
+- source: neuvector/enforcer:5.3.2
+  target: registry.suse.com/rancher/charts/mirrored-neuvector-enforcer:5.3.2
+  type: image
+- source: neuvector/enforcer:5.3.3
+  target: registry.suse.com/rancher/charts/mirrored-neuvector-enforcer:5.3.3
+  type: image
+- source: neuvector/enforcer:5.3.4
+  target: registry.suse.com/rancher/charts/mirrored-neuvector-enforcer:5.3.4
+  type: image
+- source: neuvector/enforcer:5.4.0
+  target: registry.suse.com/rancher/charts/mirrored-neuvector-enforcer:5.4.0
+  type: image
+- source: neuvector/enforcer:5.4.1
+  target: registry.suse.com/rancher/charts/mirrored-neuvector-enforcer:5.4.1
+  type: image
+- source: neuvector/enforcer:5.0.0
   target: stgregistry.suse.com/rancher/mirrored-neuvector-enforcer:5.0.0
   type: image
 - source: neuvector/enforcer:5.0.0-b1
@@ -9460,6 +15669,81 @@ sync:
   type: image
 - source: neuvector/enforcer:5.4.1
   target: stgregistry.suse.com/rancher/mirrored-neuvector-enforcer:5.4.1
+  type: image
+- source: neuvector/enforcer:5.0.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-enforcer:5.0.0
+  type: image
+- source: neuvector/enforcer:5.0.0-b1
+  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-enforcer:5.0.0-b1
+  type: image
+- source: neuvector/enforcer:5.0.0-b2
+  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-enforcer:5.0.0-b2
+  type: image
+- source: neuvector/enforcer:5.0.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-enforcer:5.0.1
+  type: image
+- source: neuvector/enforcer:5.0.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-enforcer:5.0.2
+  type: image
+- source: neuvector/enforcer:5.0.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-enforcer:5.0.3
+  type: image
+- source: neuvector/enforcer:5.0.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-enforcer:5.0.4
+  type: image
+- source: neuvector/enforcer:5.1.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-enforcer:5.1.0
+  type: image
+- source: neuvector/enforcer:5.1.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-enforcer:5.1.1
+  type: image
+- source: neuvector/enforcer:5.1.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-enforcer:5.1.2
+  type: image
+- source: neuvector/enforcer:5.1.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-enforcer:5.1.3
+  type: image
+- source: neuvector/enforcer:5.2.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-enforcer:5.2.0
+  type: image
+- source: neuvector/enforcer:5.2.0-s1
+  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-enforcer:5.2.0-s1
+  type: image
+- source: neuvector/enforcer:5.2.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-enforcer:5.2.1
+  type: image
+- source: neuvector/enforcer:5.2.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-enforcer:5.2.2
+  type: image
+- source: neuvector/enforcer:5.2.2-s1
+  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-enforcer:5.2.2-s1
+  type: image
+- source: neuvector/enforcer:5.2.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-enforcer:5.2.3
+  type: image
+- source: neuvector/enforcer:5.2.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-enforcer:5.2.4
+  type: image
+- source: neuvector/enforcer:5.2.4-s1
+  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-enforcer:5.2.4-s1
+  type: image
+- source: neuvector/enforcer:5.3.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-enforcer:5.3.0
+  type: image
+- source: neuvector/enforcer:5.3.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-enforcer:5.3.2
+  type: image
+- source: neuvector/enforcer:5.3.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-enforcer:5.3.3
+  type: image
+- source: neuvector/enforcer:5.3.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-enforcer:5.3.4
+  type: image
+- source: neuvector/enforcer:5.4.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-enforcer:5.4.0
+  type: image
+- source: neuvector/enforcer:5.4.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-enforcer:5.4.1
   type: image
 - source: neuvector/manager:5.0.0
   target: docker.io/rancher/mirrored-neuvector-manager:5.0.0
@@ -9612,6 +15896,81 @@ sync:
   target: registry.suse.com/rancher/mirrored-neuvector-manager:5.4.1
   type: image
 - source: neuvector/manager:5.0.0
+  target: registry.suse.com/rancher/charts/mirrored-neuvector-manager:5.0.0
+  type: image
+- source: neuvector/manager:5.0.0-b1
+  target: registry.suse.com/rancher/charts/mirrored-neuvector-manager:5.0.0-b1
+  type: image
+- source: neuvector/manager:5.0.0-b2
+  target: registry.suse.com/rancher/charts/mirrored-neuvector-manager:5.0.0-b2
+  type: image
+- source: neuvector/manager:5.0.1
+  target: registry.suse.com/rancher/charts/mirrored-neuvector-manager:5.0.1
+  type: image
+- source: neuvector/manager:5.0.2
+  target: registry.suse.com/rancher/charts/mirrored-neuvector-manager:5.0.2
+  type: image
+- source: neuvector/manager:5.0.3
+  target: registry.suse.com/rancher/charts/mirrored-neuvector-manager:5.0.3
+  type: image
+- source: neuvector/manager:5.0.4
+  target: registry.suse.com/rancher/charts/mirrored-neuvector-manager:5.0.4
+  type: image
+- source: neuvector/manager:5.1.0
+  target: registry.suse.com/rancher/charts/mirrored-neuvector-manager:5.1.0
+  type: image
+- source: neuvector/manager:5.1.1
+  target: registry.suse.com/rancher/charts/mirrored-neuvector-manager:5.1.1
+  type: image
+- source: neuvector/manager:5.1.2
+  target: registry.suse.com/rancher/charts/mirrored-neuvector-manager:5.1.2
+  type: image
+- source: neuvector/manager:5.1.3
+  target: registry.suse.com/rancher/charts/mirrored-neuvector-manager:5.1.3
+  type: image
+- source: neuvector/manager:5.2.0
+  target: registry.suse.com/rancher/charts/mirrored-neuvector-manager:5.2.0
+  type: image
+- source: neuvector/manager:5.2.0-s1
+  target: registry.suse.com/rancher/charts/mirrored-neuvector-manager:5.2.0-s1
+  type: image
+- source: neuvector/manager:5.2.1
+  target: registry.suse.com/rancher/charts/mirrored-neuvector-manager:5.2.1
+  type: image
+- source: neuvector/manager:5.2.2
+  target: registry.suse.com/rancher/charts/mirrored-neuvector-manager:5.2.2
+  type: image
+- source: neuvector/manager:5.2.2-s1
+  target: registry.suse.com/rancher/charts/mirrored-neuvector-manager:5.2.2-s1
+  type: image
+- source: neuvector/manager:5.2.3
+  target: registry.suse.com/rancher/charts/mirrored-neuvector-manager:5.2.3
+  type: image
+- source: neuvector/manager:5.2.4
+  target: registry.suse.com/rancher/charts/mirrored-neuvector-manager:5.2.4
+  type: image
+- source: neuvector/manager:5.2.4-s1
+  target: registry.suse.com/rancher/charts/mirrored-neuvector-manager:5.2.4-s1
+  type: image
+- source: neuvector/manager:5.3.0
+  target: registry.suse.com/rancher/charts/mirrored-neuvector-manager:5.3.0
+  type: image
+- source: neuvector/manager:5.3.2
+  target: registry.suse.com/rancher/charts/mirrored-neuvector-manager:5.3.2
+  type: image
+- source: neuvector/manager:5.3.3
+  target: registry.suse.com/rancher/charts/mirrored-neuvector-manager:5.3.3
+  type: image
+- source: neuvector/manager:5.3.4
+  target: registry.suse.com/rancher/charts/mirrored-neuvector-manager:5.3.4
+  type: image
+- source: neuvector/manager:5.4.0
+  target: registry.suse.com/rancher/charts/mirrored-neuvector-manager:5.4.0
+  type: image
+- source: neuvector/manager:5.4.1
+  target: registry.suse.com/rancher/charts/mirrored-neuvector-manager:5.4.1
+  type: image
+- source: neuvector/manager:5.0.0
   target: stgregistry.suse.com/rancher/mirrored-neuvector-manager:5.0.0
   type: image
 - source: neuvector/manager:5.0.0-b1
@@ -9686,6 +16045,81 @@ sync:
 - source: neuvector/manager:5.4.1
   target: stgregistry.suse.com/rancher/mirrored-neuvector-manager:5.4.1
   type: image
+- source: neuvector/manager:5.0.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-manager:5.0.0
+  type: image
+- source: neuvector/manager:5.0.0-b1
+  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-manager:5.0.0-b1
+  type: image
+- source: neuvector/manager:5.0.0-b2
+  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-manager:5.0.0-b2
+  type: image
+- source: neuvector/manager:5.0.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-manager:5.0.1
+  type: image
+- source: neuvector/manager:5.0.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-manager:5.0.2
+  type: image
+- source: neuvector/manager:5.0.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-manager:5.0.3
+  type: image
+- source: neuvector/manager:5.0.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-manager:5.0.4
+  type: image
+- source: neuvector/manager:5.1.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-manager:5.1.0
+  type: image
+- source: neuvector/manager:5.1.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-manager:5.1.1
+  type: image
+- source: neuvector/manager:5.1.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-manager:5.1.2
+  type: image
+- source: neuvector/manager:5.1.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-manager:5.1.3
+  type: image
+- source: neuvector/manager:5.2.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-manager:5.2.0
+  type: image
+- source: neuvector/manager:5.2.0-s1
+  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-manager:5.2.0-s1
+  type: image
+- source: neuvector/manager:5.2.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-manager:5.2.1
+  type: image
+- source: neuvector/manager:5.2.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-manager:5.2.2
+  type: image
+- source: neuvector/manager:5.2.2-s1
+  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-manager:5.2.2-s1
+  type: image
+- source: neuvector/manager:5.2.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-manager:5.2.3
+  type: image
+- source: neuvector/manager:5.2.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-manager:5.2.4
+  type: image
+- source: neuvector/manager:5.2.4-s1
+  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-manager:5.2.4-s1
+  type: image
+- source: neuvector/manager:5.3.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-manager:5.3.0
+  type: image
+- source: neuvector/manager:5.3.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-manager:5.3.2
+  type: image
+- source: neuvector/manager:5.3.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-manager:5.3.3
+  type: image
+- source: neuvector/manager:5.3.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-manager:5.3.4
+  type: image
+- source: neuvector/manager:5.4.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-manager:5.4.0
+  type: image
+- source: neuvector/manager:5.4.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-manager:5.4.1
+  type: image
 - source: neuvector/prometheus-exporter:1-1.0.0
   target: docker.io/rancher/mirrored-neuvector-prometheus-exporter:1-1.0.0
   type: image
@@ -9735,6 +16169,30 @@ sync:
   target: registry.suse.com/rancher/mirrored-neuvector-prometheus-exporter:5.3.2
   type: image
 - source: neuvector/prometheus-exporter:1-1.0.0
+  target: registry.suse.com/rancher/charts/mirrored-neuvector-prometheus-exporter:1-1.0.0
+  type: image
+- source: neuvector/prometheus-exporter:5.2.0
+  target: registry.suse.com/rancher/charts/mirrored-neuvector-prometheus-exporter:5.2.0
+  type: image
+- source: neuvector/prometheus-exporter:5.2.1
+  target: registry.suse.com/rancher/charts/mirrored-neuvector-prometheus-exporter:5.2.1
+  type: image
+- source: neuvector/prometheus-exporter:5.2.2
+  target: registry.suse.com/rancher/charts/mirrored-neuvector-prometheus-exporter:5.2.2
+  type: image
+- source: neuvector/prometheus-exporter:5.2.3
+  target: registry.suse.com/rancher/charts/mirrored-neuvector-prometheus-exporter:5.2.3
+  type: image
+- source: neuvector/prometheus-exporter:5.2.4
+  target: registry.suse.com/rancher/charts/mirrored-neuvector-prometheus-exporter:5.2.4
+  type: image
+- source: neuvector/prometheus-exporter:5.3.0
+  target: registry.suse.com/rancher/charts/mirrored-neuvector-prometheus-exporter:5.3.0
+  type: image
+- source: neuvector/prometheus-exporter:5.3.2
+  target: registry.suse.com/rancher/charts/mirrored-neuvector-prometheus-exporter:5.3.2
+  type: image
+- source: neuvector/prometheus-exporter:1-1.0.0
   target: stgregistry.suse.com/rancher/mirrored-neuvector-prometheus-exporter:1-1.0.0
   type: image
 - source: neuvector/prometheus-exporter:5.2.0
@@ -9757,6 +16215,30 @@ sync:
   type: image
 - source: neuvector/prometheus-exporter:5.3.2
   target: stgregistry.suse.com/rancher/mirrored-neuvector-prometheus-exporter:5.3.2
+  type: image
+- source: neuvector/prometheus-exporter:1-1.0.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-prometheus-exporter:1-1.0.0
+  type: image
+- source: neuvector/prometheus-exporter:5.2.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-prometheus-exporter:5.2.0
+  type: image
+- source: neuvector/prometheus-exporter:5.2.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-prometheus-exporter:5.2.1
+  type: image
+- source: neuvector/prometheus-exporter:5.2.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-prometheus-exporter:5.2.2
+  type: image
+- source: neuvector/prometheus-exporter:5.2.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-prometheus-exporter:5.2.3
+  type: image
+- source: neuvector/prometheus-exporter:5.2.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-prometheus-exporter:5.2.4
+  type: image
+- source: neuvector/prometheus-exporter:5.3.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-prometheus-exporter:5.3.0
+  type: image
+- source: neuvector/prometheus-exporter:5.3.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-prometheus-exporter:5.3.2
   type: image
 - source: neuvector/registry-adapter:0.1.0
   target: docker.io/rancher/mirrored-neuvector-registry-adapter:0.1.0
@@ -9795,6 +16277,24 @@ sync:
   target: registry.suse.com/rancher/mirrored-neuvector-registry-adapter:0.1.3
   type: image
 - source: neuvector/registry-adapter:0.1.0
+  target: registry.suse.com/rancher/charts/mirrored-neuvector-registry-adapter:0.1.0
+  type: image
+- source: neuvector/registry-adapter:0.1.1
+  target: registry.suse.com/rancher/charts/mirrored-neuvector-registry-adapter:0.1.1
+  type: image
+- source: neuvector/registry-adapter:0.1.1-s1
+  target: registry.suse.com/rancher/charts/mirrored-neuvector-registry-adapter:0.1.1-s1
+  type: image
+- source: neuvector/registry-adapter:0.1.1-s2
+  target: registry.suse.com/rancher/charts/mirrored-neuvector-registry-adapter:0.1.1-s2
+  type: image
+- source: neuvector/registry-adapter:0.1.2
+  target: registry.suse.com/rancher/charts/mirrored-neuvector-registry-adapter:0.1.2
+  type: image
+- source: neuvector/registry-adapter:0.1.3
+  target: registry.suse.com/rancher/charts/mirrored-neuvector-registry-adapter:0.1.3
+  type: image
+- source: neuvector/registry-adapter:0.1.0
   target: stgregistry.suse.com/rancher/mirrored-neuvector-registry-adapter:0.1.0
   type: image
 - source: neuvector/registry-adapter:0.1.1
@@ -9811,6 +16311,24 @@ sync:
   type: image
 - source: neuvector/registry-adapter:0.1.3
   target: stgregistry.suse.com/rancher/mirrored-neuvector-registry-adapter:0.1.3
+  type: image
+- source: neuvector/registry-adapter:0.1.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-registry-adapter:0.1.0
+  type: image
+- source: neuvector/registry-adapter:0.1.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-registry-adapter:0.1.1
+  type: image
+- source: neuvector/registry-adapter:0.1.1-s1
+  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-registry-adapter:0.1.1-s1
+  type: image
+- source: neuvector/registry-adapter:0.1.1-s2
+  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-registry-adapter:0.1.1-s2
+  type: image
+- source: neuvector/registry-adapter:0.1.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-registry-adapter:0.1.2
+  type: image
+- source: neuvector/registry-adapter:0.1.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-registry-adapter:0.1.3
   type: image
 - source: openpolicyagent/gatekeeper:v3.10.0
   target: docker.io/rancher/mirrored-openpolicyagent-gatekeeper:v3.10.0
@@ -9885,6 +16403,42 @@ sync:
   target: registry.suse.com/rancher/mirrored-openpolicyagent-gatekeeper:v3.9.0
   type: image
 - source: openpolicyagent/gatekeeper:v3.10.0
+  target: registry.suse.com/rancher/charts/mirrored-openpolicyagent-gatekeeper:v3.10.0
+  type: image
+- source: openpolicyagent/gatekeeper:v3.12.0
+  target: registry.suse.com/rancher/charts/mirrored-openpolicyagent-gatekeeper:v3.12.0
+  type: image
+- source: openpolicyagent/gatekeeper:v3.13.0
+  target: registry.suse.com/rancher/charts/mirrored-openpolicyagent-gatekeeper:v3.13.0
+  type: image
+- source: openpolicyagent/gatekeeper:v3.3.0
+  target: registry.suse.com/rancher/charts/mirrored-openpolicyagent-gatekeeper:v3.3.0
+  type: image
+- source: openpolicyagent/gatekeeper:v3.4.0
+  target: registry.suse.com/rancher/charts/mirrored-openpolicyagent-gatekeeper:v3.4.0
+  type: image
+- source: openpolicyagent/gatekeeper:v3.5.1
+  target: registry.suse.com/rancher/charts/mirrored-openpolicyagent-gatekeeper:v3.5.1
+  type: image
+- source: openpolicyagent/gatekeeper:v3.5.2
+  target: registry.suse.com/rancher/charts/mirrored-openpolicyagent-gatekeeper:v3.5.2
+  type: image
+- source: openpolicyagent/gatekeeper:v3.6.0
+  target: registry.suse.com/rancher/charts/mirrored-openpolicyagent-gatekeeper:v3.6.0
+  type: image
+- source: openpolicyagent/gatekeeper:v3.7.0
+  target: registry.suse.com/rancher/charts/mirrored-openpolicyagent-gatekeeper:v3.7.0
+  type: image
+- source: openpolicyagent/gatekeeper:v3.7.1
+  target: registry.suse.com/rancher/charts/mirrored-openpolicyagent-gatekeeper:v3.7.1
+  type: image
+- source: openpolicyagent/gatekeeper:v3.8.1
+  target: registry.suse.com/rancher/charts/mirrored-openpolicyagent-gatekeeper:v3.8.1
+  type: image
+- source: openpolicyagent/gatekeeper:v3.9.0
+  target: registry.suse.com/rancher/charts/mirrored-openpolicyagent-gatekeeper:v3.9.0
+  type: image
+- source: openpolicyagent/gatekeeper:v3.10.0
   target: stgregistry.suse.com/rancher/mirrored-openpolicyagent-gatekeeper:v3.10.0
   type: image
 - source: openpolicyagent/gatekeeper:v3.12.0
@@ -9920,6 +16474,42 @@ sync:
 - source: openpolicyagent/gatekeeper:v3.9.0
   target: stgregistry.suse.com/rancher/mirrored-openpolicyagent-gatekeeper:v3.9.0
   type: image
+- source: openpolicyagent/gatekeeper:v3.10.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-openpolicyagent-gatekeeper:v3.10.0
+  type: image
+- source: openpolicyagent/gatekeeper:v3.12.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-openpolicyagent-gatekeeper:v3.12.0
+  type: image
+- source: openpolicyagent/gatekeeper:v3.13.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-openpolicyagent-gatekeeper:v3.13.0
+  type: image
+- source: openpolicyagent/gatekeeper:v3.3.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-openpolicyagent-gatekeeper:v3.3.0
+  type: image
+- source: openpolicyagent/gatekeeper:v3.4.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-openpolicyagent-gatekeeper:v3.4.0
+  type: image
+- source: openpolicyagent/gatekeeper:v3.5.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-openpolicyagent-gatekeeper:v3.5.1
+  type: image
+- source: openpolicyagent/gatekeeper:v3.5.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-openpolicyagent-gatekeeper:v3.5.2
+  type: image
+- source: openpolicyagent/gatekeeper:v3.6.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-openpolicyagent-gatekeeper:v3.6.0
+  type: image
+- source: openpolicyagent/gatekeeper:v3.7.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-openpolicyagent-gatekeeper:v3.7.0
+  type: image
+- source: openpolicyagent/gatekeeper:v3.7.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-openpolicyagent-gatekeeper:v3.7.1
+  type: image
+- source: openpolicyagent/gatekeeper:v3.8.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-openpolicyagent-gatekeeper:v3.8.1
+  type: image
+- source: openpolicyagent/gatekeeper:v3.9.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-openpolicyagent-gatekeeper:v3.9.0
+  type: image
 - source: openpolicyagent/gatekeeper:v3.1.0
   target: docker.io/rancher/openpolicyagent-gatekeeper:v3.1.0
   type: image
@@ -9945,6 +16535,18 @@ sync:
   target: registry.suse.com/rancher/openpolicyagent-gatekeeper:v3.3.0
   type: image
 - source: openpolicyagent/gatekeeper:v3.1.0
+  target: registry.suse.com/rancher/charts/openpolicyagent-gatekeeper:v3.1.0
+  type: image
+- source: openpolicyagent/gatekeeper:v3.1.1
+  target: registry.suse.com/rancher/charts/openpolicyagent-gatekeeper:v3.1.1
+  type: image
+- source: openpolicyagent/gatekeeper:v3.2.1
+  target: registry.suse.com/rancher/charts/openpolicyagent-gatekeeper:v3.2.1
+  type: image
+- source: openpolicyagent/gatekeeper:v3.3.0
+  target: registry.suse.com/rancher/charts/openpolicyagent-gatekeeper:v3.3.0
+  type: image
+- source: openpolicyagent/gatekeeper:v3.1.0
   target: stgregistry.suse.com/rancher/openpolicyagent-gatekeeper:v3.1.0
   type: image
 - source: openpolicyagent/gatekeeper:v3.1.1
@@ -9955,6 +16557,18 @@ sync:
   type: image
 - source: openpolicyagent/gatekeeper:v3.3.0
   target: stgregistry.suse.com/rancher/openpolicyagent-gatekeeper:v3.3.0
+  type: image
+- source: openpolicyagent/gatekeeper:v3.1.0
+  target: stgregistry.suse.com/rancher/charts/openpolicyagent-gatekeeper:v3.1.0
+  type: image
+- source: openpolicyagent/gatekeeper:v3.1.1
+  target: stgregistry.suse.com/rancher/charts/openpolicyagent-gatekeeper:v3.1.1
+  type: image
+- source: openpolicyagent/gatekeeper:v3.2.1
+  target: stgregistry.suse.com/rancher/charts/openpolicyagent-gatekeeper:v3.2.1
+  type: image
+- source: openpolicyagent/gatekeeper:v3.3.0
+  target: stgregistry.suse.com/rancher/charts/openpolicyagent-gatekeeper:v3.3.0
   type: image
 - source: openpolicyagent/gatekeeper-crds:v3.10.0
   target: docker.io/rancher/mirrored-openpolicyagent-gatekeeper-crds:v3.10.0
@@ -10005,6 +16619,30 @@ sync:
   target: registry.suse.com/rancher/mirrored-openpolicyagent-gatekeeper-crds:v3.9.0
   type: image
 - source: openpolicyagent/gatekeeper-crds:v3.10.0
+  target: registry.suse.com/rancher/charts/mirrored-openpolicyagent-gatekeeper-crds:v3.10.0
+  type: image
+- source: openpolicyagent/gatekeeper-crds:v3.12.0
+  target: registry.suse.com/rancher/charts/mirrored-openpolicyagent-gatekeeper-crds:v3.12.0
+  type: image
+- source: openpolicyagent/gatekeeper-crds:v3.13.0
+  target: registry.suse.com/rancher/charts/mirrored-openpolicyagent-gatekeeper-crds:v3.13.0
+  type: image
+- source: openpolicyagent/gatekeeper-crds:v3.6.0
+  target: registry.suse.com/rancher/charts/mirrored-openpolicyagent-gatekeeper-crds:v3.6.0
+  type: image
+- source: openpolicyagent/gatekeeper-crds:v3.7.0
+  target: registry.suse.com/rancher/charts/mirrored-openpolicyagent-gatekeeper-crds:v3.7.0
+  type: image
+- source: openpolicyagent/gatekeeper-crds:v3.7.1
+  target: registry.suse.com/rancher/charts/mirrored-openpolicyagent-gatekeeper-crds:v3.7.1
+  type: image
+- source: openpolicyagent/gatekeeper-crds:v3.8.1
+  target: registry.suse.com/rancher/charts/mirrored-openpolicyagent-gatekeeper-crds:v3.8.1
+  type: image
+- source: openpolicyagent/gatekeeper-crds:v3.9.0
+  target: registry.suse.com/rancher/charts/mirrored-openpolicyagent-gatekeeper-crds:v3.9.0
+  type: image
+- source: openpolicyagent/gatekeeper-crds:v3.10.0
   target: stgregistry.suse.com/rancher/mirrored-openpolicyagent-gatekeeper-crds:v3.10.0
   type: image
 - source: openpolicyagent/gatekeeper-crds:v3.12.0
@@ -10028,6 +16666,30 @@ sync:
 - source: openpolicyagent/gatekeeper-crds:v3.9.0
   target: stgregistry.suse.com/rancher/mirrored-openpolicyagent-gatekeeper-crds:v3.9.0
   type: image
+- source: openpolicyagent/gatekeeper-crds:v3.10.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-openpolicyagent-gatekeeper-crds:v3.10.0
+  type: image
+- source: openpolicyagent/gatekeeper-crds:v3.12.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-openpolicyagent-gatekeeper-crds:v3.12.0
+  type: image
+- source: openpolicyagent/gatekeeper-crds:v3.13.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-openpolicyagent-gatekeeper-crds:v3.13.0
+  type: image
+- source: openpolicyagent/gatekeeper-crds:v3.6.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-openpolicyagent-gatekeeper-crds:v3.6.0
+  type: image
+- source: openpolicyagent/gatekeeper-crds:v3.7.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-openpolicyagent-gatekeeper-crds:v3.7.0
+  type: image
+- source: openpolicyagent/gatekeeper-crds:v3.7.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-openpolicyagent-gatekeeper-crds:v3.7.1
+  type: image
+- source: openpolicyagent/gatekeeper-crds:v3.8.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-openpolicyagent-gatekeeper-crds:v3.8.1
+  type: image
+- source: openpolicyagent/gatekeeper-crds:v3.9.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-openpolicyagent-gatekeeper-crds:v3.9.0
+  type: image
 - source: openzipkin/zipkin:2.14.2
   target: docker.io/rancher/mirrored-openzipkin-zipkin:2.14.2
   type: image
@@ -10035,7 +16697,13 @@ sync:
   target: registry.suse.com/rancher/mirrored-openzipkin-zipkin:2.14.2
   type: image
 - source: openzipkin/zipkin:2.14.2
+  target: registry.suse.com/rancher/charts/mirrored-openzipkin-zipkin:2.14.2
+  type: image
+- source: openzipkin/zipkin:2.14.2
   target: stgregistry.suse.com/rancher/mirrored-openzipkin-zipkin:2.14.2
+  type: image
+- source: openzipkin/zipkin:2.14.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-openzipkin-zipkin:2.14.2
   type: image
 - source: paketobuildpacks/builder:0.2.220-full
   target: docker.io/rancher/mirrored-paketobuildpacks-builder:0.2.220-full
@@ -10080,6 +16748,27 @@ sync:
   target: registry.suse.com/rancher/mirrored-paketobuildpacks-builder:0.2.95-full
   type: image
 - source: paketobuildpacks/builder:0.2.220-full
+  target: registry.suse.com/rancher/charts/mirrored-paketobuildpacks-builder:0.2.220-full
+  type: image
+- source: paketobuildpacks/builder:0.2.234-full
+  target: registry.suse.com/rancher/charts/mirrored-paketobuildpacks-builder:0.2.234-full
+  type: image
+- source: paketobuildpacks/builder:0.2.289-full
+  target: registry.suse.com/rancher/charts/mirrored-paketobuildpacks-builder:0.2.289-full
+  type: image
+- source: paketobuildpacks/builder:0.2.407-full
+  target: registry.suse.com/rancher/charts/mirrored-paketobuildpacks-builder:0.2.407-full
+  type: image
+- source: paketobuildpacks/builder:0.2.441-full
+  target: registry.suse.com/rancher/charts/mirrored-paketobuildpacks-builder:0.2.441-full
+  type: image
+- source: paketobuildpacks/builder:0.2.443-full
+  target: registry.suse.com/rancher/charts/mirrored-paketobuildpacks-builder:0.2.443-full
+  type: image
+- source: paketobuildpacks/builder:0.2.95-full
+  target: registry.suse.com/rancher/charts/mirrored-paketobuildpacks-builder:0.2.95-full
+  type: image
+- source: paketobuildpacks/builder:0.2.220-full
   target: stgregistry.suse.com/rancher/mirrored-paketobuildpacks-builder:0.2.220-full
   type: image
 - source: paketobuildpacks/builder:0.2.234-full
@@ -10100,6 +16789,27 @@ sync:
 - source: paketobuildpacks/builder:0.2.95-full
   target: stgregistry.suse.com/rancher/mirrored-paketobuildpacks-builder:0.2.95-full
   type: image
+- source: paketobuildpacks/builder:0.2.220-full
+  target: stgregistry.suse.com/rancher/charts/mirrored-paketobuildpacks-builder:0.2.220-full
+  type: image
+- source: paketobuildpacks/builder:0.2.234-full
+  target: stgregistry.suse.com/rancher/charts/mirrored-paketobuildpacks-builder:0.2.234-full
+  type: image
+- source: paketobuildpacks/builder:0.2.289-full
+  target: stgregistry.suse.com/rancher/charts/mirrored-paketobuildpacks-builder:0.2.289-full
+  type: image
+- source: paketobuildpacks/builder:0.2.407-full
+  target: stgregistry.suse.com/rancher/charts/mirrored-paketobuildpacks-builder:0.2.407-full
+  type: image
+- source: paketobuildpacks/builder:0.2.441-full
+  target: stgregistry.suse.com/rancher/charts/mirrored-paketobuildpacks-builder:0.2.441-full
+  type: image
+- source: paketobuildpacks/builder:0.2.443-full
+  target: stgregistry.suse.com/rancher/charts/mirrored-paketobuildpacks-builder:0.2.443-full
+  type: image
+- source: paketobuildpacks/builder:0.2.95-full
+  target: stgregistry.suse.com/rancher/charts/mirrored-paketobuildpacks-builder:0.2.95-full
+  type: image
 - source: plugins/docker:18.09
   target: docker.io/rancher/mirrored-plugins-docker:18.09
   type: image
@@ -10113,10 +16823,22 @@ sync:
   target: registry.suse.com/rancher/mirrored-plugins-docker:19.03.8
   type: image
 - source: plugins/docker:18.09
+  target: registry.suse.com/rancher/charts/mirrored-plugins-docker:18.09
+  type: image
+- source: plugins/docker:19.03.8
+  target: registry.suse.com/rancher/charts/mirrored-plugins-docker:19.03.8
+  type: image
+- source: plugins/docker:18.09
   target: stgregistry.suse.com/rancher/mirrored-plugins-docker:18.09
   type: image
 - source: plugins/docker:19.03.8
   target: stgregistry.suse.com/rancher/mirrored-plugins-docker:19.03.8
+  type: image
+- source: plugins/docker:18.09
+  target: stgregistry.suse.com/rancher/charts/mirrored-plugins-docker:18.09
+  type: image
+- source: plugins/docker:19.03.8
+  target: stgregistry.suse.com/rancher/charts/mirrored-plugins-docker:19.03.8
   type: image
 - source: prom/alertmanager:v0.21.0
   target: docker.io/rancher/mirrored-prom-alertmanager:v0.21.0
@@ -10125,7 +16847,13 @@ sync:
   target: registry.suse.com/rancher/mirrored-prom-alertmanager:v0.21.0
   type: image
 - source: prom/alertmanager:v0.21.0
+  target: registry.suse.com/rancher/charts/mirrored-prom-alertmanager:v0.21.0
+  type: image
+- source: prom/alertmanager:v0.21.0
   target: stgregistry.suse.com/rancher/mirrored-prom-alertmanager:v0.21.0
+  type: image
+- source: prom/alertmanager:v0.21.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-prom-alertmanager:v0.21.0
   type: image
 - source: prom/alertmanager:v0.21.0
   target: docker.io/rancher/prom-alertmanager:v0.21.0
@@ -10134,7 +16862,13 @@ sync:
   target: registry.suse.com/rancher/prom-alertmanager:v0.21.0
   type: image
 - source: prom/alertmanager:v0.21.0
+  target: registry.suse.com/rancher/charts/prom-alertmanager:v0.21.0
+  type: image
+- source: prom/alertmanager:v0.21.0
   target: stgregistry.suse.com/rancher/prom-alertmanager:v0.21.0
+  type: image
+- source: prom/alertmanager:v0.21.0
+  target: stgregistry.suse.com/rancher/charts/prom-alertmanager:v0.21.0
   type: image
 - source: prom/node-exporter:v1.0.1
   target: docker.io/rancher/mirrored-prom-node-exporter:v1.0.1
@@ -10143,7 +16877,13 @@ sync:
   target: registry.suse.com/rancher/mirrored-prom-node-exporter:v1.0.1
   type: image
 - source: prom/node-exporter:v1.0.1
+  target: registry.suse.com/rancher/charts/mirrored-prom-node-exporter:v1.0.1
+  type: image
+- source: prom/node-exporter:v1.0.1
   target: stgregistry.suse.com/rancher/mirrored-prom-node-exporter:v1.0.1
+  type: image
+- source: prom/node-exporter:v1.0.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-prom-node-exporter:v1.0.1
   type: image
 - source: prom/node-exporter:v1.0.1
   target: docker.io/rancher/prom-node-exporter:v1.0.1
@@ -10158,10 +16898,22 @@ sync:
   target: registry.suse.com/rancher/prom-node-exporter:v1.3.1
   type: image
 - source: prom/node-exporter:v1.0.1
+  target: registry.suse.com/rancher/charts/prom-node-exporter:v1.0.1
+  type: image
+- source: prom/node-exporter:v1.3.1
+  target: registry.suse.com/rancher/charts/prom-node-exporter:v1.3.1
+  type: image
+- source: prom/node-exporter:v1.0.1
   target: stgregistry.suse.com/rancher/prom-node-exporter:v1.0.1
   type: image
 - source: prom/node-exporter:v1.3.1
   target: stgregistry.suse.com/rancher/prom-node-exporter:v1.3.1
+  type: image
+- source: prom/node-exporter:v1.0.1
+  target: stgregistry.suse.com/rancher/charts/prom-node-exporter:v1.0.1
+  type: image
+- source: prom/node-exporter:v1.3.1
+  target: stgregistry.suse.com/rancher/charts/prom-node-exporter:v1.3.1
   type: image
 - source: prom/prometheus:v2.12.0
   target: docker.io/rancher/mirrored-prom-prometheus:v2.12.0
@@ -10170,7 +16922,13 @@ sync:
   target: registry.suse.com/rancher/mirrored-prom-prometheus:v2.12.0
   type: image
 - source: prom/prometheus:v2.12.0
+  target: registry.suse.com/rancher/charts/mirrored-prom-prometheus:v2.12.0
+  type: image
+- source: prom/prometheus:v2.12.0
   target: stgregistry.suse.com/rancher/mirrored-prom-prometheus:v2.12.0
+  type: image
+- source: prom/prometheus:v2.12.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-prom-prometheus:v2.12.0
   type: image
 - source: prom/prometheus:v2.18.2
   target: docker.io/rancher/prom-prometheus:v2.18.2
@@ -10179,7 +16937,13 @@ sync:
   target: registry.suse.com/rancher/prom-prometheus:v2.18.2
   type: image
 - source: prom/prometheus:v2.18.2
+  target: registry.suse.com/rancher/charts/prom-prometheus:v2.18.2
+  type: image
+- source: prom/prometheus:v2.18.2
   target: stgregistry.suse.com/rancher/prom-prometheus:v2.18.2
+  type: image
+- source: prom/prometheus:v2.18.2
+  target: stgregistry.suse.com/rancher/charts/prom-prometheus:v2.18.2
   type: image
 - source: pstauffer/curl:v1.0.3
   target: docker.io/rancher/mirrored-pstauffer-curl:v1.0.3
@@ -10188,7 +16952,13 @@ sync:
   target: registry.suse.com/rancher/mirrored-pstauffer-curl:v1.0.3
   type: image
 - source: pstauffer/curl:v1.0.3
+  target: registry.suse.com/rancher/charts/mirrored-pstauffer-curl:v1.0.3
+  type: image
+- source: pstauffer/curl:v1.0.3
   target: stgregistry.suse.com/rancher/mirrored-pstauffer-curl:v1.0.3
+  type: image
+- source: pstauffer/curl:v1.0.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-pstauffer-curl:v1.0.3
   type: image
 - source: quay.io/brancz/kube-rbac-proxy:v0.18.0
   target: docker.io/rancher/mirrored-brancz-kube-rbac-proxy:v0.18.0
@@ -10203,10 +16973,22 @@ sync:
   target: registry.suse.com/rancher/mirrored-brancz-kube-rbac-proxy:v0.18.2
   type: image
 - source: quay.io/brancz/kube-rbac-proxy:v0.18.0
+  target: registry.suse.com/rancher/charts/mirrored-brancz-kube-rbac-proxy:v0.18.0
+  type: image
+- source: quay.io/brancz/kube-rbac-proxy:v0.18.2
+  target: registry.suse.com/rancher/charts/mirrored-brancz-kube-rbac-proxy:v0.18.2
+  type: image
+- source: quay.io/brancz/kube-rbac-proxy:v0.18.0
   target: stgregistry.suse.com/rancher/mirrored-brancz-kube-rbac-proxy:v0.18.0
   type: image
 - source: quay.io/brancz/kube-rbac-proxy:v0.18.2
   target: stgregistry.suse.com/rancher/mirrored-brancz-kube-rbac-proxy:v0.18.2
+  type: image
+- source: quay.io/brancz/kube-rbac-proxy:v0.18.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-brancz-kube-rbac-proxy:v0.18.0
+  type: image
+- source: quay.io/brancz/kube-rbac-proxy:v0.18.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-brancz-kube-rbac-proxy:v0.18.2
   type: image
 - source: quay.io/calico/apiserver:v3.20.1
   target: docker.io/rancher/mirrored-calico-apiserver:v3.20.1
@@ -10419,6 +17201,111 @@ sync:
   target: registry.suse.com/rancher/mirrored-calico-apiserver:v3.30.3
   type: image
 - source: quay.io/calico/apiserver:v3.20.1
+  target: registry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.20.1
+  type: image
+- source: quay.io/calico/apiserver:v3.20.2
+  target: registry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.20.2
+  type: image
+- source: quay.io/calico/apiserver:v3.21.2
+  target: registry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.21.2
+  type: image
+- source: quay.io/calico/apiserver:v3.21.4
+  target: registry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.21.4
+  type: image
+- source: quay.io/calico/apiserver:v3.21.5
+  target: registry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.21.5
+  type: image
+- source: quay.io/calico/apiserver:v3.22.0
+  target: registry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.22.0
+  type: image
+- source: quay.io/calico/apiserver:v3.22.1
+  target: registry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.22.1
+  type: image
+- source: quay.io/calico/apiserver:v3.22.2
+  target: registry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.22.2
+  type: image
+- source: quay.io/calico/apiserver:v3.22.5
+  target: registry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.22.5
+  type: image
+- source: quay.io/calico/apiserver:v3.23.0
+  target: registry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.23.0
+  type: image
+- source: quay.io/calico/apiserver:v3.23.1
+  target: registry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.23.1
+  type: image
+- source: quay.io/calico/apiserver:v3.23.3
+  target: registry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.23.3
+  type: image
+- source: quay.io/calico/apiserver:v3.24.1
+  target: registry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.24.1
+  type: image
+- source: quay.io/calico/apiserver:v3.24.5
+  target: registry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.24.5
+  type: image
+- source: quay.io/calico/apiserver:v3.25.0
+  target: registry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.25.0
+  type: image
+- source: quay.io/calico/apiserver:v3.25.2
+  target: registry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.25.2
+  type: image
+- source: quay.io/calico/apiserver:v3.26.1
+  target: registry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.26.1
+  type: image
+- source: quay.io/calico/apiserver:v3.26.2
+  target: registry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.26.2
+  type: image
+- source: quay.io/calico/apiserver:v3.26.3
+  target: registry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.26.3
+  type: image
+- source: quay.io/calico/apiserver:v3.26.4
+  target: registry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.26.4
+  type: image
+- source: quay.io/calico/apiserver:v3.27.0
+  target: registry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.27.0
+  type: image
+- source: quay.io/calico/apiserver:v3.27.2
+  target: registry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.27.2
+  type: image
+- source: quay.io/calico/apiserver:v3.27.3
+  target: registry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.27.3
+  type: image
+- source: quay.io/calico/apiserver:v3.27.4
+  target: registry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.27.4
+  type: image
+- source: quay.io/calico/apiserver:v3.28.0
+  target: registry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.28.0
+  type: image
+- source: quay.io/calico/apiserver:v3.28.1
+  target: registry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.28.1
+  type: image
+- source: quay.io/calico/apiserver:v3.28.2
+  target: registry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.28.2
+  type: image
+- source: quay.io/calico/apiserver:v3.29.0
+  target: registry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.29.0
+  type: image
+- source: quay.io/calico/apiserver:v3.29.1
+  target: registry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.29.1
+  type: image
+- source: quay.io/calico/apiserver:v3.29.2
+  target: registry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.29.2
+  type: image
+- source: quay.io/calico/apiserver:v3.29.3
+  target: registry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.29.3
+  type: image
+- source: quay.io/calico/apiserver:v3.30.0
+  target: registry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.30.0
+  type: image
+- source: quay.io/calico/apiserver:v3.30.1
+  target: registry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.30.1
+  type: image
+- source: quay.io/calico/apiserver:v3.30.2
+  target: registry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.30.2
+  type: image
+- source: quay.io/calico/apiserver:v3.30.3
+  target: registry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.30.3
+  type: image
+- source: quay.io/calico/apiserver:v3.20.1
   target: stgregistry.suse.com/rancher/mirrored-calico-apiserver:v3.20.1
   type: image
 - source: quay.io/calico/apiserver:v3.20.2
@@ -10523,6 +17410,111 @@ sync:
 - source: quay.io/calico/apiserver:v3.30.3
   target: stgregistry.suse.com/rancher/mirrored-calico-apiserver:v3.30.3
   type: image
+- source: quay.io/calico/apiserver:v3.20.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.20.1
+  type: image
+- source: quay.io/calico/apiserver:v3.20.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.20.2
+  type: image
+- source: quay.io/calico/apiserver:v3.21.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.21.2
+  type: image
+- source: quay.io/calico/apiserver:v3.21.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.21.4
+  type: image
+- source: quay.io/calico/apiserver:v3.21.5
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.21.5
+  type: image
+- source: quay.io/calico/apiserver:v3.22.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.22.0
+  type: image
+- source: quay.io/calico/apiserver:v3.22.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.22.1
+  type: image
+- source: quay.io/calico/apiserver:v3.22.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.22.2
+  type: image
+- source: quay.io/calico/apiserver:v3.22.5
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.22.5
+  type: image
+- source: quay.io/calico/apiserver:v3.23.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.23.0
+  type: image
+- source: quay.io/calico/apiserver:v3.23.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.23.1
+  type: image
+- source: quay.io/calico/apiserver:v3.23.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.23.3
+  type: image
+- source: quay.io/calico/apiserver:v3.24.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.24.1
+  type: image
+- source: quay.io/calico/apiserver:v3.24.5
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.24.5
+  type: image
+- source: quay.io/calico/apiserver:v3.25.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.25.0
+  type: image
+- source: quay.io/calico/apiserver:v3.25.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.25.2
+  type: image
+- source: quay.io/calico/apiserver:v3.26.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.26.1
+  type: image
+- source: quay.io/calico/apiserver:v3.26.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.26.2
+  type: image
+- source: quay.io/calico/apiserver:v3.26.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.26.3
+  type: image
+- source: quay.io/calico/apiserver:v3.26.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.26.4
+  type: image
+- source: quay.io/calico/apiserver:v3.27.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.27.0
+  type: image
+- source: quay.io/calico/apiserver:v3.27.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.27.2
+  type: image
+- source: quay.io/calico/apiserver:v3.27.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.27.3
+  type: image
+- source: quay.io/calico/apiserver:v3.27.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.27.4
+  type: image
+- source: quay.io/calico/apiserver:v3.28.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.28.0
+  type: image
+- source: quay.io/calico/apiserver:v3.28.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.28.1
+  type: image
+- source: quay.io/calico/apiserver:v3.28.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.28.2
+  type: image
+- source: quay.io/calico/apiserver:v3.29.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.29.0
+  type: image
+- source: quay.io/calico/apiserver:v3.29.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.29.1
+  type: image
+- source: quay.io/calico/apiserver:v3.29.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.29.2
+  type: image
+- source: quay.io/calico/apiserver:v3.29.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.29.3
+  type: image
+- source: quay.io/calico/apiserver:v3.30.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.30.0
+  type: image
+- source: quay.io/calico/apiserver:v3.30.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.30.1
+  type: image
+- source: quay.io/calico/apiserver:v3.30.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.30.2
+  type: image
+- source: quay.io/calico/apiserver:v3.30.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.30.3
+  type: image
 - source: quay.io/calico/cni:v3.16.5
   target: docker.io/rancher/calico-cni:v3.16.5
   type: image
@@ -10554,6 +17546,21 @@ sync:
   target: registry.suse.com/rancher/calico-cni:v3.18.1
   type: image
 - source: quay.io/calico/cni:v3.16.5
+  target: registry.suse.com/rancher/charts/calico-cni:v3.16.5
+  type: image
+- source: quay.io/calico/cni:v3.16.6
+  target: registry.suse.com/rancher/charts/calico-cni:v3.16.6
+  type: image
+- source: quay.io/calico/cni:v3.17.1
+  target: registry.suse.com/rancher/charts/calico-cni:v3.17.1
+  type: image
+- source: quay.io/calico/cni:v3.17.2
+  target: registry.suse.com/rancher/charts/calico-cni:v3.17.2
+  type: image
+- source: quay.io/calico/cni:v3.18.1
+  target: registry.suse.com/rancher/charts/calico-cni:v3.18.1
+  type: image
+- source: quay.io/calico/cni:v3.16.5
   target: stgregistry.suse.com/rancher/calico-cni:v3.16.5
   type: image
 - source: quay.io/calico/cni:v3.16.6
@@ -10567,6 +17574,21 @@ sync:
   type: image
 - source: quay.io/calico/cni:v3.18.1
   target: stgregistry.suse.com/rancher/calico-cni:v3.18.1
+  type: image
+- source: quay.io/calico/cni:v3.16.5
+  target: stgregistry.suse.com/rancher/charts/calico-cni:v3.16.5
+  type: image
+- source: quay.io/calico/cni:v3.16.6
+  target: stgregistry.suse.com/rancher/charts/calico-cni:v3.16.6
+  type: image
+- source: quay.io/calico/cni:v3.17.1
+  target: stgregistry.suse.com/rancher/charts/calico-cni:v3.17.1
+  type: image
+- source: quay.io/calico/cni:v3.17.2
+  target: stgregistry.suse.com/rancher/charts/calico-cni:v3.17.2
+  type: image
+- source: quay.io/calico/cni:v3.18.1
+  target: stgregistry.suse.com/rancher/charts/calico-cni:v3.18.1
   type: image
 - source: quay.io/calico/cni:v3.13.4
   target: docker.io/rancher/mirrored-calico-cni:v3.13.4
@@ -10827,6 +17849,135 @@ sync:
   target: registry.suse.com/rancher/mirrored-calico-cni:v3.30.3
   type: image
 - source: quay.io/calico/cni:v3.13.4
+  target: registry.suse.com/rancher/charts/mirrored-calico-cni:v3.13.4
+  type: image
+- source: quay.io/calico/cni:v3.16.5
+  target: registry.suse.com/rancher/charts/mirrored-calico-cni:v3.16.5
+  type: image
+- source: quay.io/calico/cni:v3.17.2
+  target: registry.suse.com/rancher/charts/mirrored-calico-cni:v3.17.2
+  type: image
+- source: quay.io/calico/cni:v3.18.1
+  target: registry.suse.com/rancher/charts/mirrored-calico-cni:v3.18.1
+  type: image
+- source: quay.io/calico/cni:v3.19.0
+  target: registry.suse.com/rancher/charts/mirrored-calico-cni:v3.19.0
+  type: image
+- source: quay.io/calico/cni:v3.19.1
+  target: registry.suse.com/rancher/charts/mirrored-calico-cni:v3.19.1
+  type: image
+- source: quay.io/calico/cni:v3.19.2
+  target: registry.suse.com/rancher/charts/mirrored-calico-cni:v3.19.2
+  type: image
+- source: quay.io/calico/cni:v3.20.1
+  target: registry.suse.com/rancher/charts/mirrored-calico-cni:v3.20.1
+  type: image
+- source: quay.io/calico/cni:v3.20.2
+  target: registry.suse.com/rancher/charts/mirrored-calico-cni:v3.20.2
+  type: image
+- source: quay.io/calico/cni:v3.21.1
+  target: registry.suse.com/rancher/charts/mirrored-calico-cni:v3.21.1
+  type: image
+- source: quay.io/calico/cni:v3.21.2
+  target: registry.suse.com/rancher/charts/mirrored-calico-cni:v3.21.2
+  type: image
+- source: quay.io/calico/cni:v3.21.4
+  target: registry.suse.com/rancher/charts/mirrored-calico-cni:v3.21.4
+  type: image
+- source: quay.io/calico/cni:v3.21.5
+  target: registry.suse.com/rancher/charts/mirrored-calico-cni:v3.21.5
+  type: image
+- source: quay.io/calico/cni:v3.22.0
+  target: registry.suse.com/rancher/charts/mirrored-calico-cni:v3.22.0
+  type: image
+- source: quay.io/calico/cni:v3.22.1
+  target: registry.suse.com/rancher/charts/mirrored-calico-cni:v3.22.1
+  type: image
+- source: quay.io/calico/cni:v3.22.2
+  target: registry.suse.com/rancher/charts/mirrored-calico-cni:v3.22.2
+  type: image
+- source: quay.io/calico/cni:v3.22.5
+  target: registry.suse.com/rancher/charts/mirrored-calico-cni:v3.22.5
+  type: image
+- source: quay.io/calico/cni:v3.23.0
+  target: registry.suse.com/rancher/charts/mirrored-calico-cni:v3.23.0
+  type: image
+- source: quay.io/calico/cni:v3.23.1
+  target: registry.suse.com/rancher/charts/mirrored-calico-cni:v3.23.1
+  type: image
+- source: quay.io/calico/cni:v3.23.3
+  target: registry.suse.com/rancher/charts/mirrored-calico-cni:v3.23.3
+  type: image
+- source: quay.io/calico/cni:v3.24.1
+  target: registry.suse.com/rancher/charts/mirrored-calico-cni:v3.24.1
+  type: image
+- source: quay.io/calico/cni:v3.24.5
+  target: registry.suse.com/rancher/charts/mirrored-calico-cni:v3.24.5
+  type: image
+- source: quay.io/calico/cni:v3.25.0
+  target: registry.suse.com/rancher/charts/mirrored-calico-cni:v3.25.0
+  type: image
+- source: quay.io/calico/cni:v3.25.2
+  target: registry.suse.com/rancher/charts/mirrored-calico-cni:v3.25.2
+  type: image
+- source: quay.io/calico/cni:v3.26.1
+  target: registry.suse.com/rancher/charts/mirrored-calico-cni:v3.26.1
+  type: image
+- source: quay.io/calico/cni:v3.26.2
+  target: registry.suse.com/rancher/charts/mirrored-calico-cni:v3.26.2
+  type: image
+- source: quay.io/calico/cni:v3.26.3
+  target: registry.suse.com/rancher/charts/mirrored-calico-cni:v3.26.3
+  type: image
+- source: quay.io/calico/cni:v3.26.4
+  target: registry.suse.com/rancher/charts/mirrored-calico-cni:v3.26.4
+  type: image
+- source: quay.io/calico/cni:v3.27.0
+  target: registry.suse.com/rancher/charts/mirrored-calico-cni:v3.27.0
+  type: image
+- source: quay.io/calico/cni:v3.27.2
+  target: registry.suse.com/rancher/charts/mirrored-calico-cni:v3.27.2
+  type: image
+- source: quay.io/calico/cni:v3.27.3
+  target: registry.suse.com/rancher/charts/mirrored-calico-cni:v3.27.3
+  type: image
+- source: quay.io/calico/cni:v3.27.4
+  target: registry.suse.com/rancher/charts/mirrored-calico-cni:v3.27.4
+  type: image
+- source: quay.io/calico/cni:v3.28.0
+  target: registry.suse.com/rancher/charts/mirrored-calico-cni:v3.28.0
+  type: image
+- source: quay.io/calico/cni:v3.28.1
+  target: registry.suse.com/rancher/charts/mirrored-calico-cni:v3.28.1
+  type: image
+- source: quay.io/calico/cni:v3.28.2
+  target: registry.suse.com/rancher/charts/mirrored-calico-cni:v3.28.2
+  type: image
+- source: quay.io/calico/cni:v3.29.0
+  target: registry.suse.com/rancher/charts/mirrored-calico-cni:v3.29.0
+  type: image
+- source: quay.io/calico/cni:v3.29.1
+  target: registry.suse.com/rancher/charts/mirrored-calico-cni:v3.29.1
+  type: image
+- source: quay.io/calico/cni:v3.29.2
+  target: registry.suse.com/rancher/charts/mirrored-calico-cni:v3.29.2
+  type: image
+- source: quay.io/calico/cni:v3.29.3
+  target: registry.suse.com/rancher/charts/mirrored-calico-cni:v3.29.3
+  type: image
+- source: quay.io/calico/cni:v3.30.0
+  target: registry.suse.com/rancher/charts/mirrored-calico-cni:v3.30.0
+  type: image
+- source: quay.io/calico/cni:v3.30.1
+  target: registry.suse.com/rancher/charts/mirrored-calico-cni:v3.30.1
+  type: image
+- source: quay.io/calico/cni:v3.30.2
+  target: registry.suse.com/rancher/charts/mirrored-calico-cni:v3.30.2
+  type: image
+- source: quay.io/calico/cni:v3.30.3
+  target: registry.suse.com/rancher/charts/mirrored-calico-cni:v3.30.3
+  type: image
+- source: quay.io/calico/cni:v3.13.4
   target: stgregistry.suse.com/rancher/mirrored-calico-cni:v3.13.4
   type: image
 - source: quay.io/calico/cni:v3.16.5
@@ -10955,6 +18106,135 @@ sync:
 - source: quay.io/calico/cni:v3.30.3
   target: stgregistry.suse.com/rancher/mirrored-calico-cni:v3.30.3
   type: image
+- source: quay.io/calico/cni:v3.13.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-cni:v3.13.4
+  type: image
+- source: quay.io/calico/cni:v3.16.5
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-cni:v3.16.5
+  type: image
+- source: quay.io/calico/cni:v3.17.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-cni:v3.17.2
+  type: image
+- source: quay.io/calico/cni:v3.18.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-cni:v3.18.1
+  type: image
+- source: quay.io/calico/cni:v3.19.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-cni:v3.19.0
+  type: image
+- source: quay.io/calico/cni:v3.19.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-cni:v3.19.1
+  type: image
+- source: quay.io/calico/cni:v3.19.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-cni:v3.19.2
+  type: image
+- source: quay.io/calico/cni:v3.20.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-cni:v3.20.1
+  type: image
+- source: quay.io/calico/cni:v3.20.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-cni:v3.20.2
+  type: image
+- source: quay.io/calico/cni:v3.21.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-cni:v3.21.1
+  type: image
+- source: quay.io/calico/cni:v3.21.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-cni:v3.21.2
+  type: image
+- source: quay.io/calico/cni:v3.21.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-cni:v3.21.4
+  type: image
+- source: quay.io/calico/cni:v3.21.5
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-cni:v3.21.5
+  type: image
+- source: quay.io/calico/cni:v3.22.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-cni:v3.22.0
+  type: image
+- source: quay.io/calico/cni:v3.22.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-cni:v3.22.1
+  type: image
+- source: quay.io/calico/cni:v3.22.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-cni:v3.22.2
+  type: image
+- source: quay.io/calico/cni:v3.22.5
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-cni:v3.22.5
+  type: image
+- source: quay.io/calico/cni:v3.23.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-cni:v3.23.0
+  type: image
+- source: quay.io/calico/cni:v3.23.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-cni:v3.23.1
+  type: image
+- source: quay.io/calico/cni:v3.23.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-cni:v3.23.3
+  type: image
+- source: quay.io/calico/cni:v3.24.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-cni:v3.24.1
+  type: image
+- source: quay.io/calico/cni:v3.24.5
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-cni:v3.24.5
+  type: image
+- source: quay.io/calico/cni:v3.25.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-cni:v3.25.0
+  type: image
+- source: quay.io/calico/cni:v3.25.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-cni:v3.25.2
+  type: image
+- source: quay.io/calico/cni:v3.26.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-cni:v3.26.1
+  type: image
+- source: quay.io/calico/cni:v3.26.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-cni:v3.26.2
+  type: image
+- source: quay.io/calico/cni:v3.26.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-cni:v3.26.3
+  type: image
+- source: quay.io/calico/cni:v3.26.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-cni:v3.26.4
+  type: image
+- source: quay.io/calico/cni:v3.27.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-cni:v3.27.0
+  type: image
+- source: quay.io/calico/cni:v3.27.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-cni:v3.27.2
+  type: image
+- source: quay.io/calico/cni:v3.27.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-cni:v3.27.3
+  type: image
+- source: quay.io/calico/cni:v3.27.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-cni:v3.27.4
+  type: image
+- source: quay.io/calico/cni:v3.28.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-cni:v3.28.0
+  type: image
+- source: quay.io/calico/cni:v3.28.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-cni:v3.28.1
+  type: image
+- source: quay.io/calico/cni:v3.28.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-cni:v3.28.2
+  type: image
+- source: quay.io/calico/cni:v3.29.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-cni:v3.29.0
+  type: image
+- source: quay.io/calico/cni:v3.29.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-cni:v3.29.1
+  type: image
+- source: quay.io/calico/cni:v3.29.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-cni:v3.29.2
+  type: image
+- source: quay.io/calico/cni:v3.29.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-cni:v3.29.3
+  type: image
+- source: quay.io/calico/cni:v3.30.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-cni:v3.30.0
+  type: image
+- source: quay.io/calico/cni:v3.30.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-cni:v3.30.1
+  type: image
+- source: quay.io/calico/cni:v3.30.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-cni:v3.30.2
+  type: image
+- source: quay.io/calico/cni:v3.30.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-cni:v3.30.3
+  type: image
 - source: quay.io/calico/csi:v3.27.0
   target: docker.io/rancher/mirrored-calico-csi:v3.27.0
   type: image
@@ -11046,6 +18326,51 @@ sync:
   target: registry.suse.com/rancher/mirrored-calico-csi:v3.30.3
   type: image
 - source: quay.io/calico/csi:v3.27.0
+  target: registry.suse.com/rancher/charts/mirrored-calico-csi:v3.27.0
+  type: image
+- source: quay.io/calico/csi:v3.27.2
+  target: registry.suse.com/rancher/charts/mirrored-calico-csi:v3.27.2
+  type: image
+- source: quay.io/calico/csi:v3.27.3
+  target: registry.suse.com/rancher/charts/mirrored-calico-csi:v3.27.3
+  type: image
+- source: quay.io/calico/csi:v3.27.4
+  target: registry.suse.com/rancher/charts/mirrored-calico-csi:v3.27.4
+  type: image
+- source: quay.io/calico/csi:v3.28.0
+  target: registry.suse.com/rancher/charts/mirrored-calico-csi:v3.28.0
+  type: image
+- source: quay.io/calico/csi:v3.28.1
+  target: registry.suse.com/rancher/charts/mirrored-calico-csi:v3.28.1
+  type: image
+- source: quay.io/calico/csi:v3.28.2
+  target: registry.suse.com/rancher/charts/mirrored-calico-csi:v3.28.2
+  type: image
+- source: quay.io/calico/csi:v3.29.0
+  target: registry.suse.com/rancher/charts/mirrored-calico-csi:v3.29.0
+  type: image
+- source: quay.io/calico/csi:v3.29.1
+  target: registry.suse.com/rancher/charts/mirrored-calico-csi:v3.29.1
+  type: image
+- source: quay.io/calico/csi:v3.29.2
+  target: registry.suse.com/rancher/charts/mirrored-calico-csi:v3.29.2
+  type: image
+- source: quay.io/calico/csi:v3.29.3
+  target: registry.suse.com/rancher/charts/mirrored-calico-csi:v3.29.3
+  type: image
+- source: quay.io/calico/csi:v3.30.0
+  target: registry.suse.com/rancher/charts/mirrored-calico-csi:v3.30.0
+  type: image
+- source: quay.io/calico/csi:v3.30.1
+  target: registry.suse.com/rancher/charts/mirrored-calico-csi:v3.30.1
+  type: image
+- source: quay.io/calico/csi:v3.30.2
+  target: registry.suse.com/rancher/charts/mirrored-calico-csi:v3.30.2
+  type: image
+- source: quay.io/calico/csi:v3.30.3
+  target: registry.suse.com/rancher/charts/mirrored-calico-csi:v3.30.3
+  type: image
+- source: quay.io/calico/csi:v3.27.0
   target: stgregistry.suse.com/rancher/mirrored-calico-csi:v3.27.0
   type: image
 - source: quay.io/calico/csi:v3.27.2
@@ -11090,6 +18415,51 @@ sync:
 - source: quay.io/calico/csi:v3.30.3
   target: stgregistry.suse.com/rancher/mirrored-calico-csi:v3.30.3
   type: image
+- source: quay.io/calico/csi:v3.27.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-csi:v3.27.0
+  type: image
+- source: quay.io/calico/csi:v3.27.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-csi:v3.27.2
+  type: image
+- source: quay.io/calico/csi:v3.27.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-csi:v3.27.3
+  type: image
+- source: quay.io/calico/csi:v3.27.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-csi:v3.27.4
+  type: image
+- source: quay.io/calico/csi:v3.28.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-csi:v3.28.0
+  type: image
+- source: quay.io/calico/csi:v3.28.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-csi:v3.28.1
+  type: image
+- source: quay.io/calico/csi:v3.28.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-csi:v3.28.2
+  type: image
+- source: quay.io/calico/csi:v3.29.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-csi:v3.29.0
+  type: image
+- source: quay.io/calico/csi:v3.29.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-csi:v3.29.1
+  type: image
+- source: quay.io/calico/csi:v3.29.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-csi:v3.29.2
+  type: image
+- source: quay.io/calico/csi:v3.29.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-csi:v3.29.3
+  type: image
+- source: quay.io/calico/csi:v3.30.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-csi:v3.30.0
+  type: image
+- source: quay.io/calico/csi:v3.30.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-csi:v3.30.1
+  type: image
+- source: quay.io/calico/csi:v3.30.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-csi:v3.30.2
+  type: image
+- source: quay.io/calico/csi:v3.30.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-csi:v3.30.3
+  type: image
 - source: quay.io/calico/ctl:v3.16.5
   target: docker.io/rancher/calico-ctl:v3.16.5
   type: image
@@ -11133,6 +18503,27 @@ sync:
   target: registry.suse.com/rancher/calico-ctl:v3.19.2
   type: image
 - source: quay.io/calico/ctl:v3.16.5
+  target: registry.suse.com/rancher/charts/calico-ctl:v3.16.5
+  type: image
+- source: quay.io/calico/ctl:v3.16.6
+  target: registry.suse.com/rancher/charts/calico-ctl:v3.16.6
+  type: image
+- source: quay.io/calico/ctl:v3.17.1
+  target: registry.suse.com/rancher/charts/calico-ctl:v3.17.1
+  type: image
+- source: quay.io/calico/ctl:v3.17.2
+  target: registry.suse.com/rancher/charts/calico-ctl:v3.17.2
+  type: image
+- source: quay.io/calico/ctl:v3.18.1
+  target: registry.suse.com/rancher/charts/calico-ctl:v3.18.1
+  type: image
+- source: quay.io/calico/ctl:v3.19.1
+  target: registry.suse.com/rancher/charts/calico-ctl:v3.19.1
+  type: image
+- source: quay.io/calico/ctl:v3.19.2
+  target: registry.suse.com/rancher/charts/calico-ctl:v3.19.2
+  type: image
+- source: quay.io/calico/ctl:v3.16.5
   target: stgregistry.suse.com/rancher/calico-ctl:v3.16.5
   type: image
 - source: quay.io/calico/ctl:v3.16.6
@@ -11152,6 +18543,27 @@ sync:
   type: image
 - source: quay.io/calico/ctl:v3.19.2
   target: stgregistry.suse.com/rancher/calico-ctl:v3.19.2
+  type: image
+- source: quay.io/calico/ctl:v3.16.5
+  target: stgregistry.suse.com/rancher/charts/calico-ctl:v3.16.5
+  type: image
+- source: quay.io/calico/ctl:v3.16.6
+  target: stgregistry.suse.com/rancher/charts/calico-ctl:v3.16.6
+  type: image
+- source: quay.io/calico/ctl:v3.17.1
+  target: stgregistry.suse.com/rancher/charts/calico-ctl:v3.17.1
+  type: image
+- source: quay.io/calico/ctl:v3.17.2
+  target: stgregistry.suse.com/rancher/charts/calico-ctl:v3.17.2
+  type: image
+- source: quay.io/calico/ctl:v3.18.1
+  target: stgregistry.suse.com/rancher/charts/calico-ctl:v3.18.1
+  type: image
+- source: quay.io/calico/ctl:v3.19.1
+  target: stgregistry.suse.com/rancher/charts/calico-ctl:v3.19.1
+  type: image
+- source: quay.io/calico/ctl:v3.19.2
+  target: stgregistry.suse.com/rancher/charts/calico-ctl:v3.19.2
   type: image
 - source: quay.io/calico/ctl:v3.13.4
   target: docker.io/rancher/mirrored-calico-ctl:v3.13.4
@@ -11412,6 +18824,135 @@ sync:
   target: registry.suse.com/rancher/mirrored-calico-ctl:v3.30.3
   type: image
 - source: quay.io/calico/ctl:v3.13.4
+  target: registry.suse.com/rancher/charts/mirrored-calico-ctl:v3.13.4
+  type: image
+- source: quay.io/calico/ctl:v3.16.5
+  target: registry.suse.com/rancher/charts/mirrored-calico-ctl:v3.16.5
+  type: image
+- source: quay.io/calico/ctl:v3.17.2
+  target: registry.suse.com/rancher/charts/mirrored-calico-ctl:v3.17.2
+  type: image
+- source: quay.io/calico/ctl:v3.18.1
+  target: registry.suse.com/rancher/charts/mirrored-calico-ctl:v3.18.1
+  type: image
+- source: quay.io/calico/ctl:v3.19.0
+  target: registry.suse.com/rancher/charts/mirrored-calico-ctl:v3.19.0
+  type: image
+- source: quay.io/calico/ctl:v3.19.1
+  target: registry.suse.com/rancher/charts/mirrored-calico-ctl:v3.19.1
+  type: image
+- source: quay.io/calico/ctl:v3.19.2
+  target: registry.suse.com/rancher/charts/mirrored-calico-ctl:v3.19.2
+  type: image
+- source: quay.io/calico/ctl:v3.20.1
+  target: registry.suse.com/rancher/charts/mirrored-calico-ctl:v3.20.1
+  type: image
+- source: quay.io/calico/ctl:v3.20.2
+  target: registry.suse.com/rancher/charts/mirrored-calico-ctl:v3.20.2
+  type: image
+- source: quay.io/calico/ctl:v3.21.1
+  target: registry.suse.com/rancher/charts/mirrored-calico-ctl:v3.21.1
+  type: image
+- source: quay.io/calico/ctl:v3.21.2
+  target: registry.suse.com/rancher/charts/mirrored-calico-ctl:v3.21.2
+  type: image
+- source: quay.io/calico/ctl:v3.21.4
+  target: registry.suse.com/rancher/charts/mirrored-calico-ctl:v3.21.4
+  type: image
+- source: quay.io/calico/ctl:v3.21.5
+  target: registry.suse.com/rancher/charts/mirrored-calico-ctl:v3.21.5
+  type: image
+- source: quay.io/calico/ctl:v3.22.0
+  target: registry.suse.com/rancher/charts/mirrored-calico-ctl:v3.22.0
+  type: image
+- source: quay.io/calico/ctl:v3.22.1
+  target: registry.suse.com/rancher/charts/mirrored-calico-ctl:v3.22.1
+  type: image
+- source: quay.io/calico/ctl:v3.22.2
+  target: registry.suse.com/rancher/charts/mirrored-calico-ctl:v3.22.2
+  type: image
+- source: quay.io/calico/ctl:v3.22.5
+  target: registry.suse.com/rancher/charts/mirrored-calico-ctl:v3.22.5
+  type: image
+- source: quay.io/calico/ctl:v3.23.0
+  target: registry.suse.com/rancher/charts/mirrored-calico-ctl:v3.23.0
+  type: image
+- source: quay.io/calico/ctl:v3.23.1
+  target: registry.suse.com/rancher/charts/mirrored-calico-ctl:v3.23.1
+  type: image
+- source: quay.io/calico/ctl:v3.23.3
+  target: registry.suse.com/rancher/charts/mirrored-calico-ctl:v3.23.3
+  type: image
+- source: quay.io/calico/ctl:v3.24.1
+  target: registry.suse.com/rancher/charts/mirrored-calico-ctl:v3.24.1
+  type: image
+- source: quay.io/calico/ctl:v3.24.5
+  target: registry.suse.com/rancher/charts/mirrored-calico-ctl:v3.24.5
+  type: image
+- source: quay.io/calico/ctl:v3.25.0
+  target: registry.suse.com/rancher/charts/mirrored-calico-ctl:v3.25.0
+  type: image
+- source: quay.io/calico/ctl:v3.25.2
+  target: registry.suse.com/rancher/charts/mirrored-calico-ctl:v3.25.2
+  type: image
+- source: quay.io/calico/ctl:v3.26.1
+  target: registry.suse.com/rancher/charts/mirrored-calico-ctl:v3.26.1
+  type: image
+- source: quay.io/calico/ctl:v3.26.2
+  target: registry.suse.com/rancher/charts/mirrored-calico-ctl:v3.26.2
+  type: image
+- source: quay.io/calico/ctl:v3.26.3
+  target: registry.suse.com/rancher/charts/mirrored-calico-ctl:v3.26.3
+  type: image
+- source: quay.io/calico/ctl:v3.26.4
+  target: registry.suse.com/rancher/charts/mirrored-calico-ctl:v3.26.4
+  type: image
+- source: quay.io/calico/ctl:v3.27.0
+  target: registry.suse.com/rancher/charts/mirrored-calico-ctl:v3.27.0
+  type: image
+- source: quay.io/calico/ctl:v3.27.2
+  target: registry.suse.com/rancher/charts/mirrored-calico-ctl:v3.27.2
+  type: image
+- source: quay.io/calico/ctl:v3.27.3
+  target: registry.suse.com/rancher/charts/mirrored-calico-ctl:v3.27.3
+  type: image
+- source: quay.io/calico/ctl:v3.27.4
+  target: registry.suse.com/rancher/charts/mirrored-calico-ctl:v3.27.4
+  type: image
+- source: quay.io/calico/ctl:v3.28.0
+  target: registry.suse.com/rancher/charts/mirrored-calico-ctl:v3.28.0
+  type: image
+- source: quay.io/calico/ctl:v3.28.1
+  target: registry.suse.com/rancher/charts/mirrored-calico-ctl:v3.28.1
+  type: image
+- source: quay.io/calico/ctl:v3.28.2
+  target: registry.suse.com/rancher/charts/mirrored-calico-ctl:v3.28.2
+  type: image
+- source: quay.io/calico/ctl:v3.29.0
+  target: registry.suse.com/rancher/charts/mirrored-calico-ctl:v3.29.0
+  type: image
+- source: quay.io/calico/ctl:v3.29.1
+  target: registry.suse.com/rancher/charts/mirrored-calico-ctl:v3.29.1
+  type: image
+- source: quay.io/calico/ctl:v3.29.2
+  target: registry.suse.com/rancher/charts/mirrored-calico-ctl:v3.29.2
+  type: image
+- source: quay.io/calico/ctl:v3.29.3
+  target: registry.suse.com/rancher/charts/mirrored-calico-ctl:v3.29.3
+  type: image
+- source: quay.io/calico/ctl:v3.30.0
+  target: registry.suse.com/rancher/charts/mirrored-calico-ctl:v3.30.0
+  type: image
+- source: quay.io/calico/ctl:v3.30.1
+  target: registry.suse.com/rancher/charts/mirrored-calico-ctl:v3.30.1
+  type: image
+- source: quay.io/calico/ctl:v3.30.2
+  target: registry.suse.com/rancher/charts/mirrored-calico-ctl:v3.30.2
+  type: image
+- source: quay.io/calico/ctl:v3.30.3
+  target: registry.suse.com/rancher/charts/mirrored-calico-ctl:v3.30.3
+  type: image
+- source: quay.io/calico/ctl:v3.13.4
   target: stgregistry.suse.com/rancher/mirrored-calico-ctl:v3.13.4
   type: image
 - source: quay.io/calico/ctl:v3.16.5
@@ -11540,6 +19081,135 @@ sync:
 - source: quay.io/calico/ctl:v3.30.3
   target: stgregistry.suse.com/rancher/mirrored-calico-ctl:v3.30.3
   type: image
+- source: quay.io/calico/ctl:v3.13.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-ctl:v3.13.4
+  type: image
+- source: quay.io/calico/ctl:v3.16.5
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-ctl:v3.16.5
+  type: image
+- source: quay.io/calico/ctl:v3.17.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-ctl:v3.17.2
+  type: image
+- source: quay.io/calico/ctl:v3.18.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-ctl:v3.18.1
+  type: image
+- source: quay.io/calico/ctl:v3.19.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-ctl:v3.19.0
+  type: image
+- source: quay.io/calico/ctl:v3.19.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-ctl:v3.19.1
+  type: image
+- source: quay.io/calico/ctl:v3.19.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-ctl:v3.19.2
+  type: image
+- source: quay.io/calico/ctl:v3.20.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-ctl:v3.20.1
+  type: image
+- source: quay.io/calico/ctl:v3.20.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-ctl:v3.20.2
+  type: image
+- source: quay.io/calico/ctl:v3.21.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-ctl:v3.21.1
+  type: image
+- source: quay.io/calico/ctl:v3.21.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-ctl:v3.21.2
+  type: image
+- source: quay.io/calico/ctl:v3.21.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-ctl:v3.21.4
+  type: image
+- source: quay.io/calico/ctl:v3.21.5
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-ctl:v3.21.5
+  type: image
+- source: quay.io/calico/ctl:v3.22.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-ctl:v3.22.0
+  type: image
+- source: quay.io/calico/ctl:v3.22.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-ctl:v3.22.1
+  type: image
+- source: quay.io/calico/ctl:v3.22.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-ctl:v3.22.2
+  type: image
+- source: quay.io/calico/ctl:v3.22.5
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-ctl:v3.22.5
+  type: image
+- source: quay.io/calico/ctl:v3.23.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-ctl:v3.23.0
+  type: image
+- source: quay.io/calico/ctl:v3.23.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-ctl:v3.23.1
+  type: image
+- source: quay.io/calico/ctl:v3.23.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-ctl:v3.23.3
+  type: image
+- source: quay.io/calico/ctl:v3.24.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-ctl:v3.24.1
+  type: image
+- source: quay.io/calico/ctl:v3.24.5
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-ctl:v3.24.5
+  type: image
+- source: quay.io/calico/ctl:v3.25.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-ctl:v3.25.0
+  type: image
+- source: quay.io/calico/ctl:v3.25.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-ctl:v3.25.2
+  type: image
+- source: quay.io/calico/ctl:v3.26.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-ctl:v3.26.1
+  type: image
+- source: quay.io/calico/ctl:v3.26.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-ctl:v3.26.2
+  type: image
+- source: quay.io/calico/ctl:v3.26.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-ctl:v3.26.3
+  type: image
+- source: quay.io/calico/ctl:v3.26.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-ctl:v3.26.4
+  type: image
+- source: quay.io/calico/ctl:v3.27.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-ctl:v3.27.0
+  type: image
+- source: quay.io/calico/ctl:v3.27.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-ctl:v3.27.2
+  type: image
+- source: quay.io/calico/ctl:v3.27.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-ctl:v3.27.3
+  type: image
+- source: quay.io/calico/ctl:v3.27.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-ctl:v3.27.4
+  type: image
+- source: quay.io/calico/ctl:v3.28.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-ctl:v3.28.0
+  type: image
+- source: quay.io/calico/ctl:v3.28.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-ctl:v3.28.1
+  type: image
+- source: quay.io/calico/ctl:v3.28.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-ctl:v3.28.2
+  type: image
+- source: quay.io/calico/ctl:v3.29.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-ctl:v3.29.0
+  type: image
+- source: quay.io/calico/ctl:v3.29.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-ctl:v3.29.1
+  type: image
+- source: quay.io/calico/ctl:v3.29.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-ctl:v3.29.2
+  type: image
+- source: quay.io/calico/ctl:v3.29.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-ctl:v3.29.3
+  type: image
+- source: quay.io/calico/ctl:v3.30.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-ctl:v3.30.0
+  type: image
+- source: quay.io/calico/ctl:v3.30.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-ctl:v3.30.1
+  type: image
+- source: quay.io/calico/ctl:v3.30.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-ctl:v3.30.2
+  type: image
+- source: quay.io/calico/ctl:v3.30.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-ctl:v3.30.3
+  type: image
 - source: quay.io/calico/envoy-gateway:v3.30.0
   target: docker.io/rancher/mirrored-calico-envoy-gateway:v3.30.0
   type: image
@@ -11565,6 +19235,18 @@ sync:
   target: registry.suse.com/rancher/mirrored-calico-envoy-gateway:v3.30.3
   type: image
 - source: quay.io/calico/envoy-gateway:v3.30.0
+  target: registry.suse.com/rancher/charts/mirrored-calico-envoy-gateway:v3.30.0
+  type: image
+- source: quay.io/calico/envoy-gateway:v3.30.1
+  target: registry.suse.com/rancher/charts/mirrored-calico-envoy-gateway:v3.30.1
+  type: image
+- source: quay.io/calico/envoy-gateway:v3.30.2
+  target: registry.suse.com/rancher/charts/mirrored-calico-envoy-gateway:v3.30.2
+  type: image
+- source: quay.io/calico/envoy-gateway:v3.30.3
+  target: registry.suse.com/rancher/charts/mirrored-calico-envoy-gateway:v3.30.3
+  type: image
+- source: quay.io/calico/envoy-gateway:v3.30.0
   target: stgregistry.suse.com/rancher/mirrored-calico-envoy-gateway:v3.30.0
   type: image
 - source: quay.io/calico/envoy-gateway:v3.30.1
@@ -11575,6 +19257,18 @@ sync:
   type: image
 - source: quay.io/calico/envoy-gateway:v3.30.3
   target: stgregistry.suse.com/rancher/mirrored-calico-envoy-gateway:v3.30.3
+  type: image
+- source: quay.io/calico/envoy-gateway:v3.30.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-envoy-gateway:v3.30.0
+  type: image
+- source: quay.io/calico/envoy-gateway:v3.30.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-envoy-gateway:v3.30.1
+  type: image
+- source: quay.io/calico/envoy-gateway:v3.30.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-envoy-gateway:v3.30.2
+  type: image
+- source: quay.io/calico/envoy-gateway:v3.30.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-envoy-gateway:v3.30.3
   type: image
 - source: quay.io/calico/envoy-proxy:v3.30.0
   target: docker.io/rancher/mirrored-calico-envoy-proxy:v3.30.0
@@ -11601,6 +19295,18 @@ sync:
   target: registry.suse.com/rancher/mirrored-calico-envoy-proxy:v3.30.3
   type: image
 - source: quay.io/calico/envoy-proxy:v3.30.0
+  target: registry.suse.com/rancher/charts/mirrored-calico-envoy-proxy:v3.30.0
+  type: image
+- source: quay.io/calico/envoy-proxy:v3.30.1
+  target: registry.suse.com/rancher/charts/mirrored-calico-envoy-proxy:v3.30.1
+  type: image
+- source: quay.io/calico/envoy-proxy:v3.30.2
+  target: registry.suse.com/rancher/charts/mirrored-calico-envoy-proxy:v3.30.2
+  type: image
+- source: quay.io/calico/envoy-proxy:v3.30.3
+  target: registry.suse.com/rancher/charts/mirrored-calico-envoy-proxy:v3.30.3
+  type: image
+- source: quay.io/calico/envoy-proxy:v3.30.0
   target: stgregistry.suse.com/rancher/mirrored-calico-envoy-proxy:v3.30.0
   type: image
 - source: quay.io/calico/envoy-proxy:v3.30.1
@@ -11611,6 +19317,18 @@ sync:
   type: image
 - source: quay.io/calico/envoy-proxy:v3.30.3
   target: stgregistry.suse.com/rancher/mirrored-calico-envoy-proxy:v3.30.3
+  type: image
+- source: quay.io/calico/envoy-proxy:v3.30.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-envoy-proxy:v3.30.0
+  type: image
+- source: quay.io/calico/envoy-proxy:v3.30.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-envoy-proxy:v3.30.1
+  type: image
+- source: quay.io/calico/envoy-proxy:v3.30.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-envoy-proxy:v3.30.2
+  type: image
+- source: quay.io/calico/envoy-proxy:v3.30.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-envoy-proxy:v3.30.3
   type: image
 - source: quay.io/calico/envoy-ratelimit:v3.30.0
   target: docker.io/rancher/mirrored-calico-envoy-ratelimit:v3.30.0
@@ -11637,6 +19355,18 @@ sync:
   target: registry.suse.com/rancher/mirrored-calico-envoy-ratelimit:v3.30.3
   type: image
 - source: quay.io/calico/envoy-ratelimit:v3.30.0
+  target: registry.suse.com/rancher/charts/mirrored-calico-envoy-ratelimit:v3.30.0
+  type: image
+- source: quay.io/calico/envoy-ratelimit:v3.30.1
+  target: registry.suse.com/rancher/charts/mirrored-calico-envoy-ratelimit:v3.30.1
+  type: image
+- source: quay.io/calico/envoy-ratelimit:v3.30.2
+  target: registry.suse.com/rancher/charts/mirrored-calico-envoy-ratelimit:v3.30.2
+  type: image
+- source: quay.io/calico/envoy-ratelimit:v3.30.3
+  target: registry.suse.com/rancher/charts/mirrored-calico-envoy-ratelimit:v3.30.3
+  type: image
+- source: quay.io/calico/envoy-ratelimit:v3.30.0
   target: stgregistry.suse.com/rancher/mirrored-calico-envoy-ratelimit:v3.30.0
   type: image
 - source: quay.io/calico/envoy-ratelimit:v3.30.1
@@ -11647,6 +19377,18 @@ sync:
   type: image
 - source: quay.io/calico/envoy-ratelimit:v3.30.3
   target: stgregistry.suse.com/rancher/mirrored-calico-envoy-ratelimit:v3.30.3
+  type: image
+- source: quay.io/calico/envoy-ratelimit:v3.30.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-envoy-ratelimit:v3.30.0
+  type: image
+- source: quay.io/calico/envoy-ratelimit:v3.30.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-envoy-ratelimit:v3.30.1
+  type: image
+- source: quay.io/calico/envoy-ratelimit:v3.30.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-envoy-ratelimit:v3.30.2
+  type: image
+- source: quay.io/calico/envoy-ratelimit:v3.30.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-envoy-ratelimit:v3.30.3
   type: image
 - source: quay.io/calico/goldmane:v3.30.0
   target: docker.io/rancher/mirrored-calico-goldmane:v3.30.0
@@ -11673,6 +19415,18 @@ sync:
   target: registry.suse.com/rancher/mirrored-calico-goldmane:v3.30.3
   type: image
 - source: quay.io/calico/goldmane:v3.30.0
+  target: registry.suse.com/rancher/charts/mirrored-calico-goldmane:v3.30.0
+  type: image
+- source: quay.io/calico/goldmane:v3.30.1
+  target: registry.suse.com/rancher/charts/mirrored-calico-goldmane:v3.30.1
+  type: image
+- source: quay.io/calico/goldmane:v3.30.2
+  target: registry.suse.com/rancher/charts/mirrored-calico-goldmane:v3.30.2
+  type: image
+- source: quay.io/calico/goldmane:v3.30.3
+  target: registry.suse.com/rancher/charts/mirrored-calico-goldmane:v3.30.3
+  type: image
+- source: quay.io/calico/goldmane:v3.30.0
   target: stgregistry.suse.com/rancher/mirrored-calico-goldmane:v3.30.0
   type: image
 - source: quay.io/calico/goldmane:v3.30.1
@@ -11683,6 +19437,18 @@ sync:
   type: image
 - source: quay.io/calico/goldmane:v3.30.3
   target: stgregistry.suse.com/rancher/mirrored-calico-goldmane:v3.30.3
+  type: image
+- source: quay.io/calico/goldmane:v3.30.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-goldmane:v3.30.0
+  type: image
+- source: quay.io/calico/goldmane:v3.30.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-goldmane:v3.30.1
+  type: image
+- source: quay.io/calico/goldmane:v3.30.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-goldmane:v3.30.2
+  type: image
+- source: quay.io/calico/goldmane:v3.30.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-goldmane:v3.30.3
   type: image
 - source: quay.io/calico/kube-controllers:v3.16.5
   target: docker.io/rancher/calico-kube-controllers:v3.16.5
@@ -11715,6 +19481,21 @@ sync:
   target: registry.suse.com/rancher/calico-kube-controllers:v3.18.1
   type: image
 - source: quay.io/calico/kube-controllers:v3.16.5
+  target: registry.suse.com/rancher/charts/calico-kube-controllers:v3.16.5
+  type: image
+- source: quay.io/calico/kube-controllers:v3.16.6
+  target: registry.suse.com/rancher/charts/calico-kube-controllers:v3.16.6
+  type: image
+- source: quay.io/calico/kube-controllers:v3.17.1
+  target: registry.suse.com/rancher/charts/calico-kube-controllers:v3.17.1
+  type: image
+- source: quay.io/calico/kube-controllers:v3.17.2
+  target: registry.suse.com/rancher/charts/calico-kube-controllers:v3.17.2
+  type: image
+- source: quay.io/calico/kube-controllers:v3.18.1
+  target: registry.suse.com/rancher/charts/calico-kube-controllers:v3.18.1
+  type: image
+- source: quay.io/calico/kube-controllers:v3.16.5
   target: stgregistry.suse.com/rancher/calico-kube-controllers:v3.16.5
   type: image
 - source: quay.io/calico/kube-controllers:v3.16.6
@@ -11728,6 +19509,21 @@ sync:
   type: image
 - source: quay.io/calico/kube-controllers:v3.18.1
   target: stgregistry.suse.com/rancher/calico-kube-controllers:v3.18.1
+  type: image
+- source: quay.io/calico/kube-controllers:v3.16.5
+  target: stgregistry.suse.com/rancher/charts/calico-kube-controllers:v3.16.5
+  type: image
+- source: quay.io/calico/kube-controllers:v3.16.6
+  target: stgregistry.suse.com/rancher/charts/calico-kube-controllers:v3.16.6
+  type: image
+- source: quay.io/calico/kube-controllers:v3.17.1
+  target: stgregistry.suse.com/rancher/charts/calico-kube-controllers:v3.17.1
+  type: image
+- source: quay.io/calico/kube-controllers:v3.17.2
+  target: stgregistry.suse.com/rancher/charts/calico-kube-controllers:v3.17.2
+  type: image
+- source: quay.io/calico/kube-controllers:v3.18.1
+  target: stgregistry.suse.com/rancher/charts/calico-kube-controllers:v3.18.1
   type: image
 - source: quay.io/calico/kube-controllers:v3.13.4
   target: docker.io/rancher/mirrored-calico-kube-controllers:v3.13.4
@@ -11988,6 +19784,135 @@ sync:
   target: registry.suse.com/rancher/mirrored-calico-kube-controllers:v3.30.3
   type: image
 - source: quay.io/calico/kube-controllers:v3.13.4
+  target: registry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.13.4
+  type: image
+- source: quay.io/calico/kube-controllers:v3.16.5
+  target: registry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.16.5
+  type: image
+- source: quay.io/calico/kube-controllers:v3.17.2
+  target: registry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.17.2
+  type: image
+- source: quay.io/calico/kube-controllers:v3.18.1
+  target: registry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.18.1
+  type: image
+- source: quay.io/calico/kube-controllers:v3.19.0
+  target: registry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.19.0
+  type: image
+- source: quay.io/calico/kube-controllers:v3.19.1
+  target: registry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.19.1
+  type: image
+- source: quay.io/calico/kube-controllers:v3.19.2
+  target: registry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.19.2
+  type: image
+- source: quay.io/calico/kube-controllers:v3.20.1
+  target: registry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.20.1
+  type: image
+- source: quay.io/calico/kube-controllers:v3.20.2
+  target: registry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.20.2
+  type: image
+- source: quay.io/calico/kube-controllers:v3.21.1
+  target: registry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.21.1
+  type: image
+- source: quay.io/calico/kube-controllers:v3.21.2
+  target: registry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.21.2
+  type: image
+- source: quay.io/calico/kube-controllers:v3.21.4
+  target: registry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.21.4
+  type: image
+- source: quay.io/calico/kube-controllers:v3.21.5
+  target: registry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.21.5
+  type: image
+- source: quay.io/calico/kube-controllers:v3.22.0
+  target: registry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.22.0
+  type: image
+- source: quay.io/calico/kube-controllers:v3.22.1
+  target: registry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.22.1
+  type: image
+- source: quay.io/calico/kube-controllers:v3.22.2
+  target: registry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.22.2
+  type: image
+- source: quay.io/calico/kube-controllers:v3.22.5
+  target: registry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.22.5
+  type: image
+- source: quay.io/calico/kube-controllers:v3.23.0
+  target: registry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.23.0
+  type: image
+- source: quay.io/calico/kube-controllers:v3.23.1
+  target: registry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.23.1
+  type: image
+- source: quay.io/calico/kube-controllers:v3.23.3
+  target: registry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.23.3
+  type: image
+- source: quay.io/calico/kube-controllers:v3.24.1
+  target: registry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.24.1
+  type: image
+- source: quay.io/calico/kube-controllers:v3.24.5
+  target: registry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.24.5
+  type: image
+- source: quay.io/calico/kube-controllers:v3.25.0
+  target: registry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.25.0
+  type: image
+- source: quay.io/calico/kube-controllers:v3.25.2
+  target: registry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.25.2
+  type: image
+- source: quay.io/calico/kube-controllers:v3.26.1
+  target: registry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.26.1
+  type: image
+- source: quay.io/calico/kube-controllers:v3.26.2
+  target: registry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.26.2
+  type: image
+- source: quay.io/calico/kube-controllers:v3.26.3
+  target: registry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.26.3
+  type: image
+- source: quay.io/calico/kube-controllers:v3.26.4
+  target: registry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.26.4
+  type: image
+- source: quay.io/calico/kube-controllers:v3.27.0
+  target: registry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.27.0
+  type: image
+- source: quay.io/calico/kube-controllers:v3.27.2
+  target: registry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.27.2
+  type: image
+- source: quay.io/calico/kube-controllers:v3.27.3
+  target: registry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.27.3
+  type: image
+- source: quay.io/calico/kube-controllers:v3.27.4
+  target: registry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.27.4
+  type: image
+- source: quay.io/calico/kube-controllers:v3.28.0
+  target: registry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.28.0
+  type: image
+- source: quay.io/calico/kube-controllers:v3.28.1
+  target: registry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.28.1
+  type: image
+- source: quay.io/calico/kube-controllers:v3.28.2
+  target: registry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.28.2
+  type: image
+- source: quay.io/calico/kube-controllers:v3.29.0
+  target: registry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.29.0
+  type: image
+- source: quay.io/calico/kube-controllers:v3.29.1
+  target: registry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.29.1
+  type: image
+- source: quay.io/calico/kube-controllers:v3.29.2
+  target: registry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.29.2
+  type: image
+- source: quay.io/calico/kube-controllers:v3.29.3
+  target: registry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.29.3
+  type: image
+- source: quay.io/calico/kube-controllers:v3.30.0
+  target: registry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.30.0
+  type: image
+- source: quay.io/calico/kube-controllers:v3.30.1
+  target: registry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.30.1
+  type: image
+- source: quay.io/calico/kube-controllers:v3.30.2
+  target: registry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.30.2
+  type: image
+- source: quay.io/calico/kube-controllers:v3.30.3
+  target: registry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.30.3
+  type: image
+- source: quay.io/calico/kube-controllers:v3.13.4
   target: stgregistry.suse.com/rancher/mirrored-calico-kube-controllers:v3.13.4
   type: image
 - source: quay.io/calico/kube-controllers:v3.16.5
@@ -12116,6 +20041,135 @@ sync:
 - source: quay.io/calico/kube-controllers:v3.30.3
   target: stgregistry.suse.com/rancher/mirrored-calico-kube-controllers:v3.30.3
   type: image
+- source: quay.io/calico/kube-controllers:v3.13.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.13.4
+  type: image
+- source: quay.io/calico/kube-controllers:v3.16.5
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.16.5
+  type: image
+- source: quay.io/calico/kube-controllers:v3.17.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.17.2
+  type: image
+- source: quay.io/calico/kube-controllers:v3.18.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.18.1
+  type: image
+- source: quay.io/calico/kube-controllers:v3.19.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.19.0
+  type: image
+- source: quay.io/calico/kube-controllers:v3.19.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.19.1
+  type: image
+- source: quay.io/calico/kube-controllers:v3.19.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.19.2
+  type: image
+- source: quay.io/calico/kube-controllers:v3.20.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.20.1
+  type: image
+- source: quay.io/calico/kube-controllers:v3.20.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.20.2
+  type: image
+- source: quay.io/calico/kube-controllers:v3.21.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.21.1
+  type: image
+- source: quay.io/calico/kube-controllers:v3.21.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.21.2
+  type: image
+- source: quay.io/calico/kube-controllers:v3.21.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.21.4
+  type: image
+- source: quay.io/calico/kube-controllers:v3.21.5
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.21.5
+  type: image
+- source: quay.io/calico/kube-controllers:v3.22.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.22.0
+  type: image
+- source: quay.io/calico/kube-controllers:v3.22.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.22.1
+  type: image
+- source: quay.io/calico/kube-controllers:v3.22.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.22.2
+  type: image
+- source: quay.io/calico/kube-controllers:v3.22.5
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.22.5
+  type: image
+- source: quay.io/calico/kube-controllers:v3.23.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.23.0
+  type: image
+- source: quay.io/calico/kube-controllers:v3.23.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.23.1
+  type: image
+- source: quay.io/calico/kube-controllers:v3.23.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.23.3
+  type: image
+- source: quay.io/calico/kube-controllers:v3.24.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.24.1
+  type: image
+- source: quay.io/calico/kube-controllers:v3.24.5
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.24.5
+  type: image
+- source: quay.io/calico/kube-controllers:v3.25.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.25.0
+  type: image
+- source: quay.io/calico/kube-controllers:v3.25.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.25.2
+  type: image
+- source: quay.io/calico/kube-controllers:v3.26.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.26.1
+  type: image
+- source: quay.io/calico/kube-controllers:v3.26.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.26.2
+  type: image
+- source: quay.io/calico/kube-controllers:v3.26.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.26.3
+  type: image
+- source: quay.io/calico/kube-controllers:v3.26.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.26.4
+  type: image
+- source: quay.io/calico/kube-controllers:v3.27.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.27.0
+  type: image
+- source: quay.io/calico/kube-controllers:v3.27.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.27.2
+  type: image
+- source: quay.io/calico/kube-controllers:v3.27.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.27.3
+  type: image
+- source: quay.io/calico/kube-controllers:v3.27.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.27.4
+  type: image
+- source: quay.io/calico/kube-controllers:v3.28.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.28.0
+  type: image
+- source: quay.io/calico/kube-controllers:v3.28.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.28.1
+  type: image
+- source: quay.io/calico/kube-controllers:v3.28.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.28.2
+  type: image
+- source: quay.io/calico/kube-controllers:v3.29.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.29.0
+  type: image
+- source: quay.io/calico/kube-controllers:v3.29.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.29.1
+  type: image
+- source: quay.io/calico/kube-controllers:v3.29.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.29.2
+  type: image
+- source: quay.io/calico/kube-controllers:v3.29.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.29.3
+  type: image
+- source: quay.io/calico/kube-controllers:v3.30.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.30.0
+  type: image
+- source: quay.io/calico/kube-controllers:v3.30.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.30.1
+  type: image
+- source: quay.io/calico/kube-controllers:v3.30.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.30.2
+  type: image
+- source: quay.io/calico/kube-controllers:v3.30.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.30.3
+  type: image
 - source: quay.io/calico/node:v3.16.5
   target: docker.io/rancher/calico-node:v3.16.5
   type: image
@@ -12147,6 +20201,21 @@ sync:
   target: registry.suse.com/rancher/calico-node:v3.18.1
   type: image
 - source: quay.io/calico/node:v3.16.5
+  target: registry.suse.com/rancher/charts/calico-node:v3.16.5
+  type: image
+- source: quay.io/calico/node:v3.16.6
+  target: registry.suse.com/rancher/charts/calico-node:v3.16.6
+  type: image
+- source: quay.io/calico/node:v3.17.1
+  target: registry.suse.com/rancher/charts/calico-node:v3.17.1
+  type: image
+- source: quay.io/calico/node:v3.17.2
+  target: registry.suse.com/rancher/charts/calico-node:v3.17.2
+  type: image
+- source: quay.io/calico/node:v3.18.1
+  target: registry.suse.com/rancher/charts/calico-node:v3.18.1
+  type: image
+- source: quay.io/calico/node:v3.16.5
   target: stgregistry.suse.com/rancher/calico-node:v3.16.5
   type: image
 - source: quay.io/calico/node:v3.16.6
@@ -12160,6 +20229,21 @@ sync:
   type: image
 - source: quay.io/calico/node:v3.18.1
   target: stgregistry.suse.com/rancher/calico-node:v3.18.1
+  type: image
+- source: quay.io/calico/node:v3.16.5
+  target: stgregistry.suse.com/rancher/charts/calico-node:v3.16.5
+  type: image
+- source: quay.io/calico/node:v3.16.6
+  target: stgregistry.suse.com/rancher/charts/calico-node:v3.16.6
+  type: image
+- source: quay.io/calico/node:v3.17.1
+  target: stgregistry.suse.com/rancher/charts/calico-node:v3.17.1
+  type: image
+- source: quay.io/calico/node:v3.17.2
+  target: stgregistry.suse.com/rancher/charts/calico-node:v3.17.2
+  type: image
+- source: quay.io/calico/node:v3.18.1
+  target: stgregistry.suse.com/rancher/charts/calico-node:v3.18.1
   type: image
 - source: quay.io/calico/node:v3.13.4
   target: docker.io/rancher/mirrored-calico-node:v3.13.4
@@ -12420,6 +20504,135 @@ sync:
   target: registry.suse.com/rancher/mirrored-calico-node:v3.30.3
   type: image
 - source: quay.io/calico/node:v3.13.4
+  target: registry.suse.com/rancher/charts/mirrored-calico-node:v3.13.4
+  type: image
+- source: quay.io/calico/node:v3.16.5
+  target: registry.suse.com/rancher/charts/mirrored-calico-node:v3.16.5
+  type: image
+- source: quay.io/calico/node:v3.17.2
+  target: registry.suse.com/rancher/charts/mirrored-calico-node:v3.17.2
+  type: image
+- source: quay.io/calico/node:v3.18.1
+  target: registry.suse.com/rancher/charts/mirrored-calico-node:v3.18.1
+  type: image
+- source: quay.io/calico/node:v3.19.0
+  target: registry.suse.com/rancher/charts/mirrored-calico-node:v3.19.0
+  type: image
+- source: quay.io/calico/node:v3.19.1
+  target: registry.suse.com/rancher/charts/mirrored-calico-node:v3.19.1
+  type: image
+- source: quay.io/calico/node:v3.19.2
+  target: registry.suse.com/rancher/charts/mirrored-calico-node:v3.19.2
+  type: image
+- source: quay.io/calico/node:v3.20.1
+  target: registry.suse.com/rancher/charts/mirrored-calico-node:v3.20.1
+  type: image
+- source: quay.io/calico/node:v3.20.2
+  target: registry.suse.com/rancher/charts/mirrored-calico-node:v3.20.2
+  type: image
+- source: quay.io/calico/node:v3.21.1
+  target: registry.suse.com/rancher/charts/mirrored-calico-node:v3.21.1
+  type: image
+- source: quay.io/calico/node:v3.21.2
+  target: registry.suse.com/rancher/charts/mirrored-calico-node:v3.21.2
+  type: image
+- source: quay.io/calico/node:v3.21.4
+  target: registry.suse.com/rancher/charts/mirrored-calico-node:v3.21.4
+  type: image
+- source: quay.io/calico/node:v3.21.5
+  target: registry.suse.com/rancher/charts/mirrored-calico-node:v3.21.5
+  type: image
+- source: quay.io/calico/node:v3.22.0
+  target: registry.suse.com/rancher/charts/mirrored-calico-node:v3.22.0
+  type: image
+- source: quay.io/calico/node:v3.22.1
+  target: registry.suse.com/rancher/charts/mirrored-calico-node:v3.22.1
+  type: image
+- source: quay.io/calico/node:v3.22.2
+  target: registry.suse.com/rancher/charts/mirrored-calico-node:v3.22.2
+  type: image
+- source: quay.io/calico/node:v3.22.5
+  target: registry.suse.com/rancher/charts/mirrored-calico-node:v3.22.5
+  type: image
+- source: quay.io/calico/node:v3.23.0
+  target: registry.suse.com/rancher/charts/mirrored-calico-node:v3.23.0
+  type: image
+- source: quay.io/calico/node:v3.23.1
+  target: registry.suse.com/rancher/charts/mirrored-calico-node:v3.23.1
+  type: image
+- source: quay.io/calico/node:v3.23.3
+  target: registry.suse.com/rancher/charts/mirrored-calico-node:v3.23.3
+  type: image
+- source: quay.io/calico/node:v3.24.1
+  target: registry.suse.com/rancher/charts/mirrored-calico-node:v3.24.1
+  type: image
+- source: quay.io/calico/node:v3.24.5
+  target: registry.suse.com/rancher/charts/mirrored-calico-node:v3.24.5
+  type: image
+- source: quay.io/calico/node:v3.25.0
+  target: registry.suse.com/rancher/charts/mirrored-calico-node:v3.25.0
+  type: image
+- source: quay.io/calico/node:v3.25.2
+  target: registry.suse.com/rancher/charts/mirrored-calico-node:v3.25.2
+  type: image
+- source: quay.io/calico/node:v3.26.1
+  target: registry.suse.com/rancher/charts/mirrored-calico-node:v3.26.1
+  type: image
+- source: quay.io/calico/node:v3.26.2
+  target: registry.suse.com/rancher/charts/mirrored-calico-node:v3.26.2
+  type: image
+- source: quay.io/calico/node:v3.26.3
+  target: registry.suse.com/rancher/charts/mirrored-calico-node:v3.26.3
+  type: image
+- source: quay.io/calico/node:v3.26.4
+  target: registry.suse.com/rancher/charts/mirrored-calico-node:v3.26.4
+  type: image
+- source: quay.io/calico/node:v3.27.0
+  target: registry.suse.com/rancher/charts/mirrored-calico-node:v3.27.0
+  type: image
+- source: quay.io/calico/node:v3.27.2
+  target: registry.suse.com/rancher/charts/mirrored-calico-node:v3.27.2
+  type: image
+- source: quay.io/calico/node:v3.27.3
+  target: registry.suse.com/rancher/charts/mirrored-calico-node:v3.27.3
+  type: image
+- source: quay.io/calico/node:v3.27.4
+  target: registry.suse.com/rancher/charts/mirrored-calico-node:v3.27.4
+  type: image
+- source: quay.io/calico/node:v3.28.0
+  target: registry.suse.com/rancher/charts/mirrored-calico-node:v3.28.0
+  type: image
+- source: quay.io/calico/node:v3.28.1
+  target: registry.suse.com/rancher/charts/mirrored-calico-node:v3.28.1
+  type: image
+- source: quay.io/calico/node:v3.28.2
+  target: registry.suse.com/rancher/charts/mirrored-calico-node:v3.28.2
+  type: image
+- source: quay.io/calico/node:v3.29.0
+  target: registry.suse.com/rancher/charts/mirrored-calico-node:v3.29.0
+  type: image
+- source: quay.io/calico/node:v3.29.1
+  target: registry.suse.com/rancher/charts/mirrored-calico-node:v3.29.1
+  type: image
+- source: quay.io/calico/node:v3.29.2
+  target: registry.suse.com/rancher/charts/mirrored-calico-node:v3.29.2
+  type: image
+- source: quay.io/calico/node:v3.29.3
+  target: registry.suse.com/rancher/charts/mirrored-calico-node:v3.29.3
+  type: image
+- source: quay.io/calico/node:v3.30.0
+  target: registry.suse.com/rancher/charts/mirrored-calico-node:v3.30.0
+  type: image
+- source: quay.io/calico/node:v3.30.1
+  target: registry.suse.com/rancher/charts/mirrored-calico-node:v3.30.1
+  type: image
+- source: quay.io/calico/node:v3.30.2
+  target: registry.suse.com/rancher/charts/mirrored-calico-node:v3.30.2
+  type: image
+- source: quay.io/calico/node:v3.30.3
+  target: registry.suse.com/rancher/charts/mirrored-calico-node:v3.30.3
+  type: image
+- source: quay.io/calico/node:v3.13.4
   target: stgregistry.suse.com/rancher/mirrored-calico-node:v3.13.4
   type: image
 - source: quay.io/calico/node:v3.16.5
@@ -12548,6 +20761,135 @@ sync:
 - source: quay.io/calico/node:v3.30.3
   target: stgregistry.suse.com/rancher/mirrored-calico-node:v3.30.3
   type: image
+- source: quay.io/calico/node:v3.13.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-node:v3.13.4
+  type: image
+- source: quay.io/calico/node:v3.16.5
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-node:v3.16.5
+  type: image
+- source: quay.io/calico/node:v3.17.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-node:v3.17.2
+  type: image
+- source: quay.io/calico/node:v3.18.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-node:v3.18.1
+  type: image
+- source: quay.io/calico/node:v3.19.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-node:v3.19.0
+  type: image
+- source: quay.io/calico/node:v3.19.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-node:v3.19.1
+  type: image
+- source: quay.io/calico/node:v3.19.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-node:v3.19.2
+  type: image
+- source: quay.io/calico/node:v3.20.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-node:v3.20.1
+  type: image
+- source: quay.io/calico/node:v3.20.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-node:v3.20.2
+  type: image
+- source: quay.io/calico/node:v3.21.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-node:v3.21.1
+  type: image
+- source: quay.io/calico/node:v3.21.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-node:v3.21.2
+  type: image
+- source: quay.io/calico/node:v3.21.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-node:v3.21.4
+  type: image
+- source: quay.io/calico/node:v3.21.5
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-node:v3.21.5
+  type: image
+- source: quay.io/calico/node:v3.22.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-node:v3.22.0
+  type: image
+- source: quay.io/calico/node:v3.22.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-node:v3.22.1
+  type: image
+- source: quay.io/calico/node:v3.22.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-node:v3.22.2
+  type: image
+- source: quay.io/calico/node:v3.22.5
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-node:v3.22.5
+  type: image
+- source: quay.io/calico/node:v3.23.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-node:v3.23.0
+  type: image
+- source: quay.io/calico/node:v3.23.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-node:v3.23.1
+  type: image
+- source: quay.io/calico/node:v3.23.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-node:v3.23.3
+  type: image
+- source: quay.io/calico/node:v3.24.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-node:v3.24.1
+  type: image
+- source: quay.io/calico/node:v3.24.5
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-node:v3.24.5
+  type: image
+- source: quay.io/calico/node:v3.25.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-node:v3.25.0
+  type: image
+- source: quay.io/calico/node:v3.25.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-node:v3.25.2
+  type: image
+- source: quay.io/calico/node:v3.26.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-node:v3.26.1
+  type: image
+- source: quay.io/calico/node:v3.26.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-node:v3.26.2
+  type: image
+- source: quay.io/calico/node:v3.26.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-node:v3.26.3
+  type: image
+- source: quay.io/calico/node:v3.26.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-node:v3.26.4
+  type: image
+- source: quay.io/calico/node:v3.27.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-node:v3.27.0
+  type: image
+- source: quay.io/calico/node:v3.27.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-node:v3.27.2
+  type: image
+- source: quay.io/calico/node:v3.27.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-node:v3.27.3
+  type: image
+- source: quay.io/calico/node:v3.27.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-node:v3.27.4
+  type: image
+- source: quay.io/calico/node:v3.28.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-node:v3.28.0
+  type: image
+- source: quay.io/calico/node:v3.28.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-node:v3.28.1
+  type: image
+- source: quay.io/calico/node:v3.28.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-node:v3.28.2
+  type: image
+- source: quay.io/calico/node:v3.29.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-node:v3.29.0
+  type: image
+- source: quay.io/calico/node:v3.29.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-node:v3.29.1
+  type: image
+- source: quay.io/calico/node:v3.29.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-node:v3.29.2
+  type: image
+- source: quay.io/calico/node:v3.29.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-node:v3.29.3
+  type: image
+- source: quay.io/calico/node:v3.30.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-node:v3.30.0
+  type: image
+- source: quay.io/calico/node:v3.30.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-node:v3.30.1
+  type: image
+- source: quay.io/calico/node:v3.30.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-node:v3.30.2
+  type: image
+- source: quay.io/calico/node:v3.30.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-node:v3.30.3
+  type: image
 - source: quay.io/calico/node-driver-registrar:v3.27.0
   target: docker.io/rancher/mirrored-calico-node-driver-registrar:v3.27.0
   type: image
@@ -12639,6 +20981,51 @@ sync:
   target: registry.suse.com/rancher/mirrored-calico-node-driver-registrar:v3.30.3
   type: image
 - source: quay.io/calico/node-driver-registrar:v3.27.0
+  target: registry.suse.com/rancher/charts/mirrored-calico-node-driver-registrar:v3.27.0
+  type: image
+- source: quay.io/calico/node-driver-registrar:v3.27.2
+  target: registry.suse.com/rancher/charts/mirrored-calico-node-driver-registrar:v3.27.2
+  type: image
+- source: quay.io/calico/node-driver-registrar:v3.27.3
+  target: registry.suse.com/rancher/charts/mirrored-calico-node-driver-registrar:v3.27.3
+  type: image
+- source: quay.io/calico/node-driver-registrar:v3.27.4
+  target: registry.suse.com/rancher/charts/mirrored-calico-node-driver-registrar:v3.27.4
+  type: image
+- source: quay.io/calico/node-driver-registrar:v3.28.0
+  target: registry.suse.com/rancher/charts/mirrored-calico-node-driver-registrar:v3.28.0
+  type: image
+- source: quay.io/calico/node-driver-registrar:v3.28.1
+  target: registry.suse.com/rancher/charts/mirrored-calico-node-driver-registrar:v3.28.1
+  type: image
+- source: quay.io/calico/node-driver-registrar:v3.28.2
+  target: registry.suse.com/rancher/charts/mirrored-calico-node-driver-registrar:v3.28.2
+  type: image
+- source: quay.io/calico/node-driver-registrar:v3.29.0
+  target: registry.suse.com/rancher/charts/mirrored-calico-node-driver-registrar:v3.29.0
+  type: image
+- source: quay.io/calico/node-driver-registrar:v3.29.1
+  target: registry.suse.com/rancher/charts/mirrored-calico-node-driver-registrar:v3.29.1
+  type: image
+- source: quay.io/calico/node-driver-registrar:v3.29.2
+  target: registry.suse.com/rancher/charts/mirrored-calico-node-driver-registrar:v3.29.2
+  type: image
+- source: quay.io/calico/node-driver-registrar:v3.29.3
+  target: registry.suse.com/rancher/charts/mirrored-calico-node-driver-registrar:v3.29.3
+  type: image
+- source: quay.io/calico/node-driver-registrar:v3.30.0
+  target: registry.suse.com/rancher/charts/mirrored-calico-node-driver-registrar:v3.30.0
+  type: image
+- source: quay.io/calico/node-driver-registrar:v3.30.1
+  target: registry.suse.com/rancher/charts/mirrored-calico-node-driver-registrar:v3.30.1
+  type: image
+- source: quay.io/calico/node-driver-registrar:v3.30.2
+  target: registry.suse.com/rancher/charts/mirrored-calico-node-driver-registrar:v3.30.2
+  type: image
+- source: quay.io/calico/node-driver-registrar:v3.30.3
+  target: registry.suse.com/rancher/charts/mirrored-calico-node-driver-registrar:v3.30.3
+  type: image
+- source: quay.io/calico/node-driver-registrar:v3.27.0
   target: stgregistry.suse.com/rancher/mirrored-calico-node-driver-registrar:v3.27.0
   type: image
 - source: quay.io/calico/node-driver-registrar:v3.27.2
@@ -12683,6 +21070,51 @@ sync:
 - source: quay.io/calico/node-driver-registrar:v3.30.3
   target: stgregistry.suse.com/rancher/mirrored-calico-node-driver-registrar:v3.30.3
   type: image
+- source: quay.io/calico/node-driver-registrar:v3.27.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-node-driver-registrar:v3.27.0
+  type: image
+- source: quay.io/calico/node-driver-registrar:v3.27.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-node-driver-registrar:v3.27.2
+  type: image
+- source: quay.io/calico/node-driver-registrar:v3.27.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-node-driver-registrar:v3.27.3
+  type: image
+- source: quay.io/calico/node-driver-registrar:v3.27.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-node-driver-registrar:v3.27.4
+  type: image
+- source: quay.io/calico/node-driver-registrar:v3.28.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-node-driver-registrar:v3.28.0
+  type: image
+- source: quay.io/calico/node-driver-registrar:v3.28.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-node-driver-registrar:v3.28.1
+  type: image
+- source: quay.io/calico/node-driver-registrar:v3.28.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-node-driver-registrar:v3.28.2
+  type: image
+- source: quay.io/calico/node-driver-registrar:v3.29.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-node-driver-registrar:v3.29.0
+  type: image
+- source: quay.io/calico/node-driver-registrar:v3.29.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-node-driver-registrar:v3.29.1
+  type: image
+- source: quay.io/calico/node-driver-registrar:v3.29.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-node-driver-registrar:v3.29.2
+  type: image
+- source: quay.io/calico/node-driver-registrar:v3.29.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-node-driver-registrar:v3.29.3
+  type: image
+- source: quay.io/calico/node-driver-registrar:v3.30.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-node-driver-registrar:v3.30.0
+  type: image
+- source: quay.io/calico/node-driver-registrar:v3.30.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-node-driver-registrar:v3.30.1
+  type: image
+- source: quay.io/calico/node-driver-registrar:v3.30.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-node-driver-registrar:v3.30.2
+  type: image
+- source: quay.io/calico/node-driver-registrar:v3.30.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-node-driver-registrar:v3.30.3
+  type: image
 - source: quay.io/calico/pod2daemon-flexvol:v3.16.5
   target: docker.io/rancher/calico-pod2daemon-flexvol:v3.16.5
   type: image
@@ -12714,6 +21146,21 @@ sync:
   target: registry.suse.com/rancher/calico-pod2daemon-flexvol:v3.18.1
   type: image
 - source: quay.io/calico/pod2daemon-flexvol:v3.16.5
+  target: registry.suse.com/rancher/charts/calico-pod2daemon-flexvol:v3.16.5
+  type: image
+- source: quay.io/calico/pod2daemon-flexvol:v3.16.6
+  target: registry.suse.com/rancher/charts/calico-pod2daemon-flexvol:v3.16.6
+  type: image
+- source: quay.io/calico/pod2daemon-flexvol:v3.17.1
+  target: registry.suse.com/rancher/charts/calico-pod2daemon-flexvol:v3.17.1
+  type: image
+- source: quay.io/calico/pod2daemon-flexvol:v3.17.2
+  target: registry.suse.com/rancher/charts/calico-pod2daemon-flexvol:v3.17.2
+  type: image
+- source: quay.io/calico/pod2daemon-flexvol:v3.18.1
+  target: registry.suse.com/rancher/charts/calico-pod2daemon-flexvol:v3.18.1
+  type: image
+- source: quay.io/calico/pod2daemon-flexvol:v3.16.5
   target: stgregistry.suse.com/rancher/calico-pod2daemon-flexvol:v3.16.5
   type: image
 - source: quay.io/calico/pod2daemon-flexvol:v3.16.6
@@ -12727,6 +21174,21 @@ sync:
   type: image
 - source: quay.io/calico/pod2daemon-flexvol:v3.18.1
   target: stgregistry.suse.com/rancher/calico-pod2daemon-flexvol:v3.18.1
+  type: image
+- source: quay.io/calico/pod2daemon-flexvol:v3.16.5
+  target: stgregistry.suse.com/rancher/charts/calico-pod2daemon-flexvol:v3.16.5
+  type: image
+- source: quay.io/calico/pod2daemon-flexvol:v3.16.6
+  target: stgregistry.suse.com/rancher/charts/calico-pod2daemon-flexvol:v3.16.6
+  type: image
+- source: quay.io/calico/pod2daemon-flexvol:v3.17.1
+  target: stgregistry.suse.com/rancher/charts/calico-pod2daemon-flexvol:v3.17.1
+  type: image
+- source: quay.io/calico/pod2daemon-flexvol:v3.17.2
+  target: stgregistry.suse.com/rancher/charts/calico-pod2daemon-flexvol:v3.17.2
+  type: image
+- source: quay.io/calico/pod2daemon-flexvol:v3.18.1
+  target: stgregistry.suse.com/rancher/charts/calico-pod2daemon-flexvol:v3.18.1
   type: image
 - source: quay.io/calico/pod2daemon-flexvol:v3.13.4
   target: docker.io/rancher/mirrored-calico-pod2daemon-flexvol:v3.13.4
@@ -12987,6 +21449,135 @@ sync:
   target: registry.suse.com/rancher/mirrored-calico-pod2daemon-flexvol:v3.30.3
   type: image
 - source: quay.io/calico/pod2daemon-flexvol:v3.13.4
+  target: registry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.13.4
+  type: image
+- source: quay.io/calico/pod2daemon-flexvol:v3.16.5
+  target: registry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.16.5
+  type: image
+- source: quay.io/calico/pod2daemon-flexvol:v3.17.2
+  target: registry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.17.2
+  type: image
+- source: quay.io/calico/pod2daemon-flexvol:v3.18.1
+  target: registry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.18.1
+  type: image
+- source: quay.io/calico/pod2daemon-flexvol:v3.19.0
+  target: registry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.19.0
+  type: image
+- source: quay.io/calico/pod2daemon-flexvol:v3.19.1
+  target: registry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.19.1
+  type: image
+- source: quay.io/calico/pod2daemon-flexvol:v3.19.2
+  target: registry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.19.2
+  type: image
+- source: quay.io/calico/pod2daemon-flexvol:v3.20.1
+  target: registry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.20.1
+  type: image
+- source: quay.io/calico/pod2daemon-flexvol:v3.20.2
+  target: registry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.20.2
+  type: image
+- source: quay.io/calico/pod2daemon-flexvol:v3.21.1
+  target: registry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.21.1
+  type: image
+- source: quay.io/calico/pod2daemon-flexvol:v3.21.2
+  target: registry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.21.2
+  type: image
+- source: quay.io/calico/pod2daemon-flexvol:v3.21.4
+  target: registry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.21.4
+  type: image
+- source: quay.io/calico/pod2daemon-flexvol:v3.21.5
+  target: registry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.21.5
+  type: image
+- source: quay.io/calico/pod2daemon-flexvol:v3.22.0
+  target: registry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.22.0
+  type: image
+- source: quay.io/calico/pod2daemon-flexvol:v3.22.1
+  target: registry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.22.1
+  type: image
+- source: quay.io/calico/pod2daemon-flexvol:v3.22.2
+  target: registry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.22.2
+  type: image
+- source: quay.io/calico/pod2daemon-flexvol:v3.22.5
+  target: registry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.22.5
+  type: image
+- source: quay.io/calico/pod2daemon-flexvol:v3.23.0
+  target: registry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.23.0
+  type: image
+- source: quay.io/calico/pod2daemon-flexvol:v3.23.1
+  target: registry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.23.1
+  type: image
+- source: quay.io/calico/pod2daemon-flexvol:v3.23.3
+  target: registry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.23.3
+  type: image
+- source: quay.io/calico/pod2daemon-flexvol:v3.24.1
+  target: registry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.24.1
+  type: image
+- source: quay.io/calico/pod2daemon-flexvol:v3.24.5
+  target: registry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.24.5
+  type: image
+- source: quay.io/calico/pod2daemon-flexvol:v3.25.0
+  target: registry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.25.0
+  type: image
+- source: quay.io/calico/pod2daemon-flexvol:v3.25.2
+  target: registry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.25.2
+  type: image
+- source: quay.io/calico/pod2daemon-flexvol:v3.26.1
+  target: registry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.26.1
+  type: image
+- source: quay.io/calico/pod2daemon-flexvol:v3.26.2
+  target: registry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.26.2
+  type: image
+- source: quay.io/calico/pod2daemon-flexvol:v3.26.3
+  target: registry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.26.3
+  type: image
+- source: quay.io/calico/pod2daemon-flexvol:v3.26.4
+  target: registry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.26.4
+  type: image
+- source: quay.io/calico/pod2daemon-flexvol:v3.27.0
+  target: registry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.27.0
+  type: image
+- source: quay.io/calico/pod2daemon-flexvol:v3.27.2
+  target: registry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.27.2
+  type: image
+- source: quay.io/calico/pod2daemon-flexvol:v3.27.3
+  target: registry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.27.3
+  type: image
+- source: quay.io/calico/pod2daemon-flexvol:v3.27.4
+  target: registry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.27.4
+  type: image
+- source: quay.io/calico/pod2daemon-flexvol:v3.28.0
+  target: registry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.28.0
+  type: image
+- source: quay.io/calico/pod2daemon-flexvol:v3.28.1
+  target: registry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.28.1
+  type: image
+- source: quay.io/calico/pod2daemon-flexvol:v3.28.2
+  target: registry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.28.2
+  type: image
+- source: quay.io/calico/pod2daemon-flexvol:v3.29.0
+  target: registry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.29.0
+  type: image
+- source: quay.io/calico/pod2daemon-flexvol:v3.29.1
+  target: registry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.29.1
+  type: image
+- source: quay.io/calico/pod2daemon-flexvol:v3.29.2
+  target: registry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.29.2
+  type: image
+- source: quay.io/calico/pod2daemon-flexvol:v3.29.3
+  target: registry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.29.3
+  type: image
+- source: quay.io/calico/pod2daemon-flexvol:v3.30.0
+  target: registry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.30.0
+  type: image
+- source: quay.io/calico/pod2daemon-flexvol:v3.30.1
+  target: registry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.30.1
+  type: image
+- source: quay.io/calico/pod2daemon-flexvol:v3.30.2
+  target: registry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.30.2
+  type: image
+- source: quay.io/calico/pod2daemon-flexvol:v3.30.3
+  target: registry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.30.3
+  type: image
+- source: quay.io/calico/pod2daemon-flexvol:v3.13.4
   target: stgregistry.suse.com/rancher/mirrored-calico-pod2daemon-flexvol:v3.13.4
   type: image
 - source: quay.io/calico/pod2daemon-flexvol:v3.16.5
@@ -13114,6 +21705,135 @@ sync:
   type: image
 - source: quay.io/calico/pod2daemon-flexvol:v3.30.3
   target: stgregistry.suse.com/rancher/mirrored-calico-pod2daemon-flexvol:v3.30.3
+  type: image
+- source: quay.io/calico/pod2daemon-flexvol:v3.13.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.13.4
+  type: image
+- source: quay.io/calico/pod2daemon-flexvol:v3.16.5
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.16.5
+  type: image
+- source: quay.io/calico/pod2daemon-flexvol:v3.17.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.17.2
+  type: image
+- source: quay.io/calico/pod2daemon-flexvol:v3.18.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.18.1
+  type: image
+- source: quay.io/calico/pod2daemon-flexvol:v3.19.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.19.0
+  type: image
+- source: quay.io/calico/pod2daemon-flexvol:v3.19.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.19.1
+  type: image
+- source: quay.io/calico/pod2daemon-flexvol:v3.19.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.19.2
+  type: image
+- source: quay.io/calico/pod2daemon-flexvol:v3.20.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.20.1
+  type: image
+- source: quay.io/calico/pod2daemon-flexvol:v3.20.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.20.2
+  type: image
+- source: quay.io/calico/pod2daemon-flexvol:v3.21.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.21.1
+  type: image
+- source: quay.io/calico/pod2daemon-flexvol:v3.21.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.21.2
+  type: image
+- source: quay.io/calico/pod2daemon-flexvol:v3.21.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.21.4
+  type: image
+- source: quay.io/calico/pod2daemon-flexvol:v3.21.5
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.21.5
+  type: image
+- source: quay.io/calico/pod2daemon-flexvol:v3.22.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.22.0
+  type: image
+- source: quay.io/calico/pod2daemon-flexvol:v3.22.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.22.1
+  type: image
+- source: quay.io/calico/pod2daemon-flexvol:v3.22.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.22.2
+  type: image
+- source: quay.io/calico/pod2daemon-flexvol:v3.22.5
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.22.5
+  type: image
+- source: quay.io/calico/pod2daemon-flexvol:v3.23.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.23.0
+  type: image
+- source: quay.io/calico/pod2daemon-flexvol:v3.23.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.23.1
+  type: image
+- source: quay.io/calico/pod2daemon-flexvol:v3.23.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.23.3
+  type: image
+- source: quay.io/calico/pod2daemon-flexvol:v3.24.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.24.1
+  type: image
+- source: quay.io/calico/pod2daemon-flexvol:v3.24.5
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.24.5
+  type: image
+- source: quay.io/calico/pod2daemon-flexvol:v3.25.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.25.0
+  type: image
+- source: quay.io/calico/pod2daemon-flexvol:v3.25.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.25.2
+  type: image
+- source: quay.io/calico/pod2daemon-flexvol:v3.26.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.26.1
+  type: image
+- source: quay.io/calico/pod2daemon-flexvol:v3.26.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.26.2
+  type: image
+- source: quay.io/calico/pod2daemon-flexvol:v3.26.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.26.3
+  type: image
+- source: quay.io/calico/pod2daemon-flexvol:v3.26.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.26.4
+  type: image
+- source: quay.io/calico/pod2daemon-flexvol:v3.27.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.27.0
+  type: image
+- source: quay.io/calico/pod2daemon-flexvol:v3.27.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.27.2
+  type: image
+- source: quay.io/calico/pod2daemon-flexvol:v3.27.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.27.3
+  type: image
+- source: quay.io/calico/pod2daemon-flexvol:v3.27.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.27.4
+  type: image
+- source: quay.io/calico/pod2daemon-flexvol:v3.28.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.28.0
+  type: image
+- source: quay.io/calico/pod2daemon-flexvol:v3.28.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.28.1
+  type: image
+- source: quay.io/calico/pod2daemon-flexvol:v3.28.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.28.2
+  type: image
+- source: quay.io/calico/pod2daemon-flexvol:v3.29.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.29.0
+  type: image
+- source: quay.io/calico/pod2daemon-flexvol:v3.29.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.29.1
+  type: image
+- source: quay.io/calico/pod2daemon-flexvol:v3.29.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.29.2
+  type: image
+- source: quay.io/calico/pod2daemon-flexvol:v3.29.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.29.3
+  type: image
+- source: quay.io/calico/pod2daemon-flexvol:v3.30.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.30.0
+  type: image
+- source: quay.io/calico/pod2daemon-flexvol:v3.30.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.30.1
+  type: image
+- source: quay.io/calico/pod2daemon-flexvol:v3.30.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.30.2
+  type: image
+- source: quay.io/calico/pod2daemon-flexvol:v3.30.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.30.3
   type: image
 - source: quay.io/calico/typha:v3.18.1
   target: docker.io/rancher/mirrored-calico-typha:v3.18.1
@@ -13350,6 +22070,123 @@ sync:
   target: registry.suse.com/rancher/mirrored-calico-typha:v3.30.3
   type: image
 - source: quay.io/calico/typha:v3.18.1
+  target: registry.suse.com/rancher/charts/mirrored-calico-typha:v3.18.1
+  type: image
+- source: quay.io/calico/typha:v3.19.1
+  target: registry.suse.com/rancher/charts/mirrored-calico-typha:v3.19.1
+  type: image
+- source: quay.io/calico/typha:v3.19.2
+  target: registry.suse.com/rancher/charts/mirrored-calico-typha:v3.19.2
+  type: image
+- source: quay.io/calico/typha:v3.20.1
+  target: registry.suse.com/rancher/charts/mirrored-calico-typha:v3.20.1
+  type: image
+- source: quay.io/calico/typha:v3.20.2
+  target: registry.suse.com/rancher/charts/mirrored-calico-typha:v3.20.2
+  type: image
+- source: quay.io/calico/typha:v3.21.1
+  target: registry.suse.com/rancher/charts/mirrored-calico-typha:v3.21.1
+  type: image
+- source: quay.io/calico/typha:v3.21.2
+  target: registry.suse.com/rancher/charts/mirrored-calico-typha:v3.21.2
+  type: image
+- source: quay.io/calico/typha:v3.21.4
+  target: registry.suse.com/rancher/charts/mirrored-calico-typha:v3.21.4
+  type: image
+- source: quay.io/calico/typha:v3.21.5
+  target: registry.suse.com/rancher/charts/mirrored-calico-typha:v3.21.5
+  type: image
+- source: quay.io/calico/typha:v3.22.0
+  target: registry.suse.com/rancher/charts/mirrored-calico-typha:v3.22.0
+  type: image
+- source: quay.io/calico/typha:v3.22.1
+  target: registry.suse.com/rancher/charts/mirrored-calico-typha:v3.22.1
+  type: image
+- source: quay.io/calico/typha:v3.22.2
+  target: registry.suse.com/rancher/charts/mirrored-calico-typha:v3.22.2
+  type: image
+- source: quay.io/calico/typha:v3.22.5
+  target: registry.suse.com/rancher/charts/mirrored-calico-typha:v3.22.5
+  type: image
+- source: quay.io/calico/typha:v3.23.0
+  target: registry.suse.com/rancher/charts/mirrored-calico-typha:v3.23.0
+  type: image
+- source: quay.io/calico/typha:v3.23.1
+  target: registry.suse.com/rancher/charts/mirrored-calico-typha:v3.23.1
+  type: image
+- source: quay.io/calico/typha:v3.23.3
+  target: registry.suse.com/rancher/charts/mirrored-calico-typha:v3.23.3
+  type: image
+- source: quay.io/calico/typha:v3.24.1
+  target: registry.suse.com/rancher/charts/mirrored-calico-typha:v3.24.1
+  type: image
+- source: quay.io/calico/typha:v3.24.5
+  target: registry.suse.com/rancher/charts/mirrored-calico-typha:v3.24.5
+  type: image
+- source: quay.io/calico/typha:v3.25.0
+  target: registry.suse.com/rancher/charts/mirrored-calico-typha:v3.25.0
+  type: image
+- source: quay.io/calico/typha:v3.25.2
+  target: registry.suse.com/rancher/charts/mirrored-calico-typha:v3.25.2
+  type: image
+- source: quay.io/calico/typha:v3.26.1
+  target: registry.suse.com/rancher/charts/mirrored-calico-typha:v3.26.1
+  type: image
+- source: quay.io/calico/typha:v3.26.2
+  target: registry.suse.com/rancher/charts/mirrored-calico-typha:v3.26.2
+  type: image
+- source: quay.io/calico/typha:v3.26.3
+  target: registry.suse.com/rancher/charts/mirrored-calico-typha:v3.26.3
+  type: image
+- source: quay.io/calico/typha:v3.26.4
+  target: registry.suse.com/rancher/charts/mirrored-calico-typha:v3.26.4
+  type: image
+- source: quay.io/calico/typha:v3.27.0
+  target: registry.suse.com/rancher/charts/mirrored-calico-typha:v3.27.0
+  type: image
+- source: quay.io/calico/typha:v3.27.2
+  target: registry.suse.com/rancher/charts/mirrored-calico-typha:v3.27.2
+  type: image
+- source: quay.io/calico/typha:v3.27.3
+  target: registry.suse.com/rancher/charts/mirrored-calico-typha:v3.27.3
+  type: image
+- source: quay.io/calico/typha:v3.27.4
+  target: registry.suse.com/rancher/charts/mirrored-calico-typha:v3.27.4
+  type: image
+- source: quay.io/calico/typha:v3.28.0
+  target: registry.suse.com/rancher/charts/mirrored-calico-typha:v3.28.0
+  type: image
+- source: quay.io/calico/typha:v3.28.1
+  target: registry.suse.com/rancher/charts/mirrored-calico-typha:v3.28.1
+  type: image
+- source: quay.io/calico/typha:v3.28.2
+  target: registry.suse.com/rancher/charts/mirrored-calico-typha:v3.28.2
+  type: image
+- source: quay.io/calico/typha:v3.29.0
+  target: registry.suse.com/rancher/charts/mirrored-calico-typha:v3.29.0
+  type: image
+- source: quay.io/calico/typha:v3.29.1
+  target: registry.suse.com/rancher/charts/mirrored-calico-typha:v3.29.1
+  type: image
+- source: quay.io/calico/typha:v3.29.2
+  target: registry.suse.com/rancher/charts/mirrored-calico-typha:v3.29.2
+  type: image
+- source: quay.io/calico/typha:v3.29.3
+  target: registry.suse.com/rancher/charts/mirrored-calico-typha:v3.29.3
+  type: image
+- source: quay.io/calico/typha:v3.30.0
+  target: registry.suse.com/rancher/charts/mirrored-calico-typha:v3.30.0
+  type: image
+- source: quay.io/calico/typha:v3.30.1
+  target: registry.suse.com/rancher/charts/mirrored-calico-typha:v3.30.1
+  type: image
+- source: quay.io/calico/typha:v3.30.2
+  target: registry.suse.com/rancher/charts/mirrored-calico-typha:v3.30.2
+  type: image
+- source: quay.io/calico/typha:v3.30.3
+  target: registry.suse.com/rancher/charts/mirrored-calico-typha:v3.30.3
+  type: image
+- source: quay.io/calico/typha:v3.18.1
   target: stgregistry.suse.com/rancher/mirrored-calico-typha:v3.18.1
   type: image
 - source: quay.io/calico/typha:v3.19.1
@@ -13466,6 +22303,123 @@ sync:
 - source: quay.io/calico/typha:v3.30.3
   target: stgregistry.suse.com/rancher/mirrored-calico-typha:v3.30.3
   type: image
+- source: quay.io/calico/typha:v3.18.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-typha:v3.18.1
+  type: image
+- source: quay.io/calico/typha:v3.19.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-typha:v3.19.1
+  type: image
+- source: quay.io/calico/typha:v3.19.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-typha:v3.19.2
+  type: image
+- source: quay.io/calico/typha:v3.20.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-typha:v3.20.1
+  type: image
+- source: quay.io/calico/typha:v3.20.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-typha:v3.20.2
+  type: image
+- source: quay.io/calico/typha:v3.21.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-typha:v3.21.1
+  type: image
+- source: quay.io/calico/typha:v3.21.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-typha:v3.21.2
+  type: image
+- source: quay.io/calico/typha:v3.21.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-typha:v3.21.4
+  type: image
+- source: quay.io/calico/typha:v3.21.5
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-typha:v3.21.5
+  type: image
+- source: quay.io/calico/typha:v3.22.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-typha:v3.22.0
+  type: image
+- source: quay.io/calico/typha:v3.22.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-typha:v3.22.1
+  type: image
+- source: quay.io/calico/typha:v3.22.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-typha:v3.22.2
+  type: image
+- source: quay.io/calico/typha:v3.22.5
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-typha:v3.22.5
+  type: image
+- source: quay.io/calico/typha:v3.23.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-typha:v3.23.0
+  type: image
+- source: quay.io/calico/typha:v3.23.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-typha:v3.23.1
+  type: image
+- source: quay.io/calico/typha:v3.23.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-typha:v3.23.3
+  type: image
+- source: quay.io/calico/typha:v3.24.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-typha:v3.24.1
+  type: image
+- source: quay.io/calico/typha:v3.24.5
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-typha:v3.24.5
+  type: image
+- source: quay.io/calico/typha:v3.25.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-typha:v3.25.0
+  type: image
+- source: quay.io/calico/typha:v3.25.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-typha:v3.25.2
+  type: image
+- source: quay.io/calico/typha:v3.26.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-typha:v3.26.1
+  type: image
+- source: quay.io/calico/typha:v3.26.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-typha:v3.26.2
+  type: image
+- source: quay.io/calico/typha:v3.26.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-typha:v3.26.3
+  type: image
+- source: quay.io/calico/typha:v3.26.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-typha:v3.26.4
+  type: image
+- source: quay.io/calico/typha:v3.27.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-typha:v3.27.0
+  type: image
+- source: quay.io/calico/typha:v3.27.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-typha:v3.27.2
+  type: image
+- source: quay.io/calico/typha:v3.27.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-typha:v3.27.3
+  type: image
+- source: quay.io/calico/typha:v3.27.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-typha:v3.27.4
+  type: image
+- source: quay.io/calico/typha:v3.28.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-typha:v3.28.0
+  type: image
+- source: quay.io/calico/typha:v3.28.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-typha:v3.28.1
+  type: image
+- source: quay.io/calico/typha:v3.28.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-typha:v3.28.2
+  type: image
+- source: quay.io/calico/typha:v3.29.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-typha:v3.29.0
+  type: image
+- source: quay.io/calico/typha:v3.29.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-typha:v3.29.1
+  type: image
+- source: quay.io/calico/typha:v3.29.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-typha:v3.29.2
+  type: image
+- source: quay.io/calico/typha:v3.29.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-typha:v3.29.3
+  type: image
+- source: quay.io/calico/typha:v3.30.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-typha:v3.30.0
+  type: image
+- source: quay.io/calico/typha:v3.30.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-typha:v3.30.1
+  type: image
+- source: quay.io/calico/typha:v3.30.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-typha:v3.30.2
+  type: image
+- source: quay.io/calico/typha:v3.30.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-typha:v3.30.3
+  type: image
 - source: quay.io/calico/whisker:v3.30.0
   target: docker.io/rancher/mirrored-calico-whisker:v3.30.0
   type: image
@@ -13491,6 +22445,18 @@ sync:
   target: registry.suse.com/rancher/mirrored-calico-whisker:v3.30.3
   type: image
 - source: quay.io/calico/whisker:v3.30.0
+  target: registry.suse.com/rancher/charts/mirrored-calico-whisker:v3.30.0
+  type: image
+- source: quay.io/calico/whisker:v3.30.1
+  target: registry.suse.com/rancher/charts/mirrored-calico-whisker:v3.30.1
+  type: image
+- source: quay.io/calico/whisker:v3.30.2
+  target: registry.suse.com/rancher/charts/mirrored-calico-whisker:v3.30.2
+  type: image
+- source: quay.io/calico/whisker:v3.30.3
+  target: registry.suse.com/rancher/charts/mirrored-calico-whisker:v3.30.3
+  type: image
+- source: quay.io/calico/whisker:v3.30.0
   target: stgregistry.suse.com/rancher/mirrored-calico-whisker:v3.30.0
   type: image
 - source: quay.io/calico/whisker:v3.30.1
@@ -13501,6 +22467,18 @@ sync:
   type: image
 - source: quay.io/calico/whisker:v3.30.3
   target: stgregistry.suse.com/rancher/mirrored-calico-whisker:v3.30.3
+  type: image
+- source: quay.io/calico/whisker:v3.30.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-whisker:v3.30.0
+  type: image
+- source: quay.io/calico/whisker:v3.30.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-whisker:v3.30.1
+  type: image
+- source: quay.io/calico/whisker:v3.30.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-whisker:v3.30.2
+  type: image
+- source: quay.io/calico/whisker:v3.30.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-whisker:v3.30.3
   type: image
 - source: quay.io/calico/whisker-backend:v3.30.0
   target: docker.io/rancher/mirrored-calico-whisker-backend:v3.30.0
@@ -13527,6 +22505,18 @@ sync:
   target: registry.suse.com/rancher/mirrored-calico-whisker-backend:v3.30.3
   type: image
 - source: quay.io/calico/whisker-backend:v3.30.0
+  target: registry.suse.com/rancher/charts/mirrored-calico-whisker-backend:v3.30.0
+  type: image
+- source: quay.io/calico/whisker-backend:v3.30.1
+  target: registry.suse.com/rancher/charts/mirrored-calico-whisker-backend:v3.30.1
+  type: image
+- source: quay.io/calico/whisker-backend:v3.30.2
+  target: registry.suse.com/rancher/charts/mirrored-calico-whisker-backend:v3.30.2
+  type: image
+- source: quay.io/calico/whisker-backend:v3.30.3
+  target: registry.suse.com/rancher/charts/mirrored-calico-whisker-backend:v3.30.3
+  type: image
+- source: quay.io/calico/whisker-backend:v3.30.0
   target: stgregistry.suse.com/rancher/mirrored-calico-whisker-backend:v3.30.0
   type: image
 - source: quay.io/calico/whisker-backend:v3.30.1
@@ -13537,6 +22527,18 @@ sync:
   type: image
 - source: quay.io/calico/whisker-backend:v3.30.3
   target: stgregistry.suse.com/rancher/mirrored-calico-whisker-backend:v3.30.3
+  type: image
+- source: quay.io/calico/whisker-backend:v3.30.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-whisker-backend:v3.30.0
+  type: image
+- source: quay.io/calico/whisker-backend:v3.30.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-whisker-backend:v3.30.1
+  type: image
+- source: quay.io/calico/whisker-backend:v3.30.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-whisker-backend:v3.30.2
+  type: image
+- source: quay.io/calico/whisker-backend:v3.30.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-whisker-backend:v3.30.3
   type: image
 - source: quay.io/cilium/certgen:v0.1.11
   target: docker.io/rancher/mirrored-cilium-certgen:v0.1.11
@@ -13587,6 +22589,30 @@ sync:
   target: registry.suse.com/rancher/mirrored-cilium-certgen:v0.2.4
   type: image
 - source: quay.io/cilium/certgen:v0.1.11
+  target: registry.suse.com/rancher/charts/mirrored-cilium-certgen:v0.1.11
+  type: image
+- source: quay.io/cilium/certgen:v0.1.12
+  target: registry.suse.com/rancher/charts/mirrored-cilium-certgen:v0.1.12
+  type: image
+- source: quay.io/cilium/certgen:v0.1.13
+  target: registry.suse.com/rancher/charts/mirrored-cilium-certgen:v0.1.13
+  type: image
+- source: quay.io/cilium/certgen:v0.1.8
+  target: registry.suse.com/rancher/charts/mirrored-cilium-certgen:v0.1.8
+  type: image
+- source: quay.io/cilium/certgen:v0.1.9
+  target: registry.suse.com/rancher/charts/mirrored-cilium-certgen:v0.1.9
+  type: image
+- source: quay.io/cilium/certgen:v0.2.0
+  target: registry.suse.com/rancher/charts/mirrored-cilium-certgen:v0.2.0
+  type: image
+- source: quay.io/cilium/certgen:v0.2.1
+  target: registry.suse.com/rancher/charts/mirrored-cilium-certgen:v0.2.1
+  type: image
+- source: quay.io/cilium/certgen:v0.2.4
+  target: registry.suse.com/rancher/charts/mirrored-cilium-certgen:v0.2.4
+  type: image
+- source: quay.io/cilium/certgen:v0.1.11
   target: stgregistry.suse.com/rancher/mirrored-cilium-certgen:v0.1.11
   type: image
 - source: quay.io/cilium/certgen:v0.1.12
@@ -13609,6 +22635,30 @@ sync:
   type: image
 - source: quay.io/cilium/certgen:v0.2.4
   target: stgregistry.suse.com/rancher/mirrored-cilium-certgen:v0.2.4
+  type: image
+- source: quay.io/cilium/certgen:v0.1.11
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-certgen:v0.1.11
+  type: image
+- source: quay.io/cilium/certgen:v0.1.12
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-certgen:v0.1.12
+  type: image
+- source: quay.io/cilium/certgen:v0.1.13
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-certgen:v0.1.13
+  type: image
+- source: quay.io/cilium/certgen:v0.1.8
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-certgen:v0.1.8
+  type: image
+- source: quay.io/cilium/certgen:v0.1.9
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-certgen:v0.1.9
+  type: image
+- source: quay.io/cilium/certgen:v0.2.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-certgen:v0.2.0
+  type: image
+- source: quay.io/cilium/certgen:v0.2.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-certgen:v0.2.1
+  type: image
+- source: quay.io/cilium/certgen:v0.2.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-certgen:v0.2.4
   type: image
 - source: quay.io/cilium/cilium:v1.10.4
   target: docker.io/rancher/mirrored-cilium-cilium:v1.10.4
@@ -13905,6 +22955,153 @@ sync:
   target: registry.suse.com/rancher/mirrored-cilium-cilium:v1.9.8
   type: image
 - source: quay.io/cilium/cilium:v1.10.4
+  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.10.4
+  type: image
+- source: quay.io/cilium/cilium:v1.10.7
+  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.10.7
+  type: image
+- source: quay.io/cilium/cilium:v1.11.0
+  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.11.0
+  type: image
+- source: quay.io/cilium/cilium:v1.11.1
+  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.11.1
+  type: image
+- source: quay.io/cilium/cilium:v1.11.2
+  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.11.2
+  type: image
+- source: quay.io/cilium/cilium:v1.11.4
+  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.11.4
+  type: image
+- source: quay.io/cilium/cilium:v1.11.5
+  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.11.5
+  type: image
+- source: quay.io/cilium/cilium:v1.12.0
+  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.12.0
+  type: image
+- source: quay.io/cilium/cilium:v1.12.1
+  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.12.1
+  type: image
+- source: quay.io/cilium/cilium:v1.12.3
+  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.12.3
+  type: image
+- source: quay.io/cilium/cilium:v1.12.4
+  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.12.4
+  type: image
+- source: quay.io/cilium/cilium:v1.12.5
+  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.12.5
+  type: image
+- source: quay.io/cilium/cilium:v1.13.0
+  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.13.0
+  type: image
+- source: quay.io/cilium/cilium:v1.13.2
+  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.13.2
+  type: image
+- source: quay.io/cilium/cilium:v1.13.4
+  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.13.4
+  type: image
+- source: quay.io/cilium/cilium:v1.14.0
+  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.14.0
+  type: image
+- source: quay.io/cilium/cilium:v1.14.1
+  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.14.1
+  type: image
+- source: quay.io/cilium/cilium:v1.14.2
+  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.14.2
+  type: image
+- source: quay.io/cilium/cilium:v1.14.3
+  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.14.3
+  type: image
+- source: quay.io/cilium/cilium:v1.14.4
+  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.14.4
+  type: image
+- source: quay.io/cilium/cilium:v1.14.5
+  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.14.5
+  type: image
+- source: quay.io/cilium/cilium:v1.15.0
+  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.15.0
+  type: image
+- source: quay.io/cilium/cilium:v1.15.1
+  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.15.1
+  type: image
+- source: quay.io/cilium/cilium:v1.15.3
+  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.15.3
+  type: image
+- source: quay.io/cilium/cilium:v1.15.4
+  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.15.4
+  type: image
+- source: quay.io/cilium/cilium:v1.15.5
+  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.15.5
+  type: image
+- source: quay.io/cilium/cilium:v1.15.6
+  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.15.6
+  type: image
+- source: quay.io/cilium/cilium:v1.15.7
+  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.15.7
+  type: image
+- source: quay.io/cilium/cilium:v1.16.0
+  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.16.0
+  type: image
+- source: quay.io/cilium/cilium:v1.16.1
+  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.16.1
+  type: image
+- source: quay.io/cilium/cilium:v1.16.2
+  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.16.2
+  type: image
+- source: quay.io/cilium/cilium:v1.16.3
+  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.16.3
+  type: image
+- source: quay.io/cilium/cilium:v1.16.4
+  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.16.4
+  type: image
+- source: quay.io/cilium/cilium:v1.16.5
+  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.16.5
+  type: image
+- source: quay.io/cilium/cilium:v1.16.6
+  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.16.6
+  type: image
+- source: quay.io/cilium/cilium:v1.17.0
+  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.17.0
+  type: image
+- source: quay.io/cilium/cilium:v1.17.1
+  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.17.1
+  type: image
+- source: quay.io/cilium/cilium:v1.17.2
+  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.17.2
+  type: image
+- source: quay.io/cilium/cilium:v1.17.3
+  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.17.3
+  type: image
+- source: quay.io/cilium/cilium:v1.17.4
+  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.17.4
+  type: image
+- source: quay.io/cilium/cilium:v1.17.5
+  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.17.5
+  type: image
+- source: quay.io/cilium/cilium:v1.17.6
+  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.17.6
+  type: image
+- source: quay.io/cilium/cilium:v1.18.0
+  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.18.0
+  type: image
+- source: quay.io/cilium/cilium:v1.18.1
+  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.18.1
+  type: image
+- source: quay.io/cilium/cilium:v1.18.2
+  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.18.2
+  type: image
+- source: quay.io/cilium/cilium:v1.9.12
+  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.9.12
+  type: image
+- source: quay.io/cilium/cilium:v1.9.4
+  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.9.4
+  type: image
+- source: quay.io/cilium/cilium:v1.9.6
+  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.9.6
+  type: image
+- source: quay.io/cilium/cilium:v1.9.8
+  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.9.8
+  type: image
+- source: quay.io/cilium/cilium:v1.10.4
   target: stgregistry.suse.com/rancher/mirrored-cilium-cilium:v1.10.4
   type: image
 - source: quay.io/cilium/cilium:v1.10.7
@@ -14050,6 +23247,153 @@ sync:
   type: image
 - source: quay.io/cilium/cilium:v1.9.8
   target: stgregistry.suse.com/rancher/mirrored-cilium-cilium:v1.9.8
+  type: image
+- source: quay.io/cilium/cilium:v1.10.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.10.4
+  type: image
+- source: quay.io/cilium/cilium:v1.10.7
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.10.7
+  type: image
+- source: quay.io/cilium/cilium:v1.11.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.11.0
+  type: image
+- source: quay.io/cilium/cilium:v1.11.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.11.1
+  type: image
+- source: quay.io/cilium/cilium:v1.11.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.11.2
+  type: image
+- source: quay.io/cilium/cilium:v1.11.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.11.4
+  type: image
+- source: quay.io/cilium/cilium:v1.11.5
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.11.5
+  type: image
+- source: quay.io/cilium/cilium:v1.12.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.12.0
+  type: image
+- source: quay.io/cilium/cilium:v1.12.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.12.1
+  type: image
+- source: quay.io/cilium/cilium:v1.12.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.12.3
+  type: image
+- source: quay.io/cilium/cilium:v1.12.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.12.4
+  type: image
+- source: quay.io/cilium/cilium:v1.12.5
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.12.5
+  type: image
+- source: quay.io/cilium/cilium:v1.13.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.13.0
+  type: image
+- source: quay.io/cilium/cilium:v1.13.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.13.2
+  type: image
+- source: quay.io/cilium/cilium:v1.13.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.13.4
+  type: image
+- source: quay.io/cilium/cilium:v1.14.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.14.0
+  type: image
+- source: quay.io/cilium/cilium:v1.14.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.14.1
+  type: image
+- source: quay.io/cilium/cilium:v1.14.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.14.2
+  type: image
+- source: quay.io/cilium/cilium:v1.14.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.14.3
+  type: image
+- source: quay.io/cilium/cilium:v1.14.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.14.4
+  type: image
+- source: quay.io/cilium/cilium:v1.14.5
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.14.5
+  type: image
+- source: quay.io/cilium/cilium:v1.15.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.15.0
+  type: image
+- source: quay.io/cilium/cilium:v1.15.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.15.1
+  type: image
+- source: quay.io/cilium/cilium:v1.15.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.15.3
+  type: image
+- source: quay.io/cilium/cilium:v1.15.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.15.4
+  type: image
+- source: quay.io/cilium/cilium:v1.15.5
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.15.5
+  type: image
+- source: quay.io/cilium/cilium:v1.15.6
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.15.6
+  type: image
+- source: quay.io/cilium/cilium:v1.15.7
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.15.7
+  type: image
+- source: quay.io/cilium/cilium:v1.16.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.16.0
+  type: image
+- source: quay.io/cilium/cilium:v1.16.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.16.1
+  type: image
+- source: quay.io/cilium/cilium:v1.16.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.16.2
+  type: image
+- source: quay.io/cilium/cilium:v1.16.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.16.3
+  type: image
+- source: quay.io/cilium/cilium:v1.16.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.16.4
+  type: image
+- source: quay.io/cilium/cilium:v1.16.5
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.16.5
+  type: image
+- source: quay.io/cilium/cilium:v1.16.6
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.16.6
+  type: image
+- source: quay.io/cilium/cilium:v1.17.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.17.0
+  type: image
+- source: quay.io/cilium/cilium:v1.17.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.17.1
+  type: image
+- source: quay.io/cilium/cilium:v1.17.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.17.2
+  type: image
+- source: quay.io/cilium/cilium:v1.17.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.17.3
+  type: image
+- source: quay.io/cilium/cilium:v1.17.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.17.4
+  type: image
+- source: quay.io/cilium/cilium:v1.17.5
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.17.5
+  type: image
+- source: quay.io/cilium/cilium:v1.17.6
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.17.6
+  type: image
+- source: quay.io/cilium/cilium:v1.18.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.18.0
+  type: image
+- source: quay.io/cilium/cilium:v1.18.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.18.1
+  type: image
+- source: quay.io/cilium/cilium:v1.18.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.18.2
+  type: image
+- source: quay.io/cilium/cilium:v1.9.12
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.9.12
+  type: image
+- source: quay.io/cilium/cilium:v1.9.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.9.4
+  type: image
+- source: quay.io/cilium/cilium:v1.9.6
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.9.6
+  type: image
+- source: quay.io/cilium/cilium:v1.9.8
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.9.8
   type: image
 - source: quay.io/cilium/cilium-envoy:v1.25.10-f71a313bd0daee41470af31ce6ea20c750fe35dd
   target: docker.io/rancher/mirrored-cilium-cilium-envoy:v1.25.10-f71a313bd0daee41470af31ce6ea20c750fe35dd
@@ -14220,6 +23564,90 @@ sync:
   target: registry.suse.com/rancher/mirrored-cilium-cilium-envoy:v1.34.7-1757592137-1a52bb680a956879722f48c591a2ca90f7791324
   type: image
 - source: quay.io/cilium/cilium-envoy:v1.25.10-f71a313bd0daee41470af31ce6ea20c750fe35dd
+  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium-envoy:v1.25.10-f71a313bd0daee41470af31ce6ea20c750fe35dd
+  type: image
+- source: quay.io/cilium/cilium-envoy:v1.25.9-e198a2824d309024cb91fb6a984445e73033291d
+  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium-envoy:v1.25.9-e198a2824d309024cb91fb6a984445e73033291d
+  type: image
+- source: quay.io/cilium/cilium-envoy:v1.25.9-f039e2bd380b7eef2f2feea5750676bb36133699
+  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium-envoy:v1.25.9-f039e2bd380b7eef2f2feea5750676bb36133699
+  type: image
+- source: quay.io/cilium/cilium-envoy:v1.26.4-c0f770db7b6accadd2c7171af9ad00370a7d8693
+  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium-envoy:v1.26.4-c0f770db7b6accadd2c7171af9ad00370a7d8693
+  type: image
+- source: quay.io/cilium/cilium-envoy:v1.26.6-ad82c7c56e88989992fd25d8d67747de865c823b
+  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium-envoy:v1.26.6-ad82c7c56e88989992fd25d8d67747de865c823b
+  type: image
+- source: quay.io/cilium/cilium-envoy:v1.26.6-ff0d5d3f77d610040e93c7c7a430d61a0c0b90c1
+  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium-envoy:v1.26.6-ff0d5d3f77d610040e93c7c7a430d61a0c0b90c1
+  type: image
+- source: quay.io/cilium/cilium-envoy:v1.27.2-13f6142b9c02268b10d547c8b093ef16724538e3
+  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium-envoy:v1.27.2-13f6142b9c02268b10d547c8b093ef16724538e3
+  type: image
+- source: quay.io/cilium/cilium-envoy:v1.27.3-713b673cccf1af661efd75ca20532336517ddcb9
+  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium-envoy:v1.27.3-713b673cccf1af661efd75ca20532336517ddcb9
+  type: image
+- source: quay.io/cilium/cilium-envoy:v1.27.3-99c1c8f42c8de70fc8f6dd594f4a425cd38b6688
+  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium-envoy:v1.27.3-99c1c8f42c8de70fc8f6dd594f4a425cd38b6688
+  type: image
+- source: quay.io/cilium/cilium-envoy:v1.27.4-21905253931655328edaacf3cd16aeda73bbea2f
+  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium-envoy:v1.27.4-21905253931655328edaacf3cd16aeda73bbea2f
+  type: image
+- source: quay.io/cilium/cilium-envoy:v1.28.3-31ec52ec5f2e4d28a8e19a0bfb872fa48cf7a515
+  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium-envoy:v1.28.3-31ec52ec5f2e4d28a8e19a0bfb872fa48cf7a515
+  type: image
+- source: quay.io/cilium/cilium-envoy:v1.28.4-b35188ffa1bbe54d1720d2e392779f7a48e58f6b
+  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium-envoy:v1.28.4-b35188ffa1bbe54d1720d2e392779f7a48e58f6b
+  type: image
+- source: quay.io/cilium/cilium-envoy:v1.29.7-39a2a56bbd5b3a591f69dbca51d3e30ef97e0e51
+  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium-envoy:v1.29.7-39a2a56bbd5b3a591f69dbca51d3e30ef97e0e51
+  type: image
+- source: quay.io/cilium/cilium-envoy:v1.29.9-1726784081-a90146d13b4cd7d168d573396ccf2b3db5a3b047
+  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium-envoy:v1.29.9-1726784081-a90146d13b4cd7d168d573396ccf2b3db5a3b047
+  type: image
+- source: quay.io/cilium/cilium-envoy:v1.29.9-1728346947-0d05e48bfbb8c4737ec40d5781d970a550ed2bbd
+  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium-envoy:v1.29.9-1728346947-0d05e48bfbb8c4737ec40d5781d970a550ed2bbd
+  type: image
+- source: quay.io/cilium/cilium-envoy:v1.30.7-1731393961-97edc2815e2c6a174d3d12e71731d54f5d32ea16
+  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium-envoy:v1.30.7-1731393961-97edc2815e2c6a174d3d12e71731d54f5d32ea16
+  type: image
+- source: quay.io/cilium/cilium-envoy:v1.30.8-1733837904-eaae5aca0fb988583e5617170a65ac5aa51c0aa8
+  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium-envoy:v1.30.8-1733837904-eaae5aca0fb988583e5617170a65ac5aa51c0aa8
+  type: image
+- source: quay.io/cilium/cilium-envoy:v1.30.9-1737073743-40a016d11c0d863b772961ed0168eea6fe6b10a5
+  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium-envoy:v1.30.9-1737073743-40a016d11c0d863b772961ed0168eea6fe6b10a5
+  type: image
+- source: quay.io/cilium/cilium-envoy:v1.31.5-1737535524-fe8efeb16a7d233bffd05af9ea53599340d3f18e
+  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium-envoy:v1.31.5-1737535524-fe8efeb16a7d233bffd05af9ea53599340d3f18e
+  type: image
+- source: quay.io/cilium/cilium-envoy:v1.31.5-1739264036-958bef243c6c66fcfd73ca319f2eb49fff1eb2ae
+  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium-envoy:v1.31.5-1739264036-958bef243c6c66fcfd73ca319f2eb49fff1eb2ae
+  type: image
+- source: quay.io/cilium/cilium-envoy:v1.31.5-1741765102-efed3defcc70ab5b263a0fc44c93d316b846a211
+  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium-envoy:v1.31.5-1741765102-efed3defcc70ab5b263a0fc44c93d316b846a211
+  type: image
+- source: quay.io/cilium/cilium-envoy:v1.32.5-1744305768-f9ddca7dcd91f7ca25a505560e655c47d3dec2cf
+  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium-envoy:v1.32.5-1744305768-f9ddca7dcd91f7ca25a505560e655c47d3dec2cf
+  type: image
+- source: quay.io/cilium/cilium-envoy:v1.32.6-1746661844-0f602c28cb2aa57b29078195049fb257d5b5246c
+  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium-envoy:v1.32.6-1746661844-0f602c28cb2aa57b29078195049fb257d5b5246c
+  type: image
+- source: quay.io/cilium/cilium-envoy:v1.32.6-1749271279-0864395884b263913eac200ee2048fd985f8e626
+  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium-envoy:v1.32.6-1749271279-0864395884b263913eac200ee2048fd985f8e626
+  type: image
+- source: quay.io/cilium/cilium-envoy:v1.33.4-1752151664-7c2edb0b44cf95f326d628b837fcdd845102ba68
+  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium-envoy:v1.33.4-1752151664-7c2edb0b44cf95f326d628b837fcdd845102ba68
+  type: image
+- source: quay.io/cilium/cilium-envoy:v1.34.4-1753677767-266d5a01d1d55bd1d60148f991b98dac0390d363
+  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium-envoy:v1.34.4-1753677767-266d5a01d1d55bd1d60148f991b98dac0390d363
+  type: image
+- source: quay.io/cilium/cilium-envoy:v1.34.4-1754895458-68cffdfa568b6b226d70a7ef81fc65dda3b890bf
+  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium-envoy:v1.34.4-1754895458-68cffdfa568b6b226d70a7ef81fc65dda3b890bf
+  type: image
+- source: quay.io/cilium/cilium-envoy:v1.34.7-1757592137-1a52bb680a956879722f48c591a2ca90f7791324
+  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium-envoy:v1.34.7-1757592137-1a52bb680a956879722f48c591a2ca90f7791324
+  type: image
+- source: quay.io/cilium/cilium-envoy:v1.25.10-f71a313bd0daee41470af31ce6ea20c750fe35dd
   target: stgregistry.suse.com/rancher/mirrored-cilium-cilium-envoy:v1.25.10-f71a313bd0daee41470af31ce6ea20c750fe35dd
   type: image
 - source: quay.io/cilium/cilium-envoy:v1.25.9-e198a2824d309024cb91fb6a984445e73033291d
@@ -14303,6 +23731,90 @@ sync:
 - source: quay.io/cilium/cilium-envoy:v1.34.7-1757592137-1a52bb680a956879722f48c591a2ca90f7791324
   target: stgregistry.suse.com/rancher/mirrored-cilium-cilium-envoy:v1.34.7-1757592137-1a52bb680a956879722f48c591a2ca90f7791324
   type: image
+- source: quay.io/cilium/cilium-envoy:v1.25.10-f71a313bd0daee41470af31ce6ea20c750fe35dd
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium-envoy:v1.25.10-f71a313bd0daee41470af31ce6ea20c750fe35dd
+  type: image
+- source: quay.io/cilium/cilium-envoy:v1.25.9-e198a2824d309024cb91fb6a984445e73033291d
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium-envoy:v1.25.9-e198a2824d309024cb91fb6a984445e73033291d
+  type: image
+- source: quay.io/cilium/cilium-envoy:v1.25.9-f039e2bd380b7eef2f2feea5750676bb36133699
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium-envoy:v1.25.9-f039e2bd380b7eef2f2feea5750676bb36133699
+  type: image
+- source: quay.io/cilium/cilium-envoy:v1.26.4-c0f770db7b6accadd2c7171af9ad00370a7d8693
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium-envoy:v1.26.4-c0f770db7b6accadd2c7171af9ad00370a7d8693
+  type: image
+- source: quay.io/cilium/cilium-envoy:v1.26.6-ad82c7c56e88989992fd25d8d67747de865c823b
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium-envoy:v1.26.6-ad82c7c56e88989992fd25d8d67747de865c823b
+  type: image
+- source: quay.io/cilium/cilium-envoy:v1.26.6-ff0d5d3f77d610040e93c7c7a430d61a0c0b90c1
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium-envoy:v1.26.6-ff0d5d3f77d610040e93c7c7a430d61a0c0b90c1
+  type: image
+- source: quay.io/cilium/cilium-envoy:v1.27.2-13f6142b9c02268b10d547c8b093ef16724538e3
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium-envoy:v1.27.2-13f6142b9c02268b10d547c8b093ef16724538e3
+  type: image
+- source: quay.io/cilium/cilium-envoy:v1.27.3-713b673cccf1af661efd75ca20532336517ddcb9
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium-envoy:v1.27.3-713b673cccf1af661efd75ca20532336517ddcb9
+  type: image
+- source: quay.io/cilium/cilium-envoy:v1.27.3-99c1c8f42c8de70fc8f6dd594f4a425cd38b6688
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium-envoy:v1.27.3-99c1c8f42c8de70fc8f6dd594f4a425cd38b6688
+  type: image
+- source: quay.io/cilium/cilium-envoy:v1.27.4-21905253931655328edaacf3cd16aeda73bbea2f
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium-envoy:v1.27.4-21905253931655328edaacf3cd16aeda73bbea2f
+  type: image
+- source: quay.io/cilium/cilium-envoy:v1.28.3-31ec52ec5f2e4d28a8e19a0bfb872fa48cf7a515
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium-envoy:v1.28.3-31ec52ec5f2e4d28a8e19a0bfb872fa48cf7a515
+  type: image
+- source: quay.io/cilium/cilium-envoy:v1.28.4-b35188ffa1bbe54d1720d2e392779f7a48e58f6b
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium-envoy:v1.28.4-b35188ffa1bbe54d1720d2e392779f7a48e58f6b
+  type: image
+- source: quay.io/cilium/cilium-envoy:v1.29.7-39a2a56bbd5b3a591f69dbca51d3e30ef97e0e51
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium-envoy:v1.29.7-39a2a56bbd5b3a591f69dbca51d3e30ef97e0e51
+  type: image
+- source: quay.io/cilium/cilium-envoy:v1.29.9-1726784081-a90146d13b4cd7d168d573396ccf2b3db5a3b047
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium-envoy:v1.29.9-1726784081-a90146d13b4cd7d168d573396ccf2b3db5a3b047
+  type: image
+- source: quay.io/cilium/cilium-envoy:v1.29.9-1728346947-0d05e48bfbb8c4737ec40d5781d970a550ed2bbd
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium-envoy:v1.29.9-1728346947-0d05e48bfbb8c4737ec40d5781d970a550ed2bbd
+  type: image
+- source: quay.io/cilium/cilium-envoy:v1.30.7-1731393961-97edc2815e2c6a174d3d12e71731d54f5d32ea16
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium-envoy:v1.30.7-1731393961-97edc2815e2c6a174d3d12e71731d54f5d32ea16
+  type: image
+- source: quay.io/cilium/cilium-envoy:v1.30.8-1733837904-eaae5aca0fb988583e5617170a65ac5aa51c0aa8
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium-envoy:v1.30.8-1733837904-eaae5aca0fb988583e5617170a65ac5aa51c0aa8
+  type: image
+- source: quay.io/cilium/cilium-envoy:v1.30.9-1737073743-40a016d11c0d863b772961ed0168eea6fe6b10a5
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium-envoy:v1.30.9-1737073743-40a016d11c0d863b772961ed0168eea6fe6b10a5
+  type: image
+- source: quay.io/cilium/cilium-envoy:v1.31.5-1737535524-fe8efeb16a7d233bffd05af9ea53599340d3f18e
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium-envoy:v1.31.5-1737535524-fe8efeb16a7d233bffd05af9ea53599340d3f18e
+  type: image
+- source: quay.io/cilium/cilium-envoy:v1.31.5-1739264036-958bef243c6c66fcfd73ca319f2eb49fff1eb2ae
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium-envoy:v1.31.5-1739264036-958bef243c6c66fcfd73ca319f2eb49fff1eb2ae
+  type: image
+- source: quay.io/cilium/cilium-envoy:v1.31.5-1741765102-efed3defcc70ab5b263a0fc44c93d316b846a211
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium-envoy:v1.31.5-1741765102-efed3defcc70ab5b263a0fc44c93d316b846a211
+  type: image
+- source: quay.io/cilium/cilium-envoy:v1.32.5-1744305768-f9ddca7dcd91f7ca25a505560e655c47d3dec2cf
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium-envoy:v1.32.5-1744305768-f9ddca7dcd91f7ca25a505560e655c47d3dec2cf
+  type: image
+- source: quay.io/cilium/cilium-envoy:v1.32.6-1746661844-0f602c28cb2aa57b29078195049fb257d5b5246c
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium-envoy:v1.32.6-1746661844-0f602c28cb2aa57b29078195049fb257d5b5246c
+  type: image
+- source: quay.io/cilium/cilium-envoy:v1.32.6-1749271279-0864395884b263913eac200ee2048fd985f8e626
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium-envoy:v1.32.6-1749271279-0864395884b263913eac200ee2048fd985f8e626
+  type: image
+- source: quay.io/cilium/cilium-envoy:v1.33.4-1752151664-7c2edb0b44cf95f326d628b837fcdd845102ba68
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium-envoy:v1.33.4-1752151664-7c2edb0b44cf95f326d628b837fcdd845102ba68
+  type: image
+- source: quay.io/cilium/cilium-envoy:v1.34.4-1753677767-266d5a01d1d55bd1d60148f991b98dac0390d363
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium-envoy:v1.34.4-1753677767-266d5a01d1d55bd1d60148f991b98dac0390d363
+  type: image
+- source: quay.io/cilium/cilium-envoy:v1.34.4-1754895458-68cffdfa568b6b226d70a7ef81fc65dda3b890bf
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium-envoy:v1.34.4-1754895458-68cffdfa568b6b226d70a7ef81fc65dda3b890bf
+  type: image
+- source: quay.io/cilium/cilium-envoy:v1.34.7-1757592137-1a52bb680a956879722f48c591a2ca90f7791324
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium-envoy:v1.34.7-1757592137-1a52bb680a956879722f48c591a2ca90f7791324
+  type: image
 - source: quay.io/cilium/cilium-etcd-operator:v2.0.7
   target: docker.io/rancher/mirrored-cilium-cilium-etcd-operator:v2.0.7
   type: image
@@ -14310,7 +23822,13 @@ sync:
   target: registry.suse.com/rancher/mirrored-cilium-cilium-etcd-operator:v2.0.7
   type: image
 - source: quay.io/cilium/cilium-etcd-operator:v2.0.7
+  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium-etcd-operator:v2.0.7
+  type: image
+- source: quay.io/cilium/cilium-etcd-operator:v2.0.7
   target: stgregistry.suse.com/rancher/mirrored-cilium-cilium-etcd-operator:v2.0.7
+  type: image
+- source: quay.io/cilium/cilium-etcd-operator:v2.0.7
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium-etcd-operator:v2.0.7
   type: image
 - source: quay.io/cilium/clustermesh-apiserver:v1.12.4
   target: docker.io/rancher/mirrored-cilium-clustermesh-apiserver:v1.12.4
@@ -14523,6 +24041,111 @@ sync:
   target: registry.suse.com/rancher/mirrored-cilium-clustermesh-apiserver:v1.18.2
   type: image
 - source: quay.io/cilium/clustermesh-apiserver:v1.12.4
+  target: registry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.12.4
+  type: image
+- source: quay.io/cilium/clustermesh-apiserver:v1.12.5
+  target: registry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.12.5
+  type: image
+- source: quay.io/cilium/clustermesh-apiserver:v1.13.0
+  target: registry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.13.0
+  type: image
+- source: quay.io/cilium/clustermesh-apiserver:v1.13.2
+  target: registry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.13.2
+  type: image
+- source: quay.io/cilium/clustermesh-apiserver:v1.13.4
+  target: registry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.13.4
+  type: image
+- source: quay.io/cilium/clustermesh-apiserver:v1.14.0
+  target: registry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.14.0
+  type: image
+- source: quay.io/cilium/clustermesh-apiserver:v1.14.1
+  target: registry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.14.1
+  type: image
+- source: quay.io/cilium/clustermesh-apiserver:v1.14.2
+  target: registry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.14.2
+  type: image
+- source: quay.io/cilium/clustermesh-apiserver:v1.14.3
+  target: registry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.14.3
+  type: image
+- source: quay.io/cilium/clustermesh-apiserver:v1.14.4
+  target: registry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.14.4
+  type: image
+- source: quay.io/cilium/clustermesh-apiserver:v1.14.5
+  target: registry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.14.5
+  type: image
+- source: quay.io/cilium/clustermesh-apiserver:v1.15.0
+  target: registry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.15.0
+  type: image
+- source: quay.io/cilium/clustermesh-apiserver:v1.15.1
+  target: registry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.15.1
+  type: image
+- source: quay.io/cilium/clustermesh-apiserver:v1.15.3
+  target: registry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.15.3
+  type: image
+- source: quay.io/cilium/clustermesh-apiserver:v1.15.4
+  target: registry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.15.4
+  type: image
+- source: quay.io/cilium/clustermesh-apiserver:v1.15.5
+  target: registry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.15.5
+  type: image
+- source: quay.io/cilium/clustermesh-apiserver:v1.15.6
+  target: registry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.15.6
+  type: image
+- source: quay.io/cilium/clustermesh-apiserver:v1.15.7
+  target: registry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.15.7
+  type: image
+- source: quay.io/cilium/clustermesh-apiserver:v1.16.0
+  target: registry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.16.0
+  type: image
+- source: quay.io/cilium/clustermesh-apiserver:v1.16.1
+  target: registry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.16.1
+  type: image
+- source: quay.io/cilium/clustermesh-apiserver:v1.16.2
+  target: registry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.16.2
+  type: image
+- source: quay.io/cilium/clustermesh-apiserver:v1.16.3
+  target: registry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.16.3
+  type: image
+- source: quay.io/cilium/clustermesh-apiserver:v1.16.4
+  target: registry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.16.4
+  type: image
+- source: quay.io/cilium/clustermesh-apiserver:v1.16.5
+  target: registry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.16.5
+  type: image
+- source: quay.io/cilium/clustermesh-apiserver:v1.16.6
+  target: registry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.16.6
+  type: image
+- source: quay.io/cilium/clustermesh-apiserver:v1.17.0
+  target: registry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.17.0
+  type: image
+- source: quay.io/cilium/clustermesh-apiserver:v1.17.1
+  target: registry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.17.1
+  type: image
+- source: quay.io/cilium/clustermesh-apiserver:v1.17.2
+  target: registry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.17.2
+  type: image
+- source: quay.io/cilium/clustermesh-apiserver:v1.17.3
+  target: registry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.17.3
+  type: image
+- source: quay.io/cilium/clustermesh-apiserver:v1.17.4
+  target: registry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.17.4
+  type: image
+- source: quay.io/cilium/clustermesh-apiserver:v1.17.5
+  target: registry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.17.5
+  type: image
+- source: quay.io/cilium/clustermesh-apiserver:v1.17.6
+  target: registry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.17.6
+  type: image
+- source: quay.io/cilium/clustermesh-apiserver:v1.18.0
+  target: registry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.18.0
+  type: image
+- source: quay.io/cilium/clustermesh-apiserver:v1.18.1
+  target: registry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.18.1
+  type: image
+- source: quay.io/cilium/clustermesh-apiserver:v1.18.2
+  target: registry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.18.2
+  type: image
+- source: quay.io/cilium/clustermesh-apiserver:v1.12.4
   target: stgregistry.suse.com/rancher/mirrored-cilium-clustermesh-apiserver:v1.12.4
   type: image
 - source: quay.io/cilium/clustermesh-apiserver:v1.12.5
@@ -14626,6 +24249,111 @@ sync:
   type: image
 - source: quay.io/cilium/clustermesh-apiserver:v1.18.2
   target: stgregistry.suse.com/rancher/mirrored-cilium-clustermesh-apiserver:v1.18.2
+  type: image
+- source: quay.io/cilium/clustermesh-apiserver:v1.12.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.12.4
+  type: image
+- source: quay.io/cilium/clustermesh-apiserver:v1.12.5
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.12.5
+  type: image
+- source: quay.io/cilium/clustermesh-apiserver:v1.13.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.13.0
+  type: image
+- source: quay.io/cilium/clustermesh-apiserver:v1.13.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.13.2
+  type: image
+- source: quay.io/cilium/clustermesh-apiserver:v1.13.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.13.4
+  type: image
+- source: quay.io/cilium/clustermesh-apiserver:v1.14.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.14.0
+  type: image
+- source: quay.io/cilium/clustermesh-apiserver:v1.14.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.14.1
+  type: image
+- source: quay.io/cilium/clustermesh-apiserver:v1.14.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.14.2
+  type: image
+- source: quay.io/cilium/clustermesh-apiserver:v1.14.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.14.3
+  type: image
+- source: quay.io/cilium/clustermesh-apiserver:v1.14.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.14.4
+  type: image
+- source: quay.io/cilium/clustermesh-apiserver:v1.14.5
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.14.5
+  type: image
+- source: quay.io/cilium/clustermesh-apiserver:v1.15.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.15.0
+  type: image
+- source: quay.io/cilium/clustermesh-apiserver:v1.15.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.15.1
+  type: image
+- source: quay.io/cilium/clustermesh-apiserver:v1.15.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.15.3
+  type: image
+- source: quay.io/cilium/clustermesh-apiserver:v1.15.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.15.4
+  type: image
+- source: quay.io/cilium/clustermesh-apiserver:v1.15.5
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.15.5
+  type: image
+- source: quay.io/cilium/clustermesh-apiserver:v1.15.6
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.15.6
+  type: image
+- source: quay.io/cilium/clustermesh-apiserver:v1.15.7
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.15.7
+  type: image
+- source: quay.io/cilium/clustermesh-apiserver:v1.16.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.16.0
+  type: image
+- source: quay.io/cilium/clustermesh-apiserver:v1.16.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.16.1
+  type: image
+- source: quay.io/cilium/clustermesh-apiserver:v1.16.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.16.2
+  type: image
+- source: quay.io/cilium/clustermesh-apiserver:v1.16.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.16.3
+  type: image
+- source: quay.io/cilium/clustermesh-apiserver:v1.16.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.16.4
+  type: image
+- source: quay.io/cilium/clustermesh-apiserver:v1.16.5
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.16.5
+  type: image
+- source: quay.io/cilium/clustermesh-apiserver:v1.16.6
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.16.6
+  type: image
+- source: quay.io/cilium/clustermesh-apiserver:v1.17.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.17.0
+  type: image
+- source: quay.io/cilium/clustermesh-apiserver:v1.17.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.17.1
+  type: image
+- source: quay.io/cilium/clustermesh-apiserver:v1.17.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.17.2
+  type: image
+- source: quay.io/cilium/clustermesh-apiserver:v1.17.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.17.3
+  type: image
+- source: quay.io/cilium/clustermesh-apiserver:v1.17.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.17.4
+  type: image
+- source: quay.io/cilium/clustermesh-apiserver:v1.17.5
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.17.5
+  type: image
+- source: quay.io/cilium/clustermesh-apiserver:v1.17.6
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.17.6
+  type: image
+- source: quay.io/cilium/clustermesh-apiserver:v1.18.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.18.0
+  type: image
+- source: quay.io/cilium/clustermesh-apiserver:v1.18.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.18.1
+  type: image
+- source: quay.io/cilium/clustermesh-apiserver:v1.18.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.18.2
   type: image
 - source: quay.io/cilium/hubble-relay:v1.12.4
   target: docker.io/rancher/mirrored-cilium-hubble-relay:v1.12.4
@@ -14838,6 +24566,111 @@ sync:
   target: registry.suse.com/rancher/mirrored-cilium-hubble-relay:v1.18.2
   type: image
 - source: quay.io/cilium/hubble-relay:v1.12.4
+  target: registry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.12.4
+  type: image
+- source: quay.io/cilium/hubble-relay:v1.12.5
+  target: registry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.12.5
+  type: image
+- source: quay.io/cilium/hubble-relay:v1.13.0
+  target: registry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.13.0
+  type: image
+- source: quay.io/cilium/hubble-relay:v1.13.2
+  target: registry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.13.2
+  type: image
+- source: quay.io/cilium/hubble-relay:v1.13.4
+  target: registry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.13.4
+  type: image
+- source: quay.io/cilium/hubble-relay:v1.14.0
+  target: registry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.14.0
+  type: image
+- source: quay.io/cilium/hubble-relay:v1.14.1
+  target: registry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.14.1
+  type: image
+- source: quay.io/cilium/hubble-relay:v1.14.2
+  target: registry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.14.2
+  type: image
+- source: quay.io/cilium/hubble-relay:v1.14.3
+  target: registry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.14.3
+  type: image
+- source: quay.io/cilium/hubble-relay:v1.14.4
+  target: registry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.14.4
+  type: image
+- source: quay.io/cilium/hubble-relay:v1.14.5
+  target: registry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.14.5
+  type: image
+- source: quay.io/cilium/hubble-relay:v1.15.0
+  target: registry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.15.0
+  type: image
+- source: quay.io/cilium/hubble-relay:v1.15.1
+  target: registry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.15.1
+  type: image
+- source: quay.io/cilium/hubble-relay:v1.15.3
+  target: registry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.15.3
+  type: image
+- source: quay.io/cilium/hubble-relay:v1.15.4
+  target: registry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.15.4
+  type: image
+- source: quay.io/cilium/hubble-relay:v1.15.5
+  target: registry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.15.5
+  type: image
+- source: quay.io/cilium/hubble-relay:v1.15.6
+  target: registry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.15.6
+  type: image
+- source: quay.io/cilium/hubble-relay:v1.15.7
+  target: registry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.15.7
+  type: image
+- source: quay.io/cilium/hubble-relay:v1.16.0
+  target: registry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.16.0
+  type: image
+- source: quay.io/cilium/hubble-relay:v1.16.1
+  target: registry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.16.1
+  type: image
+- source: quay.io/cilium/hubble-relay:v1.16.2
+  target: registry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.16.2
+  type: image
+- source: quay.io/cilium/hubble-relay:v1.16.3
+  target: registry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.16.3
+  type: image
+- source: quay.io/cilium/hubble-relay:v1.16.4
+  target: registry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.16.4
+  type: image
+- source: quay.io/cilium/hubble-relay:v1.16.5
+  target: registry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.16.5
+  type: image
+- source: quay.io/cilium/hubble-relay:v1.16.6
+  target: registry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.16.6
+  type: image
+- source: quay.io/cilium/hubble-relay:v1.17.0
+  target: registry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.17.0
+  type: image
+- source: quay.io/cilium/hubble-relay:v1.17.1
+  target: registry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.17.1
+  type: image
+- source: quay.io/cilium/hubble-relay:v1.17.2
+  target: registry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.17.2
+  type: image
+- source: quay.io/cilium/hubble-relay:v1.17.3
+  target: registry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.17.3
+  type: image
+- source: quay.io/cilium/hubble-relay:v1.17.4
+  target: registry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.17.4
+  type: image
+- source: quay.io/cilium/hubble-relay:v1.17.5
+  target: registry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.17.5
+  type: image
+- source: quay.io/cilium/hubble-relay:v1.17.6
+  target: registry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.17.6
+  type: image
+- source: quay.io/cilium/hubble-relay:v1.18.0
+  target: registry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.18.0
+  type: image
+- source: quay.io/cilium/hubble-relay:v1.18.1
+  target: registry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.18.1
+  type: image
+- source: quay.io/cilium/hubble-relay:v1.18.2
+  target: registry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.18.2
+  type: image
+- source: quay.io/cilium/hubble-relay:v1.12.4
   target: stgregistry.suse.com/rancher/mirrored-cilium-hubble-relay:v1.12.4
   type: image
 - source: quay.io/cilium/hubble-relay:v1.12.5
@@ -14942,6 +24775,111 @@ sync:
 - source: quay.io/cilium/hubble-relay:v1.18.2
   target: stgregistry.suse.com/rancher/mirrored-cilium-hubble-relay:v1.18.2
   type: image
+- source: quay.io/cilium/hubble-relay:v1.12.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.12.4
+  type: image
+- source: quay.io/cilium/hubble-relay:v1.12.5
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.12.5
+  type: image
+- source: quay.io/cilium/hubble-relay:v1.13.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.13.0
+  type: image
+- source: quay.io/cilium/hubble-relay:v1.13.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.13.2
+  type: image
+- source: quay.io/cilium/hubble-relay:v1.13.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.13.4
+  type: image
+- source: quay.io/cilium/hubble-relay:v1.14.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.14.0
+  type: image
+- source: quay.io/cilium/hubble-relay:v1.14.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.14.1
+  type: image
+- source: quay.io/cilium/hubble-relay:v1.14.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.14.2
+  type: image
+- source: quay.io/cilium/hubble-relay:v1.14.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.14.3
+  type: image
+- source: quay.io/cilium/hubble-relay:v1.14.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.14.4
+  type: image
+- source: quay.io/cilium/hubble-relay:v1.14.5
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.14.5
+  type: image
+- source: quay.io/cilium/hubble-relay:v1.15.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.15.0
+  type: image
+- source: quay.io/cilium/hubble-relay:v1.15.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.15.1
+  type: image
+- source: quay.io/cilium/hubble-relay:v1.15.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.15.3
+  type: image
+- source: quay.io/cilium/hubble-relay:v1.15.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.15.4
+  type: image
+- source: quay.io/cilium/hubble-relay:v1.15.5
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.15.5
+  type: image
+- source: quay.io/cilium/hubble-relay:v1.15.6
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.15.6
+  type: image
+- source: quay.io/cilium/hubble-relay:v1.15.7
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.15.7
+  type: image
+- source: quay.io/cilium/hubble-relay:v1.16.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.16.0
+  type: image
+- source: quay.io/cilium/hubble-relay:v1.16.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.16.1
+  type: image
+- source: quay.io/cilium/hubble-relay:v1.16.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.16.2
+  type: image
+- source: quay.io/cilium/hubble-relay:v1.16.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.16.3
+  type: image
+- source: quay.io/cilium/hubble-relay:v1.16.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.16.4
+  type: image
+- source: quay.io/cilium/hubble-relay:v1.16.5
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.16.5
+  type: image
+- source: quay.io/cilium/hubble-relay:v1.16.6
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.16.6
+  type: image
+- source: quay.io/cilium/hubble-relay:v1.17.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.17.0
+  type: image
+- source: quay.io/cilium/hubble-relay:v1.17.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.17.1
+  type: image
+- source: quay.io/cilium/hubble-relay:v1.17.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.17.2
+  type: image
+- source: quay.io/cilium/hubble-relay:v1.17.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.17.3
+  type: image
+- source: quay.io/cilium/hubble-relay:v1.17.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.17.4
+  type: image
+- source: quay.io/cilium/hubble-relay:v1.17.5
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.17.5
+  type: image
+- source: quay.io/cilium/hubble-relay:v1.17.6
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.17.6
+  type: image
+- source: quay.io/cilium/hubble-relay:v1.18.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.18.0
+  type: image
+- source: quay.io/cilium/hubble-relay:v1.18.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.18.1
+  type: image
+- source: quay.io/cilium/hubble-relay:v1.18.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.18.2
+  type: image
 - source: quay.io/cilium/hubble-ui:v0.10.0
   target: docker.io/rancher/mirrored-cilium-hubble-ui:v0.10.0
   type: image
@@ -15003,6 +24941,36 @@ sync:
   target: registry.suse.com/rancher/mirrored-cilium-hubble-ui:v0.9.2
   type: image
 - source: quay.io/cilium/hubble-ui:v0.10.0
+  target: registry.suse.com/rancher/charts/mirrored-cilium-hubble-ui:v0.10.0
+  type: image
+- source: quay.io/cilium/hubble-ui:v0.11.0
+  target: registry.suse.com/rancher/charts/mirrored-cilium-hubble-ui:v0.11.0
+  type: image
+- source: quay.io/cilium/hubble-ui:v0.12.0
+  target: registry.suse.com/rancher/charts/mirrored-cilium-hubble-ui:v0.12.0
+  type: image
+- source: quay.io/cilium/hubble-ui:v0.12.1
+  target: registry.suse.com/rancher/charts/mirrored-cilium-hubble-ui:v0.12.1
+  type: image
+- source: quay.io/cilium/hubble-ui:v0.12.3
+  target: registry.suse.com/rancher/charts/mirrored-cilium-hubble-ui:v0.12.3
+  type: image
+- source: quay.io/cilium/hubble-ui:v0.13.0
+  target: registry.suse.com/rancher/charts/mirrored-cilium-hubble-ui:v0.13.0
+  type: image
+- source: quay.io/cilium/hubble-ui:v0.13.1
+  target: registry.suse.com/rancher/charts/mirrored-cilium-hubble-ui:v0.13.1
+  type: image
+- source: quay.io/cilium/hubble-ui:v0.13.2
+  target: registry.suse.com/rancher/charts/mirrored-cilium-hubble-ui:v0.13.2
+  type: image
+- source: quay.io/cilium/hubble-ui:v0.13.3
+  target: registry.suse.com/rancher/charts/mirrored-cilium-hubble-ui:v0.13.3
+  type: image
+- source: quay.io/cilium/hubble-ui:v0.9.2
+  target: registry.suse.com/rancher/charts/mirrored-cilium-hubble-ui:v0.9.2
+  type: image
+- source: quay.io/cilium/hubble-ui:v0.10.0
   target: stgregistry.suse.com/rancher/mirrored-cilium-hubble-ui:v0.10.0
   type: image
 - source: quay.io/cilium/hubble-ui:v0.11.0
@@ -15031,6 +24999,36 @@ sync:
   type: image
 - source: quay.io/cilium/hubble-ui:v0.9.2
   target: stgregistry.suse.com/rancher/mirrored-cilium-hubble-ui:v0.9.2
+  type: image
+- source: quay.io/cilium/hubble-ui:v0.10.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-hubble-ui:v0.10.0
+  type: image
+- source: quay.io/cilium/hubble-ui:v0.11.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-hubble-ui:v0.11.0
+  type: image
+- source: quay.io/cilium/hubble-ui:v0.12.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-hubble-ui:v0.12.0
+  type: image
+- source: quay.io/cilium/hubble-ui:v0.12.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-hubble-ui:v0.12.1
+  type: image
+- source: quay.io/cilium/hubble-ui:v0.12.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-hubble-ui:v0.12.3
+  type: image
+- source: quay.io/cilium/hubble-ui:v0.13.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-hubble-ui:v0.13.0
+  type: image
+- source: quay.io/cilium/hubble-ui:v0.13.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-hubble-ui:v0.13.1
+  type: image
+- source: quay.io/cilium/hubble-ui:v0.13.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-hubble-ui:v0.13.2
+  type: image
+- source: quay.io/cilium/hubble-ui:v0.13.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-hubble-ui:v0.13.3
+  type: image
+- source: quay.io/cilium/hubble-ui:v0.9.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-hubble-ui:v0.9.2
   type: image
 - source: quay.io/cilium/hubble-ui-backend:v0.10.0
   target: docker.io/rancher/mirrored-cilium-hubble-ui-backend:v0.10.0
@@ -15093,6 +25091,36 @@ sync:
   target: registry.suse.com/rancher/mirrored-cilium-hubble-ui-backend:v0.9.2
   type: image
 - source: quay.io/cilium/hubble-ui-backend:v0.10.0
+  target: registry.suse.com/rancher/charts/mirrored-cilium-hubble-ui-backend:v0.10.0
+  type: image
+- source: quay.io/cilium/hubble-ui-backend:v0.11.0
+  target: registry.suse.com/rancher/charts/mirrored-cilium-hubble-ui-backend:v0.11.0
+  type: image
+- source: quay.io/cilium/hubble-ui-backend:v0.12.0
+  target: registry.suse.com/rancher/charts/mirrored-cilium-hubble-ui-backend:v0.12.0
+  type: image
+- source: quay.io/cilium/hubble-ui-backend:v0.12.1
+  target: registry.suse.com/rancher/charts/mirrored-cilium-hubble-ui-backend:v0.12.1
+  type: image
+- source: quay.io/cilium/hubble-ui-backend:v0.12.3
+  target: registry.suse.com/rancher/charts/mirrored-cilium-hubble-ui-backend:v0.12.3
+  type: image
+- source: quay.io/cilium/hubble-ui-backend:v0.13.0
+  target: registry.suse.com/rancher/charts/mirrored-cilium-hubble-ui-backend:v0.13.0
+  type: image
+- source: quay.io/cilium/hubble-ui-backend:v0.13.1
+  target: registry.suse.com/rancher/charts/mirrored-cilium-hubble-ui-backend:v0.13.1
+  type: image
+- source: quay.io/cilium/hubble-ui-backend:v0.13.2
+  target: registry.suse.com/rancher/charts/mirrored-cilium-hubble-ui-backend:v0.13.2
+  type: image
+- source: quay.io/cilium/hubble-ui-backend:v0.13.3
+  target: registry.suse.com/rancher/charts/mirrored-cilium-hubble-ui-backend:v0.13.3
+  type: image
+- source: quay.io/cilium/hubble-ui-backend:v0.9.2
+  target: registry.suse.com/rancher/charts/mirrored-cilium-hubble-ui-backend:v0.9.2
+  type: image
+- source: quay.io/cilium/hubble-ui-backend:v0.10.0
   target: stgregistry.suse.com/rancher/mirrored-cilium-hubble-ui-backend:v0.10.0
   type: image
 - source: quay.io/cilium/hubble-ui-backend:v0.11.0
@@ -15121,6 +25149,36 @@ sync:
   type: image
 - source: quay.io/cilium/hubble-ui-backend:v0.9.2
   target: stgregistry.suse.com/rancher/mirrored-cilium-hubble-ui-backend:v0.9.2
+  type: image
+- source: quay.io/cilium/hubble-ui-backend:v0.10.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-hubble-ui-backend:v0.10.0
+  type: image
+- source: quay.io/cilium/hubble-ui-backend:v0.11.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-hubble-ui-backend:v0.11.0
+  type: image
+- source: quay.io/cilium/hubble-ui-backend:v0.12.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-hubble-ui-backend:v0.12.0
+  type: image
+- source: quay.io/cilium/hubble-ui-backend:v0.12.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-hubble-ui-backend:v0.12.1
+  type: image
+- source: quay.io/cilium/hubble-ui-backend:v0.12.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-hubble-ui-backend:v0.12.3
+  type: image
+- source: quay.io/cilium/hubble-ui-backend:v0.13.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-hubble-ui-backend:v0.13.0
+  type: image
+- source: quay.io/cilium/hubble-ui-backend:v0.13.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-hubble-ui-backend:v0.13.1
+  type: image
+- source: quay.io/cilium/hubble-ui-backend:v0.13.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-hubble-ui-backend:v0.13.2
+  type: image
+- source: quay.io/cilium/hubble-ui-backend:v0.13.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-hubble-ui-backend:v0.13.3
+  type: image
+- source: quay.io/cilium/hubble-ui-backend:v0.9.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-hubble-ui-backend:v0.9.2
   type: image
 - source: quay.io/cilium/kvstoremesh:v1.14.0
   target: docker.io/rancher/mirrored-cilium-kvstoremesh:v1.14.0
@@ -15159,6 +25217,24 @@ sync:
   target: registry.suse.com/rancher/mirrored-cilium-kvstoremesh:v1.14.5
   type: image
 - source: quay.io/cilium/kvstoremesh:v1.14.0
+  target: registry.suse.com/rancher/charts/mirrored-cilium-kvstoremesh:v1.14.0
+  type: image
+- source: quay.io/cilium/kvstoremesh:v1.14.1
+  target: registry.suse.com/rancher/charts/mirrored-cilium-kvstoremesh:v1.14.1
+  type: image
+- source: quay.io/cilium/kvstoremesh:v1.14.2
+  target: registry.suse.com/rancher/charts/mirrored-cilium-kvstoremesh:v1.14.2
+  type: image
+- source: quay.io/cilium/kvstoremesh:v1.14.3
+  target: registry.suse.com/rancher/charts/mirrored-cilium-kvstoremesh:v1.14.3
+  type: image
+- source: quay.io/cilium/kvstoremesh:v1.14.4
+  target: registry.suse.com/rancher/charts/mirrored-cilium-kvstoremesh:v1.14.4
+  type: image
+- source: quay.io/cilium/kvstoremesh:v1.14.5
+  target: registry.suse.com/rancher/charts/mirrored-cilium-kvstoremesh:v1.14.5
+  type: image
+- source: quay.io/cilium/kvstoremesh:v1.14.0
   target: stgregistry.suse.com/rancher/mirrored-cilium-kvstoremesh:v1.14.0
   type: image
 - source: quay.io/cilium/kvstoremesh:v1.14.1
@@ -15175,6 +25251,24 @@ sync:
   type: image
 - source: quay.io/cilium/kvstoremesh:v1.14.5
   target: stgregistry.suse.com/rancher/mirrored-cilium-kvstoremesh:v1.14.5
+  type: image
+- source: quay.io/cilium/kvstoremesh:v1.14.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-kvstoremesh:v1.14.0
+  type: image
+- source: quay.io/cilium/kvstoremesh:v1.14.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-kvstoremesh:v1.14.1
+  type: image
+- source: quay.io/cilium/kvstoremesh:v1.14.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-kvstoremesh:v1.14.2
+  type: image
+- source: quay.io/cilium/kvstoremesh:v1.14.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-kvstoremesh:v1.14.3
+  type: image
+- source: quay.io/cilium/kvstoremesh:v1.14.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-kvstoremesh:v1.14.4
+  type: image
+- source: quay.io/cilium/kvstoremesh:v1.14.5
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-kvstoremesh:v1.14.5
   type: image
 - source: quay.io/cilium/operator-aws:v1.10.4
   target: docker.io/rancher/mirrored-cilium-operator-aws:v1.10.4
@@ -15471,6 +25565,153 @@ sync:
   target: registry.suse.com/rancher/mirrored-cilium-operator-aws:v1.9.8
   type: image
 - source: quay.io/cilium/operator-aws:v1.10.4
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.10.4
+  type: image
+- source: quay.io/cilium/operator-aws:v1.10.7
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.10.7
+  type: image
+- source: quay.io/cilium/operator-aws:v1.11.0
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.11.0
+  type: image
+- source: quay.io/cilium/operator-aws:v1.11.1
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.11.1
+  type: image
+- source: quay.io/cilium/operator-aws:v1.11.2
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.11.2
+  type: image
+- source: quay.io/cilium/operator-aws:v1.11.4
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.11.4
+  type: image
+- source: quay.io/cilium/operator-aws:v1.11.5
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.11.5
+  type: image
+- source: quay.io/cilium/operator-aws:v1.12.0
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.12.0
+  type: image
+- source: quay.io/cilium/operator-aws:v1.12.1
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.12.1
+  type: image
+- source: quay.io/cilium/operator-aws:v1.12.3
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.12.3
+  type: image
+- source: quay.io/cilium/operator-aws:v1.12.4
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.12.4
+  type: image
+- source: quay.io/cilium/operator-aws:v1.12.5
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.12.5
+  type: image
+- source: quay.io/cilium/operator-aws:v1.13.0
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.13.0
+  type: image
+- source: quay.io/cilium/operator-aws:v1.13.2
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.13.2
+  type: image
+- source: quay.io/cilium/operator-aws:v1.13.4
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.13.4
+  type: image
+- source: quay.io/cilium/operator-aws:v1.14.0
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.14.0
+  type: image
+- source: quay.io/cilium/operator-aws:v1.14.1
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.14.1
+  type: image
+- source: quay.io/cilium/operator-aws:v1.14.2
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.14.2
+  type: image
+- source: quay.io/cilium/operator-aws:v1.14.3
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.14.3
+  type: image
+- source: quay.io/cilium/operator-aws:v1.14.4
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.14.4
+  type: image
+- source: quay.io/cilium/operator-aws:v1.14.5
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.14.5
+  type: image
+- source: quay.io/cilium/operator-aws:v1.15.0
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.15.0
+  type: image
+- source: quay.io/cilium/operator-aws:v1.15.1
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.15.1
+  type: image
+- source: quay.io/cilium/operator-aws:v1.15.3
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.15.3
+  type: image
+- source: quay.io/cilium/operator-aws:v1.15.4
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.15.4
+  type: image
+- source: quay.io/cilium/operator-aws:v1.15.5
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.15.5
+  type: image
+- source: quay.io/cilium/operator-aws:v1.15.6
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.15.6
+  type: image
+- source: quay.io/cilium/operator-aws:v1.15.7
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.15.7
+  type: image
+- source: quay.io/cilium/operator-aws:v1.16.0
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.16.0
+  type: image
+- source: quay.io/cilium/operator-aws:v1.16.1
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.16.1
+  type: image
+- source: quay.io/cilium/operator-aws:v1.16.2
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.16.2
+  type: image
+- source: quay.io/cilium/operator-aws:v1.16.3
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.16.3
+  type: image
+- source: quay.io/cilium/operator-aws:v1.16.4
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.16.4
+  type: image
+- source: quay.io/cilium/operator-aws:v1.16.5
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.16.5
+  type: image
+- source: quay.io/cilium/operator-aws:v1.16.6
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.16.6
+  type: image
+- source: quay.io/cilium/operator-aws:v1.17.0
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.17.0
+  type: image
+- source: quay.io/cilium/operator-aws:v1.17.1
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.17.1
+  type: image
+- source: quay.io/cilium/operator-aws:v1.17.2
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.17.2
+  type: image
+- source: quay.io/cilium/operator-aws:v1.17.3
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.17.3
+  type: image
+- source: quay.io/cilium/operator-aws:v1.17.4
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.17.4
+  type: image
+- source: quay.io/cilium/operator-aws:v1.17.5
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.17.5
+  type: image
+- source: quay.io/cilium/operator-aws:v1.17.6
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.17.6
+  type: image
+- source: quay.io/cilium/operator-aws:v1.18.0
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.18.0
+  type: image
+- source: quay.io/cilium/operator-aws:v1.18.1
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.18.1
+  type: image
+- source: quay.io/cilium/operator-aws:v1.18.2
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.18.2
+  type: image
+- source: quay.io/cilium/operator-aws:v1.9.12
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.9.12
+  type: image
+- source: quay.io/cilium/operator-aws:v1.9.4
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.9.4
+  type: image
+- source: quay.io/cilium/operator-aws:v1.9.6
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.9.6
+  type: image
+- source: quay.io/cilium/operator-aws:v1.9.8
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.9.8
+  type: image
+- source: quay.io/cilium/operator-aws:v1.10.4
   target: stgregistry.suse.com/rancher/mirrored-cilium-operator-aws:v1.10.4
   type: image
 - source: quay.io/cilium/operator-aws:v1.10.7
@@ -15616,6 +25857,153 @@ sync:
   type: image
 - source: quay.io/cilium/operator-aws:v1.9.8
   target: stgregistry.suse.com/rancher/mirrored-cilium-operator-aws:v1.9.8
+  type: image
+- source: quay.io/cilium/operator-aws:v1.10.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.10.4
+  type: image
+- source: quay.io/cilium/operator-aws:v1.10.7
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.10.7
+  type: image
+- source: quay.io/cilium/operator-aws:v1.11.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.11.0
+  type: image
+- source: quay.io/cilium/operator-aws:v1.11.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.11.1
+  type: image
+- source: quay.io/cilium/operator-aws:v1.11.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.11.2
+  type: image
+- source: quay.io/cilium/operator-aws:v1.11.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.11.4
+  type: image
+- source: quay.io/cilium/operator-aws:v1.11.5
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.11.5
+  type: image
+- source: quay.io/cilium/operator-aws:v1.12.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.12.0
+  type: image
+- source: quay.io/cilium/operator-aws:v1.12.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.12.1
+  type: image
+- source: quay.io/cilium/operator-aws:v1.12.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.12.3
+  type: image
+- source: quay.io/cilium/operator-aws:v1.12.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.12.4
+  type: image
+- source: quay.io/cilium/operator-aws:v1.12.5
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.12.5
+  type: image
+- source: quay.io/cilium/operator-aws:v1.13.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.13.0
+  type: image
+- source: quay.io/cilium/operator-aws:v1.13.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.13.2
+  type: image
+- source: quay.io/cilium/operator-aws:v1.13.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.13.4
+  type: image
+- source: quay.io/cilium/operator-aws:v1.14.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.14.0
+  type: image
+- source: quay.io/cilium/operator-aws:v1.14.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.14.1
+  type: image
+- source: quay.io/cilium/operator-aws:v1.14.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.14.2
+  type: image
+- source: quay.io/cilium/operator-aws:v1.14.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.14.3
+  type: image
+- source: quay.io/cilium/operator-aws:v1.14.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.14.4
+  type: image
+- source: quay.io/cilium/operator-aws:v1.14.5
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.14.5
+  type: image
+- source: quay.io/cilium/operator-aws:v1.15.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.15.0
+  type: image
+- source: quay.io/cilium/operator-aws:v1.15.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.15.1
+  type: image
+- source: quay.io/cilium/operator-aws:v1.15.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.15.3
+  type: image
+- source: quay.io/cilium/operator-aws:v1.15.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.15.4
+  type: image
+- source: quay.io/cilium/operator-aws:v1.15.5
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.15.5
+  type: image
+- source: quay.io/cilium/operator-aws:v1.15.6
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.15.6
+  type: image
+- source: quay.io/cilium/operator-aws:v1.15.7
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.15.7
+  type: image
+- source: quay.io/cilium/operator-aws:v1.16.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.16.0
+  type: image
+- source: quay.io/cilium/operator-aws:v1.16.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.16.1
+  type: image
+- source: quay.io/cilium/operator-aws:v1.16.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.16.2
+  type: image
+- source: quay.io/cilium/operator-aws:v1.16.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.16.3
+  type: image
+- source: quay.io/cilium/operator-aws:v1.16.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.16.4
+  type: image
+- source: quay.io/cilium/operator-aws:v1.16.5
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.16.5
+  type: image
+- source: quay.io/cilium/operator-aws:v1.16.6
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.16.6
+  type: image
+- source: quay.io/cilium/operator-aws:v1.17.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.17.0
+  type: image
+- source: quay.io/cilium/operator-aws:v1.17.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.17.1
+  type: image
+- source: quay.io/cilium/operator-aws:v1.17.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.17.2
+  type: image
+- source: quay.io/cilium/operator-aws:v1.17.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.17.3
+  type: image
+- source: quay.io/cilium/operator-aws:v1.17.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.17.4
+  type: image
+- source: quay.io/cilium/operator-aws:v1.17.5
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.17.5
+  type: image
+- source: quay.io/cilium/operator-aws:v1.17.6
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.17.6
+  type: image
+- source: quay.io/cilium/operator-aws:v1.18.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.18.0
+  type: image
+- source: quay.io/cilium/operator-aws:v1.18.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.18.1
+  type: image
+- source: quay.io/cilium/operator-aws:v1.18.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.18.2
+  type: image
+- source: quay.io/cilium/operator-aws:v1.9.12
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.9.12
+  type: image
+- source: quay.io/cilium/operator-aws:v1.9.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.9.4
+  type: image
+- source: quay.io/cilium/operator-aws:v1.9.6
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.9.6
+  type: image
+- source: quay.io/cilium/operator-aws:v1.9.8
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.9.8
   type: image
 - source: quay.io/cilium/operator-azure:v1.10.4
   target: docker.io/rancher/mirrored-cilium-operator-azure:v1.10.4
@@ -15912,6 +26300,153 @@ sync:
   target: registry.suse.com/rancher/mirrored-cilium-operator-azure:v1.9.8
   type: image
 - source: quay.io/cilium/operator-azure:v1.10.4
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.10.4
+  type: image
+- source: quay.io/cilium/operator-azure:v1.10.7
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.10.7
+  type: image
+- source: quay.io/cilium/operator-azure:v1.11.0
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.11.0
+  type: image
+- source: quay.io/cilium/operator-azure:v1.11.1
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.11.1
+  type: image
+- source: quay.io/cilium/operator-azure:v1.11.2
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.11.2
+  type: image
+- source: quay.io/cilium/operator-azure:v1.11.4
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.11.4
+  type: image
+- source: quay.io/cilium/operator-azure:v1.11.5
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.11.5
+  type: image
+- source: quay.io/cilium/operator-azure:v1.12.0
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.12.0
+  type: image
+- source: quay.io/cilium/operator-azure:v1.12.1
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.12.1
+  type: image
+- source: quay.io/cilium/operator-azure:v1.12.3
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.12.3
+  type: image
+- source: quay.io/cilium/operator-azure:v1.12.4
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.12.4
+  type: image
+- source: quay.io/cilium/operator-azure:v1.12.5
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.12.5
+  type: image
+- source: quay.io/cilium/operator-azure:v1.13.0
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.13.0
+  type: image
+- source: quay.io/cilium/operator-azure:v1.13.2
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.13.2
+  type: image
+- source: quay.io/cilium/operator-azure:v1.13.4
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.13.4
+  type: image
+- source: quay.io/cilium/operator-azure:v1.14.0
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.14.0
+  type: image
+- source: quay.io/cilium/operator-azure:v1.14.1
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.14.1
+  type: image
+- source: quay.io/cilium/operator-azure:v1.14.2
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.14.2
+  type: image
+- source: quay.io/cilium/operator-azure:v1.14.3
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.14.3
+  type: image
+- source: quay.io/cilium/operator-azure:v1.14.4
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.14.4
+  type: image
+- source: quay.io/cilium/operator-azure:v1.14.5
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.14.5
+  type: image
+- source: quay.io/cilium/operator-azure:v1.15.0
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.15.0
+  type: image
+- source: quay.io/cilium/operator-azure:v1.15.1
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.15.1
+  type: image
+- source: quay.io/cilium/operator-azure:v1.15.3
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.15.3
+  type: image
+- source: quay.io/cilium/operator-azure:v1.15.4
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.15.4
+  type: image
+- source: quay.io/cilium/operator-azure:v1.15.5
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.15.5
+  type: image
+- source: quay.io/cilium/operator-azure:v1.15.6
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.15.6
+  type: image
+- source: quay.io/cilium/operator-azure:v1.15.7
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.15.7
+  type: image
+- source: quay.io/cilium/operator-azure:v1.16.0
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.16.0
+  type: image
+- source: quay.io/cilium/operator-azure:v1.16.1
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.16.1
+  type: image
+- source: quay.io/cilium/operator-azure:v1.16.2
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.16.2
+  type: image
+- source: quay.io/cilium/operator-azure:v1.16.3
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.16.3
+  type: image
+- source: quay.io/cilium/operator-azure:v1.16.4
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.16.4
+  type: image
+- source: quay.io/cilium/operator-azure:v1.16.5
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.16.5
+  type: image
+- source: quay.io/cilium/operator-azure:v1.16.6
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.16.6
+  type: image
+- source: quay.io/cilium/operator-azure:v1.17.0
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.17.0
+  type: image
+- source: quay.io/cilium/operator-azure:v1.17.1
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.17.1
+  type: image
+- source: quay.io/cilium/operator-azure:v1.17.2
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.17.2
+  type: image
+- source: quay.io/cilium/operator-azure:v1.17.3
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.17.3
+  type: image
+- source: quay.io/cilium/operator-azure:v1.17.4
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.17.4
+  type: image
+- source: quay.io/cilium/operator-azure:v1.17.5
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.17.5
+  type: image
+- source: quay.io/cilium/operator-azure:v1.17.6
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.17.6
+  type: image
+- source: quay.io/cilium/operator-azure:v1.18.0
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.18.0
+  type: image
+- source: quay.io/cilium/operator-azure:v1.18.1
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.18.1
+  type: image
+- source: quay.io/cilium/operator-azure:v1.18.2
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.18.2
+  type: image
+- source: quay.io/cilium/operator-azure:v1.9.12
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.9.12
+  type: image
+- source: quay.io/cilium/operator-azure:v1.9.4
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.9.4
+  type: image
+- source: quay.io/cilium/operator-azure:v1.9.6
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.9.6
+  type: image
+- source: quay.io/cilium/operator-azure:v1.9.8
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.9.8
+  type: image
+- source: quay.io/cilium/operator-azure:v1.10.4
   target: stgregistry.suse.com/rancher/mirrored-cilium-operator-azure:v1.10.4
   type: image
 - source: quay.io/cilium/operator-azure:v1.10.7
@@ -16057,6 +26592,153 @@ sync:
   type: image
 - source: quay.io/cilium/operator-azure:v1.9.8
   target: stgregistry.suse.com/rancher/mirrored-cilium-operator-azure:v1.9.8
+  type: image
+- source: quay.io/cilium/operator-azure:v1.10.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.10.4
+  type: image
+- source: quay.io/cilium/operator-azure:v1.10.7
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.10.7
+  type: image
+- source: quay.io/cilium/operator-azure:v1.11.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.11.0
+  type: image
+- source: quay.io/cilium/operator-azure:v1.11.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.11.1
+  type: image
+- source: quay.io/cilium/operator-azure:v1.11.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.11.2
+  type: image
+- source: quay.io/cilium/operator-azure:v1.11.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.11.4
+  type: image
+- source: quay.io/cilium/operator-azure:v1.11.5
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.11.5
+  type: image
+- source: quay.io/cilium/operator-azure:v1.12.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.12.0
+  type: image
+- source: quay.io/cilium/operator-azure:v1.12.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.12.1
+  type: image
+- source: quay.io/cilium/operator-azure:v1.12.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.12.3
+  type: image
+- source: quay.io/cilium/operator-azure:v1.12.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.12.4
+  type: image
+- source: quay.io/cilium/operator-azure:v1.12.5
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.12.5
+  type: image
+- source: quay.io/cilium/operator-azure:v1.13.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.13.0
+  type: image
+- source: quay.io/cilium/operator-azure:v1.13.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.13.2
+  type: image
+- source: quay.io/cilium/operator-azure:v1.13.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.13.4
+  type: image
+- source: quay.io/cilium/operator-azure:v1.14.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.14.0
+  type: image
+- source: quay.io/cilium/operator-azure:v1.14.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.14.1
+  type: image
+- source: quay.io/cilium/operator-azure:v1.14.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.14.2
+  type: image
+- source: quay.io/cilium/operator-azure:v1.14.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.14.3
+  type: image
+- source: quay.io/cilium/operator-azure:v1.14.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.14.4
+  type: image
+- source: quay.io/cilium/operator-azure:v1.14.5
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.14.5
+  type: image
+- source: quay.io/cilium/operator-azure:v1.15.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.15.0
+  type: image
+- source: quay.io/cilium/operator-azure:v1.15.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.15.1
+  type: image
+- source: quay.io/cilium/operator-azure:v1.15.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.15.3
+  type: image
+- source: quay.io/cilium/operator-azure:v1.15.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.15.4
+  type: image
+- source: quay.io/cilium/operator-azure:v1.15.5
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.15.5
+  type: image
+- source: quay.io/cilium/operator-azure:v1.15.6
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.15.6
+  type: image
+- source: quay.io/cilium/operator-azure:v1.15.7
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.15.7
+  type: image
+- source: quay.io/cilium/operator-azure:v1.16.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.16.0
+  type: image
+- source: quay.io/cilium/operator-azure:v1.16.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.16.1
+  type: image
+- source: quay.io/cilium/operator-azure:v1.16.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.16.2
+  type: image
+- source: quay.io/cilium/operator-azure:v1.16.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.16.3
+  type: image
+- source: quay.io/cilium/operator-azure:v1.16.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.16.4
+  type: image
+- source: quay.io/cilium/operator-azure:v1.16.5
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.16.5
+  type: image
+- source: quay.io/cilium/operator-azure:v1.16.6
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.16.6
+  type: image
+- source: quay.io/cilium/operator-azure:v1.17.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.17.0
+  type: image
+- source: quay.io/cilium/operator-azure:v1.17.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.17.1
+  type: image
+- source: quay.io/cilium/operator-azure:v1.17.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.17.2
+  type: image
+- source: quay.io/cilium/operator-azure:v1.17.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.17.3
+  type: image
+- source: quay.io/cilium/operator-azure:v1.17.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.17.4
+  type: image
+- source: quay.io/cilium/operator-azure:v1.17.5
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.17.5
+  type: image
+- source: quay.io/cilium/operator-azure:v1.17.6
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.17.6
+  type: image
+- source: quay.io/cilium/operator-azure:v1.18.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.18.0
+  type: image
+- source: quay.io/cilium/operator-azure:v1.18.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.18.1
+  type: image
+- source: quay.io/cilium/operator-azure:v1.18.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.18.2
+  type: image
+- source: quay.io/cilium/operator-azure:v1.9.12
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.9.12
+  type: image
+- source: quay.io/cilium/operator-azure:v1.9.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.9.4
+  type: image
+- source: quay.io/cilium/operator-azure:v1.9.6
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.9.6
+  type: image
+- source: quay.io/cilium/operator-azure:v1.9.8
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.9.8
   type: image
 - source: quay.io/cilium/operator-generic:v1.10.4
   target: docker.io/rancher/mirrored-cilium-operator-generic:v1.10.4
@@ -16353,6 +27035,153 @@ sync:
   target: registry.suse.com/rancher/mirrored-cilium-operator-generic:v1.9.8
   type: image
 - source: quay.io/cilium/operator-generic:v1.10.4
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.10.4
+  type: image
+- source: quay.io/cilium/operator-generic:v1.10.7
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.10.7
+  type: image
+- source: quay.io/cilium/operator-generic:v1.11.0
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.11.0
+  type: image
+- source: quay.io/cilium/operator-generic:v1.11.1
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.11.1
+  type: image
+- source: quay.io/cilium/operator-generic:v1.11.2
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.11.2
+  type: image
+- source: quay.io/cilium/operator-generic:v1.11.4
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.11.4
+  type: image
+- source: quay.io/cilium/operator-generic:v1.11.5
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.11.5
+  type: image
+- source: quay.io/cilium/operator-generic:v1.12.0
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.12.0
+  type: image
+- source: quay.io/cilium/operator-generic:v1.12.1
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.12.1
+  type: image
+- source: quay.io/cilium/operator-generic:v1.12.3
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.12.3
+  type: image
+- source: quay.io/cilium/operator-generic:v1.12.4
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.12.4
+  type: image
+- source: quay.io/cilium/operator-generic:v1.12.5
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.12.5
+  type: image
+- source: quay.io/cilium/operator-generic:v1.13.0
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.13.0
+  type: image
+- source: quay.io/cilium/operator-generic:v1.13.2
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.13.2
+  type: image
+- source: quay.io/cilium/operator-generic:v1.13.4
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.13.4
+  type: image
+- source: quay.io/cilium/operator-generic:v1.14.0
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.14.0
+  type: image
+- source: quay.io/cilium/operator-generic:v1.14.1
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.14.1
+  type: image
+- source: quay.io/cilium/operator-generic:v1.14.2
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.14.2
+  type: image
+- source: quay.io/cilium/operator-generic:v1.14.3
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.14.3
+  type: image
+- source: quay.io/cilium/operator-generic:v1.14.4
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.14.4
+  type: image
+- source: quay.io/cilium/operator-generic:v1.14.5
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.14.5
+  type: image
+- source: quay.io/cilium/operator-generic:v1.15.0
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.15.0
+  type: image
+- source: quay.io/cilium/operator-generic:v1.15.1
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.15.1
+  type: image
+- source: quay.io/cilium/operator-generic:v1.15.3
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.15.3
+  type: image
+- source: quay.io/cilium/operator-generic:v1.15.4
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.15.4
+  type: image
+- source: quay.io/cilium/operator-generic:v1.15.5
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.15.5
+  type: image
+- source: quay.io/cilium/operator-generic:v1.15.6
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.15.6
+  type: image
+- source: quay.io/cilium/operator-generic:v1.15.7
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.15.7
+  type: image
+- source: quay.io/cilium/operator-generic:v1.16.0
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.16.0
+  type: image
+- source: quay.io/cilium/operator-generic:v1.16.1
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.16.1
+  type: image
+- source: quay.io/cilium/operator-generic:v1.16.2
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.16.2
+  type: image
+- source: quay.io/cilium/operator-generic:v1.16.3
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.16.3
+  type: image
+- source: quay.io/cilium/operator-generic:v1.16.4
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.16.4
+  type: image
+- source: quay.io/cilium/operator-generic:v1.16.5
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.16.5
+  type: image
+- source: quay.io/cilium/operator-generic:v1.16.6
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.16.6
+  type: image
+- source: quay.io/cilium/operator-generic:v1.17.0
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.17.0
+  type: image
+- source: quay.io/cilium/operator-generic:v1.17.1
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.17.1
+  type: image
+- source: quay.io/cilium/operator-generic:v1.17.2
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.17.2
+  type: image
+- source: quay.io/cilium/operator-generic:v1.17.3
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.17.3
+  type: image
+- source: quay.io/cilium/operator-generic:v1.17.4
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.17.4
+  type: image
+- source: quay.io/cilium/operator-generic:v1.17.5
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.17.5
+  type: image
+- source: quay.io/cilium/operator-generic:v1.17.6
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.17.6
+  type: image
+- source: quay.io/cilium/operator-generic:v1.18.0
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.18.0
+  type: image
+- source: quay.io/cilium/operator-generic:v1.18.1
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.18.1
+  type: image
+- source: quay.io/cilium/operator-generic:v1.18.2
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.18.2
+  type: image
+- source: quay.io/cilium/operator-generic:v1.9.12
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.9.12
+  type: image
+- source: quay.io/cilium/operator-generic:v1.9.4
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.9.4
+  type: image
+- source: quay.io/cilium/operator-generic:v1.9.6
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.9.6
+  type: image
+- source: quay.io/cilium/operator-generic:v1.9.8
+  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.9.8
+  type: image
+- source: quay.io/cilium/operator-generic:v1.10.4
   target: stgregistry.suse.com/rancher/mirrored-cilium-operator-generic:v1.10.4
   type: image
 - source: quay.io/cilium/operator-generic:v1.10.7
@@ -16499,6 +27328,153 @@ sync:
 - source: quay.io/cilium/operator-generic:v1.9.8
   target: stgregistry.suse.com/rancher/mirrored-cilium-operator-generic:v1.9.8
   type: image
+- source: quay.io/cilium/operator-generic:v1.10.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.10.4
+  type: image
+- source: quay.io/cilium/operator-generic:v1.10.7
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.10.7
+  type: image
+- source: quay.io/cilium/operator-generic:v1.11.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.11.0
+  type: image
+- source: quay.io/cilium/operator-generic:v1.11.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.11.1
+  type: image
+- source: quay.io/cilium/operator-generic:v1.11.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.11.2
+  type: image
+- source: quay.io/cilium/operator-generic:v1.11.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.11.4
+  type: image
+- source: quay.io/cilium/operator-generic:v1.11.5
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.11.5
+  type: image
+- source: quay.io/cilium/operator-generic:v1.12.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.12.0
+  type: image
+- source: quay.io/cilium/operator-generic:v1.12.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.12.1
+  type: image
+- source: quay.io/cilium/operator-generic:v1.12.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.12.3
+  type: image
+- source: quay.io/cilium/operator-generic:v1.12.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.12.4
+  type: image
+- source: quay.io/cilium/operator-generic:v1.12.5
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.12.5
+  type: image
+- source: quay.io/cilium/operator-generic:v1.13.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.13.0
+  type: image
+- source: quay.io/cilium/operator-generic:v1.13.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.13.2
+  type: image
+- source: quay.io/cilium/operator-generic:v1.13.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.13.4
+  type: image
+- source: quay.io/cilium/operator-generic:v1.14.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.14.0
+  type: image
+- source: quay.io/cilium/operator-generic:v1.14.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.14.1
+  type: image
+- source: quay.io/cilium/operator-generic:v1.14.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.14.2
+  type: image
+- source: quay.io/cilium/operator-generic:v1.14.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.14.3
+  type: image
+- source: quay.io/cilium/operator-generic:v1.14.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.14.4
+  type: image
+- source: quay.io/cilium/operator-generic:v1.14.5
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.14.5
+  type: image
+- source: quay.io/cilium/operator-generic:v1.15.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.15.0
+  type: image
+- source: quay.io/cilium/operator-generic:v1.15.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.15.1
+  type: image
+- source: quay.io/cilium/operator-generic:v1.15.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.15.3
+  type: image
+- source: quay.io/cilium/operator-generic:v1.15.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.15.4
+  type: image
+- source: quay.io/cilium/operator-generic:v1.15.5
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.15.5
+  type: image
+- source: quay.io/cilium/operator-generic:v1.15.6
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.15.6
+  type: image
+- source: quay.io/cilium/operator-generic:v1.15.7
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.15.7
+  type: image
+- source: quay.io/cilium/operator-generic:v1.16.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.16.0
+  type: image
+- source: quay.io/cilium/operator-generic:v1.16.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.16.1
+  type: image
+- source: quay.io/cilium/operator-generic:v1.16.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.16.2
+  type: image
+- source: quay.io/cilium/operator-generic:v1.16.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.16.3
+  type: image
+- source: quay.io/cilium/operator-generic:v1.16.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.16.4
+  type: image
+- source: quay.io/cilium/operator-generic:v1.16.5
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.16.5
+  type: image
+- source: quay.io/cilium/operator-generic:v1.16.6
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.16.6
+  type: image
+- source: quay.io/cilium/operator-generic:v1.17.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.17.0
+  type: image
+- source: quay.io/cilium/operator-generic:v1.17.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.17.1
+  type: image
+- source: quay.io/cilium/operator-generic:v1.17.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.17.2
+  type: image
+- source: quay.io/cilium/operator-generic:v1.17.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.17.3
+  type: image
+- source: quay.io/cilium/operator-generic:v1.17.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.17.4
+  type: image
+- source: quay.io/cilium/operator-generic:v1.17.5
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.17.5
+  type: image
+- source: quay.io/cilium/operator-generic:v1.17.6
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.17.6
+  type: image
+- source: quay.io/cilium/operator-generic:v1.18.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.18.0
+  type: image
+- source: quay.io/cilium/operator-generic:v1.18.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.18.1
+  type: image
+- source: quay.io/cilium/operator-generic:v1.18.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.18.2
+  type: image
+- source: quay.io/cilium/operator-generic:v1.9.12
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.9.12
+  type: image
+- source: quay.io/cilium/operator-generic:v1.9.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.9.4
+  type: image
+- source: quay.io/cilium/operator-generic:v1.9.6
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.9.6
+  type: image
+- source: quay.io/cilium/operator-generic:v1.9.8
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.9.8
+  type: image
 - source: quay.io/cilium/startup-script:5e928f628f9fc644a1d2651d6cd6aecbde0e7acd
   target: docker.io/rancher/mirrored-cilium-startup-script:5e928f628f9fc644a1d2651d6cd6aecbde0e7acd
   type: image
@@ -16518,6 +27494,15 @@ sync:
   target: registry.suse.com/rancher/mirrored-cilium-startup-script:d69851597ea019af980891a4628fb36b7880ec26
   type: image
 - source: quay.io/cilium/startup-script:5e928f628f9fc644a1d2651d6cd6aecbde0e7acd
+  target: registry.suse.com/rancher/charts/mirrored-cilium-startup-script:5e928f628f9fc644a1d2651d6cd6aecbde0e7acd
+  type: image
+- source: quay.io/cilium/startup-script:62bfbe88c17778aad7bef9fa57ff9e2d4a9ba0d8
+  target: registry.suse.com/rancher/charts/mirrored-cilium-startup-script:62bfbe88c17778aad7bef9fa57ff9e2d4a9ba0d8
+  type: image
+- source: quay.io/cilium/startup-script:d69851597ea019af980891a4628fb36b7880ec26
+  target: registry.suse.com/rancher/charts/mirrored-cilium-startup-script:d69851597ea019af980891a4628fb36b7880ec26
+  type: image
+- source: quay.io/cilium/startup-script:5e928f628f9fc644a1d2651d6cd6aecbde0e7acd
   target: stgregistry.suse.com/rancher/mirrored-cilium-startup-script:5e928f628f9fc644a1d2651d6cd6aecbde0e7acd
   type: image
 - source: quay.io/cilium/startup-script:62bfbe88c17778aad7bef9fa57ff9e2d4a9ba0d8
@@ -16525,6 +27510,15 @@ sync:
   type: image
 - source: quay.io/cilium/startup-script:d69851597ea019af980891a4628fb36b7880ec26
   target: stgregistry.suse.com/rancher/mirrored-cilium-startup-script:d69851597ea019af980891a4628fb36b7880ec26
+  type: image
+- source: quay.io/cilium/startup-script:5e928f628f9fc644a1d2651d6cd6aecbde0e7acd
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-startup-script:5e928f628f9fc644a1d2651d6cd6aecbde0e7acd
+  type: image
+- source: quay.io/cilium/startup-script:62bfbe88c17778aad7bef9fa57ff9e2d4a9ba0d8
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-startup-script:62bfbe88c17778aad7bef9fa57ff9e2d4a9ba0d8
+  type: image
+- source: quay.io/cilium/startup-script:d69851597ea019af980891a4628fb36b7880ec26
+  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-startup-script:d69851597ea019af980891a4628fb36b7880ec26
   type: image
 - source: quay.io/coreos/etcd:v3.5.0
   target: docker.io/rancher/mirrored-coreos-etcd:v3.5.0
@@ -16677,6 +27671,81 @@ sync:
   target: registry.suse.com/rancher/mirrored-coreos-etcd:v3.6.4
   type: image
 - source: quay.io/coreos/etcd:v3.5.0
+  target: registry.suse.com/rancher/charts/mirrored-coreos-etcd:v3.5.0
+  type: image
+- source: quay.io/coreos/etcd:v3.5.10
+  target: registry.suse.com/rancher/charts/mirrored-coreos-etcd:v3.5.10
+  type: image
+- source: quay.io/coreos/etcd:v3.5.11
+  target: registry.suse.com/rancher/charts/mirrored-coreos-etcd:v3.5.11
+  type: image
+- source: quay.io/coreos/etcd:v3.5.12
+  target: registry.suse.com/rancher/charts/mirrored-coreos-etcd:v3.5.12
+  type: image
+- source: quay.io/coreos/etcd:v3.5.13
+  target: registry.suse.com/rancher/charts/mirrored-coreos-etcd:v3.5.13
+  type: image
+- source: quay.io/coreos/etcd:v3.5.14
+  target: registry.suse.com/rancher/charts/mirrored-coreos-etcd:v3.5.14
+  type: image
+- source: quay.io/coreos/etcd:v3.5.15
+  target: registry.suse.com/rancher/charts/mirrored-coreos-etcd:v3.5.15
+  type: image
+- source: quay.io/coreos/etcd:v3.5.16
+  target: registry.suse.com/rancher/charts/mirrored-coreos-etcd:v3.5.16
+  type: image
+- source: quay.io/coreos/etcd:v3.5.17
+  target: registry.suse.com/rancher/charts/mirrored-coreos-etcd:v3.5.17
+  type: image
+- source: quay.io/coreos/etcd:v3.5.18
+  target: registry.suse.com/rancher/charts/mirrored-coreos-etcd:v3.5.18
+  type: image
+- source: quay.io/coreos/etcd:v3.5.19
+  target: registry.suse.com/rancher/charts/mirrored-coreos-etcd:v3.5.19
+  type: image
+- source: quay.io/coreos/etcd:v3.5.2
+  target: registry.suse.com/rancher/charts/mirrored-coreos-etcd:v3.5.2
+  type: image
+- source: quay.io/coreos/etcd:v3.5.20
+  target: registry.suse.com/rancher/charts/mirrored-coreos-etcd:v3.5.20
+  type: image
+- source: quay.io/coreos/etcd:v3.5.21
+  target: registry.suse.com/rancher/charts/mirrored-coreos-etcd:v3.5.21
+  type: image
+- source: quay.io/coreos/etcd:v3.5.22
+  target: registry.suse.com/rancher/charts/mirrored-coreos-etcd:v3.5.22
+  type: image
+- source: quay.io/coreos/etcd:v3.5.3
+  target: registry.suse.com/rancher/charts/mirrored-coreos-etcd:v3.5.3
+  type: image
+- source: quay.io/coreos/etcd:v3.5.4
+  target: registry.suse.com/rancher/charts/mirrored-coreos-etcd:v3.5.4
+  type: image
+- source: quay.io/coreos/etcd:v3.5.6
+  target: registry.suse.com/rancher/charts/mirrored-coreos-etcd:v3.5.6
+  type: image
+- source: quay.io/coreos/etcd:v3.5.7
+  target: registry.suse.com/rancher/charts/mirrored-coreos-etcd:v3.5.7
+  type: image
+- source: quay.io/coreos/etcd:v3.5.9
+  target: registry.suse.com/rancher/charts/mirrored-coreos-etcd:v3.5.9
+  type: image
+- source: quay.io/coreos/etcd:v3.6.0
+  target: registry.suse.com/rancher/charts/mirrored-coreos-etcd:v3.6.0
+  type: image
+- source: quay.io/coreos/etcd:v3.6.1
+  target: registry.suse.com/rancher/charts/mirrored-coreos-etcd:v3.6.1
+  type: image
+- source: quay.io/coreos/etcd:v3.6.2
+  target: registry.suse.com/rancher/charts/mirrored-coreos-etcd:v3.6.2
+  type: image
+- source: quay.io/coreos/etcd:v3.6.3
+  target: registry.suse.com/rancher/charts/mirrored-coreos-etcd:v3.6.3
+  type: image
+- source: quay.io/coreos/etcd:v3.6.4
+  target: registry.suse.com/rancher/charts/mirrored-coreos-etcd:v3.6.4
+  type: image
+- source: quay.io/coreos/etcd:v3.5.0
   target: stgregistry.suse.com/rancher/mirrored-coreos-etcd:v3.5.0
   type: image
 - source: quay.io/coreos/etcd:v3.5.10
@@ -16751,6 +27820,81 @@ sync:
 - source: quay.io/coreos/etcd:v3.6.4
   target: stgregistry.suse.com/rancher/mirrored-coreos-etcd:v3.6.4
   type: image
+- source: quay.io/coreos/etcd:v3.5.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-coreos-etcd:v3.5.0
+  type: image
+- source: quay.io/coreos/etcd:v3.5.10
+  target: stgregistry.suse.com/rancher/charts/mirrored-coreos-etcd:v3.5.10
+  type: image
+- source: quay.io/coreos/etcd:v3.5.11
+  target: stgregistry.suse.com/rancher/charts/mirrored-coreos-etcd:v3.5.11
+  type: image
+- source: quay.io/coreos/etcd:v3.5.12
+  target: stgregistry.suse.com/rancher/charts/mirrored-coreos-etcd:v3.5.12
+  type: image
+- source: quay.io/coreos/etcd:v3.5.13
+  target: stgregistry.suse.com/rancher/charts/mirrored-coreos-etcd:v3.5.13
+  type: image
+- source: quay.io/coreos/etcd:v3.5.14
+  target: stgregistry.suse.com/rancher/charts/mirrored-coreos-etcd:v3.5.14
+  type: image
+- source: quay.io/coreos/etcd:v3.5.15
+  target: stgregistry.suse.com/rancher/charts/mirrored-coreos-etcd:v3.5.15
+  type: image
+- source: quay.io/coreos/etcd:v3.5.16
+  target: stgregistry.suse.com/rancher/charts/mirrored-coreos-etcd:v3.5.16
+  type: image
+- source: quay.io/coreos/etcd:v3.5.17
+  target: stgregistry.suse.com/rancher/charts/mirrored-coreos-etcd:v3.5.17
+  type: image
+- source: quay.io/coreos/etcd:v3.5.18
+  target: stgregistry.suse.com/rancher/charts/mirrored-coreos-etcd:v3.5.18
+  type: image
+- source: quay.io/coreos/etcd:v3.5.19
+  target: stgregistry.suse.com/rancher/charts/mirrored-coreos-etcd:v3.5.19
+  type: image
+- source: quay.io/coreos/etcd:v3.5.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-coreos-etcd:v3.5.2
+  type: image
+- source: quay.io/coreos/etcd:v3.5.20
+  target: stgregistry.suse.com/rancher/charts/mirrored-coreos-etcd:v3.5.20
+  type: image
+- source: quay.io/coreos/etcd:v3.5.21
+  target: stgregistry.suse.com/rancher/charts/mirrored-coreos-etcd:v3.5.21
+  type: image
+- source: quay.io/coreos/etcd:v3.5.22
+  target: stgregistry.suse.com/rancher/charts/mirrored-coreos-etcd:v3.5.22
+  type: image
+- source: quay.io/coreos/etcd:v3.5.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-coreos-etcd:v3.5.3
+  type: image
+- source: quay.io/coreos/etcd:v3.5.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-coreos-etcd:v3.5.4
+  type: image
+- source: quay.io/coreos/etcd:v3.5.6
+  target: stgregistry.suse.com/rancher/charts/mirrored-coreos-etcd:v3.5.6
+  type: image
+- source: quay.io/coreos/etcd:v3.5.7
+  target: stgregistry.suse.com/rancher/charts/mirrored-coreos-etcd:v3.5.7
+  type: image
+- source: quay.io/coreos/etcd:v3.5.9
+  target: stgregistry.suse.com/rancher/charts/mirrored-coreos-etcd:v3.5.9
+  type: image
+- source: quay.io/coreos/etcd:v3.6.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-coreos-etcd:v3.6.0
+  type: image
+- source: quay.io/coreos/etcd:v3.6.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-coreos-etcd:v3.6.1
+  type: image
+- source: quay.io/coreos/etcd:v3.6.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-coreos-etcd:v3.6.2
+  type: image
+- source: quay.io/coreos/etcd:v3.6.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-coreos-etcd:v3.6.3
+  type: image
+- source: quay.io/coreos/etcd:v3.6.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-coreos-etcd:v3.6.4
+  type: image
 - source: quay.io/coreos/flannel:v0.13.0
   target: docker.io/rancher/mirrored-coreos-flannel:v0.13.0
   type: image
@@ -16776,6 +27920,18 @@ sync:
   target: registry.suse.com/rancher/mirrored-coreos-flannel:v0.15.1
   type: image
 - source: quay.io/coreos/flannel:v0.13.0
+  target: registry.suse.com/rancher/charts/mirrored-coreos-flannel:v0.13.0
+  type: image
+- source: quay.io/coreos/flannel:v0.14.0
+  target: registry.suse.com/rancher/charts/mirrored-coreos-flannel:v0.14.0
+  type: image
+- source: quay.io/coreos/flannel:v0.15.0
+  target: registry.suse.com/rancher/charts/mirrored-coreos-flannel:v0.15.0
+  type: image
+- source: quay.io/coreos/flannel:v0.15.1
+  target: registry.suse.com/rancher/charts/mirrored-coreos-flannel:v0.15.1
+  type: image
+- source: quay.io/coreos/flannel:v0.13.0
   target: stgregistry.suse.com/rancher/mirrored-coreos-flannel:v0.13.0
   type: image
 - source: quay.io/coreos/flannel:v0.14.0
@@ -16787,6 +27943,18 @@ sync:
 - source: quay.io/coreos/flannel:v0.15.1
   target: stgregistry.suse.com/rancher/mirrored-coreos-flannel:v0.15.1
   type: image
+- source: quay.io/coreos/flannel:v0.13.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-coreos-flannel:v0.13.0
+  type: image
+- source: quay.io/coreos/flannel:v0.14.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-coreos-flannel:v0.14.0
+  type: image
+- source: quay.io/coreos/flannel:v0.15.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-coreos-flannel:v0.15.0
+  type: image
+- source: quay.io/coreos/flannel:v0.15.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-coreos-flannel:v0.15.1
+  type: image
 - source: quay.io/jetstack/cert-manager-controller:v0.8.1
   target: docker.io/rancher/mirrored-jetstack-cert-manager-controller:v0.8.1
   type: image
@@ -16794,7 +27962,13 @@ sync:
   target: registry.suse.com/rancher/mirrored-jetstack-cert-manager-controller:v0.8.1
   type: image
 - source: quay.io/jetstack/cert-manager-controller:v0.8.1
+  target: registry.suse.com/rancher/charts/mirrored-jetstack-cert-manager-controller:v0.8.1
+  type: image
+- source: quay.io/jetstack/cert-manager-controller:v0.8.1
   target: stgregistry.suse.com/rancher/mirrored-jetstack-cert-manager-controller:v0.8.1
+  type: image
+- source: quay.io/jetstack/cert-manager-controller:v0.8.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-jetstack-cert-manager-controller:v0.8.1
   type: image
 - source: quay.io/kiali/kiali:v1.22.1
   target: docker.io/rancher/kiali-kiali:v1.22.1
@@ -16827,6 +28001,21 @@ sync:
   target: registry.suse.com/rancher/kiali-kiali:v1.29.0
   type: image
 - source: quay.io/kiali/kiali:v1.22.1
+  target: registry.suse.com/rancher/charts/kiali-kiali:v1.22.1
+  type: image
+- source: quay.io/kiali/kiali:v1.23.0
+  target: registry.suse.com/rancher/charts/kiali-kiali:v1.23.0
+  type: image
+- source: quay.io/kiali/kiali:v1.24.0
+  target: registry.suse.com/rancher/charts/kiali-kiali:v1.24.0
+  type: image
+- source: quay.io/kiali/kiali:v1.28.0
+  target: registry.suse.com/rancher/charts/kiali-kiali:v1.28.0
+  type: image
+- source: quay.io/kiali/kiali:v1.29.0
+  target: registry.suse.com/rancher/charts/kiali-kiali:v1.29.0
+  type: image
+- source: quay.io/kiali/kiali:v1.22.1
   target: stgregistry.suse.com/rancher/kiali-kiali:v1.22.1
   type: image
 - source: quay.io/kiali/kiali:v1.23.0
@@ -16840,6 +28029,21 @@ sync:
   type: image
 - source: quay.io/kiali/kiali:v1.29.0
   target: stgregistry.suse.com/rancher/kiali-kiali:v1.29.0
+  type: image
+- source: quay.io/kiali/kiali:v1.22.1
+  target: stgregistry.suse.com/rancher/charts/kiali-kiali:v1.22.1
+  type: image
+- source: quay.io/kiali/kiali:v1.23.0
+  target: stgregistry.suse.com/rancher/charts/kiali-kiali:v1.23.0
+  type: image
+- source: quay.io/kiali/kiali:v1.24.0
+  target: stgregistry.suse.com/rancher/charts/kiali-kiali:v1.24.0
+  type: image
+- source: quay.io/kiali/kiali:v1.28.0
+  target: stgregistry.suse.com/rancher/charts/kiali-kiali:v1.28.0
+  type: image
+- source: quay.io/kiali/kiali:v1.29.0
+  target: stgregistry.suse.com/rancher/charts/kiali-kiali:v1.29.0
   type: image
 - source: quay.io/kiali/kiali:v1.17
   target: docker.io/rancher/mirrored-kiali-kiali:v1.17
@@ -17010,6 +28214,90 @@ sync:
   target: registry.suse.com/rancher/mirrored-kiali-kiali:v2.7.1
   type: image
 - source: quay.io/kiali/kiali:v1.17
+  target: registry.suse.com/rancher/charts/mirrored-kiali-kiali:v1.17
+  type: image
+- source: quay.io/kiali/kiali:v1.29.0
+  target: registry.suse.com/rancher/charts/mirrored-kiali-kiali:v1.29.0
+  type: image
+- source: quay.io/kiali/kiali:v1.32.0
+  target: registry.suse.com/rancher/charts/mirrored-kiali-kiali:v1.32.0
+  type: image
+- source: quay.io/kiali/kiali:v1.34.1
+  target: registry.suse.com/rancher/charts/mirrored-kiali-kiali:v1.34.1
+  type: image
+- source: quay.io/kiali/kiali:v1.35.0
+  target: registry.suse.com/rancher/charts/mirrored-kiali-kiali:v1.35.0
+  type: image
+- source: quay.io/kiali/kiali:v1.40.1
+  target: registry.suse.com/rancher/charts/mirrored-kiali-kiali:v1.40.1
+  type: image
+- source: quay.io/kiali/kiali:v1.41.0
+  target: registry.suse.com/rancher/charts/mirrored-kiali-kiali:v1.41.0
+  type: image
+- source: quay.io/kiali/kiali:v1.44.0
+  target: registry.suse.com/rancher/charts/mirrored-kiali-kiali:v1.44.0
+  type: image
+- source: quay.io/kiali/kiali:v1.50.0
+  target: registry.suse.com/rancher/charts/mirrored-kiali-kiali:v1.50.0
+  type: image
+- source: quay.io/kiali/kiali:v1.52.0
+  target: registry.suse.com/rancher/charts/mirrored-kiali-kiali:v1.52.0
+  type: image
+- source: quay.io/kiali/kiali:v1.55.0
+  target: registry.suse.com/rancher/charts/mirrored-kiali-kiali:v1.55.0
+  type: image
+- source: quay.io/kiali/kiali:v1.57.3
+  target: registry.suse.com/rancher/charts/mirrored-kiali-kiali:v1.57.3
+  type: image
+- source: quay.io/kiali/kiali:v1.59.0
+  target: registry.suse.com/rancher/charts/mirrored-kiali-kiali:v1.59.0
+  type: image
+- source: quay.io/kiali/kiali:v1.63.2
+  target: registry.suse.com/rancher/charts/mirrored-kiali-kiali:v1.63.2
+  type: image
+- source: quay.io/kiali/kiali:v1.66.0
+  target: registry.suse.com/rancher/charts/mirrored-kiali-kiali:v1.66.0
+  type: image
+- source: quay.io/kiali/kiali:v1.67.0
+  target: registry.suse.com/rancher/charts/mirrored-kiali-kiali:v1.67.0
+  type: image
+- source: quay.io/kiali/kiali:v1.72.0
+  target: registry.suse.com/rancher/charts/mirrored-kiali-kiali:v1.72.0
+  type: image
+- source: quay.io/kiali/kiali:v1.74.0
+  target: registry.suse.com/rancher/charts/mirrored-kiali-kiali:v1.74.0
+  type: image
+- source: quay.io/kiali/kiali:v1.75.0
+  target: registry.suse.com/rancher/charts/mirrored-kiali-kiali:v1.75.0
+  type: image
+- source: quay.io/kiali/kiali:v1.76.0
+  target: registry.suse.com/rancher/charts/mirrored-kiali-kiali:v1.76.0
+  type: image
+- source: quay.io/kiali/kiali:v1.78.0
+  target: registry.suse.com/rancher/charts/mirrored-kiali-kiali:v1.78.0
+  type: image
+- source: quay.io/kiali/kiali:v1.79.0
+  target: registry.suse.com/rancher/charts/mirrored-kiali-kiali:v1.79.0
+  type: image
+- source: quay.io/kiali/kiali:v1.85.0
+  target: registry.suse.com/rancher/charts/mirrored-kiali-kiali:v1.85.0
+  type: image
+- source: quay.io/kiali/kiali:v1.86.0
+  target: registry.suse.com/rancher/charts/mirrored-kiali-kiali:v1.86.0
+  type: image
+- source: quay.io/kiali/kiali:v1.89.3
+  target: registry.suse.com/rancher/charts/mirrored-kiali-kiali:v1.89.3
+  type: image
+- source: quay.io/kiali/kiali:v2.1.0
+  target: registry.suse.com/rancher/charts/mirrored-kiali-kiali:v2.1.0
+  type: image
+- source: quay.io/kiali/kiali:v2.12.0
+  target: registry.suse.com/rancher/charts/mirrored-kiali-kiali:v2.12.0
+  type: image
+- source: quay.io/kiali/kiali:v2.7.1
+  target: registry.suse.com/rancher/charts/mirrored-kiali-kiali:v2.7.1
+  type: image
+- source: quay.io/kiali/kiali:v1.17
   target: stgregistry.suse.com/rancher/mirrored-kiali-kiali:v1.17
   type: image
 - source: quay.io/kiali/kiali:v1.29.0
@@ -17093,6 +28381,90 @@ sync:
 - source: quay.io/kiali/kiali:v2.7.1
   target: stgregistry.suse.com/rancher/mirrored-kiali-kiali:v2.7.1
   type: image
+- source: quay.io/kiali/kiali:v1.17
+  target: stgregistry.suse.com/rancher/charts/mirrored-kiali-kiali:v1.17
+  type: image
+- source: quay.io/kiali/kiali:v1.29.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-kiali-kiali:v1.29.0
+  type: image
+- source: quay.io/kiali/kiali:v1.32.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-kiali-kiali:v1.32.0
+  type: image
+- source: quay.io/kiali/kiali:v1.34.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-kiali-kiali:v1.34.1
+  type: image
+- source: quay.io/kiali/kiali:v1.35.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-kiali-kiali:v1.35.0
+  type: image
+- source: quay.io/kiali/kiali:v1.40.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-kiali-kiali:v1.40.1
+  type: image
+- source: quay.io/kiali/kiali:v1.41.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-kiali-kiali:v1.41.0
+  type: image
+- source: quay.io/kiali/kiali:v1.44.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-kiali-kiali:v1.44.0
+  type: image
+- source: quay.io/kiali/kiali:v1.50.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-kiali-kiali:v1.50.0
+  type: image
+- source: quay.io/kiali/kiali:v1.52.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-kiali-kiali:v1.52.0
+  type: image
+- source: quay.io/kiali/kiali:v1.55.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-kiali-kiali:v1.55.0
+  type: image
+- source: quay.io/kiali/kiali:v1.57.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-kiali-kiali:v1.57.3
+  type: image
+- source: quay.io/kiali/kiali:v1.59.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-kiali-kiali:v1.59.0
+  type: image
+- source: quay.io/kiali/kiali:v1.63.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-kiali-kiali:v1.63.2
+  type: image
+- source: quay.io/kiali/kiali:v1.66.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-kiali-kiali:v1.66.0
+  type: image
+- source: quay.io/kiali/kiali:v1.67.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-kiali-kiali:v1.67.0
+  type: image
+- source: quay.io/kiali/kiali:v1.72.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-kiali-kiali:v1.72.0
+  type: image
+- source: quay.io/kiali/kiali:v1.74.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-kiali-kiali:v1.74.0
+  type: image
+- source: quay.io/kiali/kiali:v1.75.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-kiali-kiali:v1.75.0
+  type: image
+- source: quay.io/kiali/kiali:v1.76.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-kiali-kiali:v1.76.0
+  type: image
+- source: quay.io/kiali/kiali:v1.78.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-kiali-kiali:v1.78.0
+  type: image
+- source: quay.io/kiali/kiali:v1.79.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-kiali-kiali:v1.79.0
+  type: image
+- source: quay.io/kiali/kiali:v1.85.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-kiali-kiali:v1.85.0
+  type: image
+- source: quay.io/kiali/kiali:v1.86.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-kiali-kiali:v1.86.0
+  type: image
+- source: quay.io/kiali/kiali:v1.89.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-kiali-kiali:v1.89.3
+  type: image
+- source: quay.io/kiali/kiali:v2.1.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-kiali-kiali:v2.1.0
+  type: image
+- source: quay.io/kiali/kiali:v2.12.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-kiali-kiali:v2.12.0
+  type: image
+- source: quay.io/kiali/kiali:v2.7.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-kiali-kiali:v2.7.1
+  type: image
 - source: quay.io/kiwigrid/k8s-sidecar:1.10.7
   target: docker.io/rancher/mirrored-kiwigrid-k8s-sidecar:1.10.7
   type: image
@@ -17154,6 +28526,36 @@ sync:
   target: registry.suse.com/rancher/mirrored-kiwigrid-k8s-sidecar:1.30.0
   type: image
 - source: quay.io/kiwigrid/k8s-sidecar:1.10.7
+  target: registry.suse.com/rancher/charts/mirrored-kiwigrid-k8s-sidecar:1.10.7
+  type: image
+- source: quay.io/kiwigrid/k8s-sidecar:1.12.2
+  target: registry.suse.com/rancher/charts/mirrored-kiwigrid-k8s-sidecar:1.12.2
+  type: image
+- source: quay.io/kiwigrid/k8s-sidecar:1.12.3
+  target: registry.suse.com/rancher/charts/mirrored-kiwigrid-k8s-sidecar:1.12.3
+  type: image
+- source: quay.io/kiwigrid/k8s-sidecar:1.15.6
+  target: registry.suse.com/rancher/charts/mirrored-kiwigrid-k8s-sidecar:1.15.6
+  type: image
+- source: quay.io/kiwigrid/k8s-sidecar:1.15.9
+  target: registry.suse.com/rancher/charts/mirrored-kiwigrid-k8s-sidecar:1.15.9
+  type: image
+- source: quay.io/kiwigrid/k8s-sidecar:1.19.2
+  target: registry.suse.com/rancher/charts/mirrored-kiwigrid-k8s-sidecar:1.19.2
+  type: image
+- source: quay.io/kiwigrid/k8s-sidecar:1.24.6
+  target: registry.suse.com/rancher/charts/mirrored-kiwigrid-k8s-sidecar:1.24.6
+  type: image
+- source: quay.io/kiwigrid/k8s-sidecar:1.26.1
+  target: registry.suse.com/rancher/charts/mirrored-kiwigrid-k8s-sidecar:1.26.1
+  type: image
+- source: quay.io/kiwigrid/k8s-sidecar:1.28.0
+  target: registry.suse.com/rancher/charts/mirrored-kiwigrid-k8s-sidecar:1.28.0
+  type: image
+- source: quay.io/kiwigrid/k8s-sidecar:1.30.0
+  target: registry.suse.com/rancher/charts/mirrored-kiwigrid-k8s-sidecar:1.30.0
+  type: image
+- source: quay.io/kiwigrid/k8s-sidecar:1.10.7
   target: stgregistry.suse.com/rancher/mirrored-kiwigrid-k8s-sidecar:1.10.7
   type: image
 - source: quay.io/kiwigrid/k8s-sidecar:1.12.2
@@ -17183,6 +28585,36 @@ sync:
 - source: quay.io/kiwigrid/k8s-sidecar:1.30.0
   target: stgregistry.suse.com/rancher/mirrored-kiwigrid-k8s-sidecar:1.30.0
   type: image
+- source: quay.io/kiwigrid/k8s-sidecar:1.10.7
+  target: stgregistry.suse.com/rancher/charts/mirrored-kiwigrid-k8s-sidecar:1.10.7
+  type: image
+- source: quay.io/kiwigrid/k8s-sidecar:1.12.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-kiwigrid-k8s-sidecar:1.12.2
+  type: image
+- source: quay.io/kiwigrid/k8s-sidecar:1.12.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-kiwigrid-k8s-sidecar:1.12.3
+  type: image
+- source: quay.io/kiwigrid/k8s-sidecar:1.15.6
+  target: stgregistry.suse.com/rancher/charts/mirrored-kiwigrid-k8s-sidecar:1.15.6
+  type: image
+- source: quay.io/kiwigrid/k8s-sidecar:1.15.9
+  target: stgregistry.suse.com/rancher/charts/mirrored-kiwigrid-k8s-sidecar:1.15.9
+  type: image
+- source: quay.io/kiwigrid/k8s-sidecar:1.19.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-kiwigrid-k8s-sidecar:1.19.2
+  type: image
+- source: quay.io/kiwigrid/k8s-sidecar:1.24.6
+  target: stgregistry.suse.com/rancher/charts/mirrored-kiwigrid-k8s-sidecar:1.24.6
+  type: image
+- source: quay.io/kiwigrid/k8s-sidecar:1.26.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-kiwigrid-k8s-sidecar:1.26.1
+  type: image
+- source: quay.io/kiwigrid/k8s-sidecar:1.28.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-kiwigrid-k8s-sidecar:1.28.0
+  type: image
+- source: quay.io/kiwigrid/k8s-sidecar:1.30.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-kiwigrid-k8s-sidecar:1.30.0
+  type: image
 - source: quay.io/minio/minio:RELEASE.2022-03-24T00-43-44Z
   target: docker.io/rancher/mirrored-minio-minio:RELEASE.2022-03-24T00-43-44Z
   type: image
@@ -17190,7 +28622,13 @@ sync:
   target: registry.suse.com/rancher/mirrored-minio-minio:RELEASE.2022-03-24T00-43-44Z
   type: image
 - source: quay.io/minio/minio:RELEASE.2022-03-24T00-43-44Z
+  target: registry.suse.com/rancher/charts/mirrored-minio-minio:RELEASE.2022-03-24T00-43-44Z
+  type: image
+- source: quay.io/minio/minio:RELEASE.2022-03-24T00-43-44Z
   target: stgregistry.suse.com/rancher/mirrored-minio-minio:RELEASE.2022-03-24T00-43-44Z
+  type: image
+- source: quay.io/minio/minio:RELEASE.2022-03-24T00-43-44Z
+  target: stgregistry.suse.com/rancher/charts/mirrored-minio-minio:RELEASE.2022-03-24T00-43-44Z
   type: image
 - source: quay.io/prometheus-operator/admission-webhook:v0.72.0
   target: docker.io/rancher/mirrored-prometheus-operator-admission-webhook:v0.72.0
@@ -17229,6 +28667,24 @@ sync:
   target: registry.suse.com/rancher/mirrored-prometheus-operator-admission-webhook:v0.85.0
   type: image
 - source: quay.io/prometheus-operator/admission-webhook:v0.72.0
+  target: registry.suse.com/rancher/charts/mirrored-prometheus-operator-admission-webhook:v0.72.0
+  type: image
+- source: quay.io/prometheus-operator/admission-webhook:v0.75.1
+  target: registry.suse.com/rancher/charts/mirrored-prometheus-operator-admission-webhook:v0.75.1
+  type: image
+- source: quay.io/prometheus-operator/admission-webhook:v0.77.2
+  target: registry.suse.com/rancher/charts/mirrored-prometheus-operator-admission-webhook:v0.77.2
+  type: image
+- source: quay.io/prometheus-operator/admission-webhook:v0.79.0
+  target: registry.suse.com/rancher/charts/mirrored-prometheus-operator-admission-webhook:v0.79.0
+  type: image
+- source: quay.io/prometheus-operator/admission-webhook:v0.80.1
+  target: registry.suse.com/rancher/charts/mirrored-prometheus-operator-admission-webhook:v0.80.1
+  type: image
+- source: quay.io/prometheus-operator/admission-webhook:v0.85.0
+  target: registry.suse.com/rancher/charts/mirrored-prometheus-operator-admission-webhook:v0.85.0
+  type: image
+- source: quay.io/prometheus-operator/admission-webhook:v0.72.0
   target: stgregistry.suse.com/rancher/mirrored-prometheus-operator-admission-webhook:v0.72.0
   type: image
 - source: quay.io/prometheus-operator/admission-webhook:v0.75.1
@@ -17246,6 +28702,24 @@ sync:
 - source: quay.io/prometheus-operator/admission-webhook:v0.85.0
   target: stgregistry.suse.com/rancher/mirrored-prometheus-operator-admission-webhook:v0.85.0
   type: image
+- source: quay.io/prometheus-operator/admission-webhook:v0.72.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-operator-admission-webhook:v0.72.0
+  type: image
+- source: quay.io/prometheus-operator/admission-webhook:v0.75.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-operator-admission-webhook:v0.75.1
+  type: image
+- source: quay.io/prometheus-operator/admission-webhook:v0.77.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-operator-admission-webhook:v0.77.2
+  type: image
+- source: quay.io/prometheus-operator/admission-webhook:v0.79.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-operator-admission-webhook:v0.79.0
+  type: image
+- source: quay.io/prometheus-operator/admission-webhook:v0.80.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-operator-admission-webhook:v0.80.1
+  type: image
+- source: quay.io/prometheus-operator/admission-webhook:v0.85.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-operator-admission-webhook:v0.85.0
+  type: image
 - source: quay.io/prometheus-operator/prometheus-config-reloader:v0.43.0
   target: docker.io/rancher/coreos-prometheus-config-reloader:v0.43.0
   type: image
@@ -17253,7 +28727,13 @@ sync:
   target: registry.suse.com/rancher/coreos-prometheus-config-reloader:v0.43.0
   type: image
 - source: quay.io/prometheus-operator/prometheus-config-reloader:v0.43.0
+  target: registry.suse.com/rancher/charts/coreos-prometheus-config-reloader:v0.43.0
+  type: image
+- source: quay.io/prometheus-operator/prometheus-config-reloader:v0.43.0
   target: stgregistry.suse.com/rancher/coreos-prometheus-config-reloader:v0.43.0
+  type: image
+- source: quay.io/prometheus-operator/prometheus-config-reloader:v0.43.0
+  target: stgregistry.suse.com/rancher/charts/coreos-prometheus-config-reloader:v0.43.0
   type: image
 - source: quay.io/prometheus-operator/prometheus-config-reloader:v0.46.0
   target: docker.io/rancher/mirrored-prometheus-operator-prometheus-config-reloader:v0.46.0
@@ -17334,6 +28814,45 @@ sync:
   target: registry.suse.com/rancher/mirrored-prometheus-operator-prometheus-config-reloader:v0.85.0
   type: image
 - source: quay.io/prometheus-operator/prometheus-config-reloader:v0.46.0
+  target: registry.suse.com/rancher/charts/mirrored-prometheus-operator-prometheus-config-reloader:v0.46.0
+  type: image
+- source: quay.io/prometheus-operator/prometheus-config-reloader:v0.48.0
+  target: registry.suse.com/rancher/charts/mirrored-prometheus-operator-prometheus-config-reloader:v0.48.0
+  type: image
+- source: quay.io/prometheus-operator/prometheus-config-reloader:v0.50.0
+  target: registry.suse.com/rancher/charts/mirrored-prometheus-operator-prometheus-config-reloader:v0.50.0
+  type: image
+- source: quay.io/prometheus-operator/prometheus-config-reloader:v0.59.1
+  target: registry.suse.com/rancher/charts/mirrored-prometheus-operator-prometheus-config-reloader:v0.59.1
+  type: image
+- source: quay.io/prometheus-operator/prometheus-config-reloader:v0.65.1
+  target: registry.suse.com/rancher/charts/mirrored-prometheus-operator-prometheus-config-reloader:v0.65.1
+  type: image
+- source: quay.io/prometheus-operator/prometheus-config-reloader:v0.70.0
+  target: registry.suse.com/rancher/charts/mirrored-prometheus-operator-prometheus-config-reloader:v0.70.0
+  type: image
+- source: quay.io/prometheus-operator/prometheus-config-reloader:v0.72.0
+  target: registry.suse.com/rancher/charts/mirrored-prometheus-operator-prometheus-config-reloader:v0.72.0
+  type: image
+- source: quay.io/prometheus-operator/prometheus-config-reloader:v0.75.1
+  target: registry.suse.com/rancher/charts/mirrored-prometheus-operator-prometheus-config-reloader:v0.75.1
+  type: image
+- source: quay.io/prometheus-operator/prometheus-config-reloader:v0.77.2
+  target: registry.suse.com/rancher/charts/mirrored-prometheus-operator-prometheus-config-reloader:v0.77.2
+  type: image
+- source: quay.io/prometheus-operator/prometheus-config-reloader:v0.79.0
+  target: registry.suse.com/rancher/charts/mirrored-prometheus-operator-prometheus-config-reloader:v0.79.0
+  type: image
+- source: quay.io/prometheus-operator/prometheus-config-reloader:v0.79.2
+  target: registry.suse.com/rancher/charts/mirrored-prometheus-operator-prometheus-config-reloader:v0.79.2
+  type: image
+- source: quay.io/prometheus-operator/prometheus-config-reloader:v0.80.1
+  target: registry.suse.com/rancher/charts/mirrored-prometheus-operator-prometheus-config-reloader:v0.80.1
+  type: image
+- source: quay.io/prometheus-operator/prometheus-config-reloader:v0.85.0
+  target: registry.suse.com/rancher/charts/mirrored-prometheus-operator-prometheus-config-reloader:v0.85.0
+  type: image
+- source: quay.io/prometheus-operator/prometheus-config-reloader:v0.46.0
   target: stgregistry.suse.com/rancher/mirrored-prometheus-operator-prometheus-config-reloader:v0.46.0
   type: image
 - source: quay.io/prometheus-operator/prometheus-config-reloader:v0.48.0
@@ -17372,6 +28891,45 @@ sync:
 - source: quay.io/prometheus-operator/prometheus-config-reloader:v0.85.0
   target: stgregistry.suse.com/rancher/mirrored-prometheus-operator-prometheus-config-reloader:v0.85.0
   type: image
+- source: quay.io/prometheus-operator/prometheus-config-reloader:v0.46.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-operator-prometheus-config-reloader:v0.46.0
+  type: image
+- source: quay.io/prometheus-operator/prometheus-config-reloader:v0.48.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-operator-prometheus-config-reloader:v0.48.0
+  type: image
+- source: quay.io/prometheus-operator/prometheus-config-reloader:v0.50.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-operator-prometheus-config-reloader:v0.50.0
+  type: image
+- source: quay.io/prometheus-operator/prometheus-config-reloader:v0.59.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-operator-prometheus-config-reloader:v0.59.1
+  type: image
+- source: quay.io/prometheus-operator/prometheus-config-reloader:v0.65.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-operator-prometheus-config-reloader:v0.65.1
+  type: image
+- source: quay.io/prometheus-operator/prometheus-config-reloader:v0.70.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-operator-prometheus-config-reloader:v0.70.0
+  type: image
+- source: quay.io/prometheus-operator/prometheus-config-reloader:v0.72.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-operator-prometheus-config-reloader:v0.72.0
+  type: image
+- source: quay.io/prometheus-operator/prometheus-config-reloader:v0.75.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-operator-prometheus-config-reloader:v0.75.1
+  type: image
+- source: quay.io/prometheus-operator/prometheus-config-reloader:v0.77.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-operator-prometheus-config-reloader:v0.77.2
+  type: image
+- source: quay.io/prometheus-operator/prometheus-config-reloader:v0.79.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-operator-prometheus-config-reloader:v0.79.0
+  type: image
+- source: quay.io/prometheus-operator/prometheus-config-reloader:v0.79.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-operator-prometheus-config-reloader:v0.79.2
+  type: image
+- source: quay.io/prometheus-operator/prometheus-config-reloader:v0.80.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-operator-prometheus-config-reloader:v0.80.1
+  type: image
+- source: quay.io/prometheus-operator/prometheus-config-reloader:v0.85.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-operator-prometheus-config-reloader:v0.85.0
+  type: image
 - source: quay.io/prometheus-operator/prometheus-operator:v0.43.0
   target: docker.io/rancher/coreos-prometheus-operator:v0.43.0
   type: image
@@ -17379,7 +28937,13 @@ sync:
   target: registry.suse.com/rancher/coreos-prometheus-operator:v0.43.0
   type: image
 - source: quay.io/prometheus-operator/prometheus-operator:v0.43.0
+  target: registry.suse.com/rancher/charts/coreos-prometheus-operator:v0.43.0
+  type: image
+- source: quay.io/prometheus-operator/prometheus-operator:v0.43.0
   target: stgregistry.suse.com/rancher/coreos-prometheus-operator:v0.43.0
+  type: image
+- source: quay.io/prometheus-operator/prometheus-operator:v0.43.0
+  target: stgregistry.suse.com/rancher/charts/coreos-prometheus-operator:v0.43.0
   type: image
 - source: quay.io/prometheus-operator/prometheus-operator:v0.46.0
   target: docker.io/rancher/mirrored-prometheus-operator-prometheus-operator:v0.46.0
@@ -17460,6 +29024,45 @@ sync:
   target: registry.suse.com/rancher/mirrored-prometheus-operator-prometheus-operator:v0.85.0
   type: image
 - source: quay.io/prometheus-operator/prometheus-operator:v0.46.0
+  target: registry.suse.com/rancher/charts/mirrored-prometheus-operator-prometheus-operator:v0.46.0
+  type: image
+- source: quay.io/prometheus-operator/prometheus-operator:v0.48.0
+  target: registry.suse.com/rancher/charts/mirrored-prometheus-operator-prometheus-operator:v0.48.0
+  type: image
+- source: quay.io/prometheus-operator/prometheus-operator:v0.50.0
+  target: registry.suse.com/rancher/charts/mirrored-prometheus-operator-prometheus-operator:v0.50.0
+  type: image
+- source: quay.io/prometheus-operator/prometheus-operator:v0.59.1
+  target: registry.suse.com/rancher/charts/mirrored-prometheus-operator-prometheus-operator:v0.59.1
+  type: image
+- source: quay.io/prometheus-operator/prometheus-operator:v0.65.1
+  target: registry.suse.com/rancher/charts/mirrored-prometheus-operator-prometheus-operator:v0.65.1
+  type: image
+- source: quay.io/prometheus-operator/prometheus-operator:v0.70.0
+  target: registry.suse.com/rancher/charts/mirrored-prometheus-operator-prometheus-operator:v0.70.0
+  type: image
+- source: quay.io/prometheus-operator/prometheus-operator:v0.72.0
+  target: registry.suse.com/rancher/charts/mirrored-prometheus-operator-prometheus-operator:v0.72.0
+  type: image
+- source: quay.io/prometheus-operator/prometheus-operator:v0.75.1
+  target: registry.suse.com/rancher/charts/mirrored-prometheus-operator-prometheus-operator:v0.75.1
+  type: image
+- source: quay.io/prometheus-operator/prometheus-operator:v0.77.2
+  target: registry.suse.com/rancher/charts/mirrored-prometheus-operator-prometheus-operator:v0.77.2
+  type: image
+- source: quay.io/prometheus-operator/prometheus-operator:v0.79.0
+  target: registry.suse.com/rancher/charts/mirrored-prometheus-operator-prometheus-operator:v0.79.0
+  type: image
+- source: quay.io/prometheus-operator/prometheus-operator:v0.79.2
+  target: registry.suse.com/rancher/charts/mirrored-prometheus-operator-prometheus-operator:v0.79.2
+  type: image
+- source: quay.io/prometheus-operator/prometheus-operator:v0.80.1
+  target: registry.suse.com/rancher/charts/mirrored-prometheus-operator-prometheus-operator:v0.80.1
+  type: image
+- source: quay.io/prometheus-operator/prometheus-operator:v0.85.0
+  target: registry.suse.com/rancher/charts/mirrored-prometheus-operator-prometheus-operator:v0.85.0
+  type: image
+- source: quay.io/prometheus-operator/prometheus-operator:v0.46.0
   target: stgregistry.suse.com/rancher/mirrored-prometheus-operator-prometheus-operator:v0.46.0
   type: image
 - source: quay.io/prometheus-operator/prometheus-operator:v0.48.0
@@ -17497,6 +29100,45 @@ sync:
   type: image
 - source: quay.io/prometheus-operator/prometheus-operator:v0.85.0
   target: stgregistry.suse.com/rancher/mirrored-prometheus-operator-prometheus-operator:v0.85.0
+  type: image
+- source: quay.io/prometheus-operator/prometheus-operator:v0.46.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-operator-prometheus-operator:v0.46.0
+  type: image
+- source: quay.io/prometheus-operator/prometheus-operator:v0.48.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-operator-prometheus-operator:v0.48.0
+  type: image
+- source: quay.io/prometheus-operator/prometheus-operator:v0.50.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-operator-prometheus-operator:v0.50.0
+  type: image
+- source: quay.io/prometheus-operator/prometheus-operator:v0.59.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-operator-prometheus-operator:v0.59.1
+  type: image
+- source: quay.io/prometheus-operator/prometheus-operator:v0.65.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-operator-prometheus-operator:v0.65.1
+  type: image
+- source: quay.io/prometheus-operator/prometheus-operator:v0.70.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-operator-prometheus-operator:v0.70.0
+  type: image
+- source: quay.io/prometheus-operator/prometheus-operator:v0.72.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-operator-prometheus-operator:v0.72.0
+  type: image
+- source: quay.io/prometheus-operator/prometheus-operator:v0.75.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-operator-prometheus-operator:v0.75.1
+  type: image
+- source: quay.io/prometheus-operator/prometheus-operator:v0.77.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-operator-prometheus-operator:v0.77.2
+  type: image
+- source: quay.io/prometheus-operator/prometheus-operator:v0.79.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-operator-prometheus-operator:v0.79.0
+  type: image
+- source: quay.io/prometheus-operator/prometheus-operator:v0.79.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-operator-prometheus-operator:v0.79.2
+  type: image
+- source: quay.io/prometheus-operator/prometheus-operator:v0.80.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-operator-prometheus-operator:v0.80.1
+  type: image
+- source: quay.io/prometheus-operator/prometheus-operator:v0.85.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-operator-prometheus-operator:v0.85.0
   type: image
 - source: quay.io/prometheus/alertmanager:v0.22.0
   target: docker.io/rancher/mirrored-prometheus-alertmanager:v0.22.0
@@ -17541,6 +29183,27 @@ sync:
   target: registry.suse.com/rancher/mirrored-prometheus-alertmanager:v0.28.1
   type: image
 - source: quay.io/prometheus/alertmanager:v0.22.0
+  target: registry.suse.com/rancher/charts/mirrored-prometheus-alertmanager:v0.22.0
+  type: image
+- source: quay.io/prometheus/alertmanager:v0.22.2
+  target: registry.suse.com/rancher/charts/mirrored-prometheus-alertmanager:v0.22.2
+  type: image
+- source: quay.io/prometheus/alertmanager:v0.24.0
+  target: registry.suse.com/rancher/charts/mirrored-prometheus-alertmanager:v0.24.0
+  type: image
+- source: quay.io/prometheus/alertmanager:v0.25.0
+  target: registry.suse.com/rancher/charts/mirrored-prometheus-alertmanager:v0.25.0
+  type: image
+- source: quay.io/prometheus/alertmanager:v0.26.0
+  target: registry.suse.com/rancher/charts/mirrored-prometheus-alertmanager:v0.26.0
+  type: image
+- source: quay.io/prometheus/alertmanager:v0.27.0
+  target: registry.suse.com/rancher/charts/mirrored-prometheus-alertmanager:v0.27.0
+  type: image
+- source: quay.io/prometheus/alertmanager:v0.28.1
+  target: registry.suse.com/rancher/charts/mirrored-prometheus-alertmanager:v0.28.1
+  type: image
+- source: quay.io/prometheus/alertmanager:v0.22.0
   target: stgregistry.suse.com/rancher/mirrored-prometheus-alertmanager:v0.22.0
   type: image
 - source: quay.io/prometheus/alertmanager:v0.22.2
@@ -17560,6 +29223,27 @@ sync:
   type: image
 - source: quay.io/prometheus/alertmanager:v0.28.1
   target: stgregistry.suse.com/rancher/mirrored-prometheus-alertmanager:v0.28.1
+  type: image
+- source: quay.io/prometheus/alertmanager:v0.22.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-alertmanager:v0.22.0
+  type: image
+- source: quay.io/prometheus/alertmanager:v0.22.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-alertmanager:v0.22.2
+  type: image
+- source: quay.io/prometheus/alertmanager:v0.24.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-alertmanager:v0.24.0
+  type: image
+- source: quay.io/prometheus/alertmanager:v0.25.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-alertmanager:v0.25.0
+  type: image
+- source: quay.io/prometheus/alertmanager:v0.26.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-alertmanager:v0.26.0
+  type: image
+- source: quay.io/prometheus/alertmanager:v0.27.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-alertmanager:v0.27.0
+  type: image
+- source: quay.io/prometheus/alertmanager:v0.28.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-alertmanager:v0.28.1
   type: image
 - source: quay.io/prometheus/node-exporter:v1.1.2
   target: docker.io/rancher/mirrored-prometheus-node-exporter:v1.1.2
@@ -17604,6 +29288,27 @@ sync:
   target: registry.suse.com/rancher/mirrored-prometheus-node-exporter:v1.9.1
   type: image
 - source: quay.io/prometheus/node-exporter:v1.1.2
+  target: registry.suse.com/rancher/charts/mirrored-prometheus-node-exporter:v1.1.2
+  type: image
+- source: quay.io/prometheus/node-exporter:v1.2.2
+  target: registry.suse.com/rancher/charts/mirrored-prometheus-node-exporter:v1.2.2
+  type: image
+- source: quay.io/prometheus/node-exporter:v1.3.1
+  target: registry.suse.com/rancher/charts/mirrored-prometheus-node-exporter:v1.3.1
+  type: image
+- source: quay.io/prometheus/node-exporter:v1.7.0
+  target: registry.suse.com/rancher/charts/mirrored-prometheus-node-exporter:v1.7.0
+  type: image
+- source: quay.io/prometheus/node-exporter:v1.8.2
+  target: registry.suse.com/rancher/charts/mirrored-prometheus-node-exporter:v1.8.2
+  type: image
+- source: quay.io/prometheus/node-exporter:v1.9.0
+  target: registry.suse.com/rancher/charts/mirrored-prometheus-node-exporter:v1.9.0
+  type: image
+- source: quay.io/prometheus/node-exporter:v1.9.1
+  target: registry.suse.com/rancher/charts/mirrored-prometheus-node-exporter:v1.9.1
+  type: image
+- source: quay.io/prometheus/node-exporter:v1.1.2
   target: stgregistry.suse.com/rancher/mirrored-prometheus-node-exporter:v1.1.2
   type: image
 - source: quay.io/prometheus/node-exporter:v1.2.2
@@ -17624,6 +29329,27 @@ sync:
 - source: quay.io/prometheus/node-exporter:v1.9.1
   target: stgregistry.suse.com/rancher/mirrored-prometheus-node-exporter:v1.9.1
   type: image
+- source: quay.io/prometheus/node-exporter:v1.1.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-node-exporter:v1.1.2
+  type: image
+- source: quay.io/prometheus/node-exporter:v1.2.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-node-exporter:v1.2.2
+  type: image
+- source: quay.io/prometheus/node-exporter:v1.3.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-node-exporter:v1.3.1
+  type: image
+- source: quay.io/prometheus/node-exporter:v1.7.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-node-exporter:v1.7.0
+  type: image
+- source: quay.io/prometheus/node-exporter:v1.8.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-node-exporter:v1.8.2
+  type: image
+- source: quay.io/prometheus/node-exporter:v1.9.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-node-exporter:v1.9.0
+  type: image
+- source: quay.io/prometheus/node-exporter:v1.9.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-node-exporter:v1.9.1
+  type: image
 - source: quay.io/prometheus/prometheus:v2.18.2
   target: docker.io/rancher/mirrored-prom-prometheus:v2.18.2
   type: image
@@ -17631,7 +29357,13 @@ sync:
   target: registry.suse.com/rancher/mirrored-prom-prometheus:v2.18.2
   type: image
 - source: quay.io/prometheus/prometheus:v2.18.2
+  target: registry.suse.com/rancher/charts/mirrored-prom-prometheus:v2.18.2
+  type: image
+- source: quay.io/prometheus/prometheus:v2.18.2
   target: stgregistry.suse.com/rancher/mirrored-prom-prometheus:v2.18.2
+  type: image
+- source: quay.io/prometheus/prometheus:v2.18.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-prom-prometheus:v2.18.2
   type: image
 - source: quay.io/prometheus/prometheus:v2.24.0
   target: docker.io/rancher/mirrored-prometheus-prometheus:v2.24.0
@@ -17694,6 +29426,36 @@ sync:
   target: registry.suse.com/rancher/mirrored-prometheus-prometheus:v2.55.0
   type: image
 - source: quay.io/prometheus/prometheus:v2.24.0
+  target: registry.suse.com/rancher/charts/mirrored-prometheus-prometheus:v2.24.0
+  type: image
+- source: quay.io/prometheus/prometheus:v2.27.1
+  target: registry.suse.com/rancher/charts/mirrored-prometheus-prometheus:v2.27.1
+  type: image
+- source: quay.io/prometheus/prometheus:v2.28.1
+  target: registry.suse.com/rancher/charts/mirrored-prometheus-prometheus:v2.28.1
+  type: image
+- source: quay.io/prometheus/prometheus:v2.38.0
+  target: registry.suse.com/rancher/charts/mirrored-prometheus-prometheus:v2.38.0
+  type: image
+- source: quay.io/prometheus/prometheus:v2.42.0
+  target: registry.suse.com/rancher/charts/mirrored-prometheus-prometheus:v2.42.0
+  type: image
+- source: quay.io/prometheus/prometheus:v2.45.0
+  target: registry.suse.com/rancher/charts/mirrored-prometheus-prometheus:v2.45.0
+  type: image
+- source: quay.io/prometheus/prometheus:v2.48.1
+  target: registry.suse.com/rancher/charts/mirrored-prometheus-prometheus:v2.48.1
+  type: image
+- source: quay.io/prometheus/prometheus:v2.50.1
+  target: registry.suse.com/rancher/charts/mirrored-prometheus-prometheus:v2.50.1
+  type: image
+- source: quay.io/prometheus/prometheus:v2.53.1
+  target: registry.suse.com/rancher/charts/mirrored-prometheus-prometheus:v2.53.1
+  type: image
+- source: quay.io/prometheus/prometheus:v2.55.0
+  target: registry.suse.com/rancher/charts/mirrored-prometheus-prometheus:v2.55.0
+  type: image
+- source: quay.io/prometheus/prometheus:v2.24.0
   target: stgregistry.suse.com/rancher/mirrored-prometheus-prometheus:v2.24.0
   type: image
 - source: quay.io/prometheus/prometheus:v2.27.1
@@ -17722,6 +29484,36 @@ sync:
   type: image
 - source: quay.io/prometheus/prometheus:v2.55.0
   target: stgregistry.suse.com/rancher/mirrored-prometheus-prometheus:v2.55.0
+  type: image
+- source: quay.io/prometheus/prometheus:v2.24.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-prometheus:v2.24.0
+  type: image
+- source: quay.io/prometheus/prometheus:v2.27.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-prometheus:v2.27.1
+  type: image
+- source: quay.io/prometheus/prometheus:v2.28.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-prometheus:v2.28.1
+  type: image
+- source: quay.io/prometheus/prometheus:v2.38.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-prometheus:v2.38.0
+  type: image
+- source: quay.io/prometheus/prometheus:v2.42.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-prometheus:v2.42.0
+  type: image
+- source: quay.io/prometheus/prometheus:v2.45.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-prometheus:v2.45.0
+  type: image
+- source: quay.io/prometheus/prometheus:v2.48.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-prometheus:v2.48.1
+  type: image
+- source: quay.io/prometheus/prometheus:v2.50.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-prometheus:v2.50.1
+  type: image
+- source: quay.io/prometheus/prometheus:v2.53.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-prometheus:v2.53.1
+  type: image
+- source: quay.io/prometheus/prometheus:v2.55.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-prometheus:v2.55.0
   type: image
 - source: quay.io/prometheus/prometheus:v2.19.2
   target: docker.io/rancher/prom-prometheus:v2.19.2
@@ -17754,6 +29546,21 @@ sync:
   target: registry.suse.com/rancher/prom-prometheus:v3.5.0
   type: image
 - source: quay.io/prometheus/prometheus:v2.19.2
+  target: registry.suse.com/rancher/charts/prom-prometheus:v2.19.2
+  type: image
+- source: quay.io/prometheus/prometheus:v2.22.0
+  target: registry.suse.com/rancher/charts/prom-prometheus:v2.22.0
+  type: image
+- source: quay.io/prometheus/prometheus:v2.55.1
+  target: registry.suse.com/rancher/charts/prom-prometheus:v2.55.1
+  type: image
+- source: quay.io/prometheus/prometheus:v3.2.1
+  target: registry.suse.com/rancher/charts/prom-prometheus:v3.2.1
+  type: image
+- source: quay.io/prometheus/prometheus:v3.5.0
+  target: registry.suse.com/rancher/charts/prom-prometheus:v3.5.0
+  type: image
+- source: quay.io/prometheus/prometheus:v2.19.2
   target: stgregistry.suse.com/rancher/prom-prometheus:v2.19.2
   type: image
 - source: quay.io/prometheus/prometheus:v2.22.0
@@ -17768,6 +29575,21 @@ sync:
 - source: quay.io/prometheus/prometheus:v3.5.0
   target: stgregistry.suse.com/rancher/prom-prometheus:v3.5.0
   type: image
+- source: quay.io/prometheus/prometheus:v2.19.2
+  target: stgregistry.suse.com/rancher/charts/prom-prometheus:v2.19.2
+  type: image
+- source: quay.io/prometheus/prometheus:v2.22.0
+  target: stgregistry.suse.com/rancher/charts/prom-prometheus:v2.22.0
+  type: image
+- source: quay.io/prometheus/prometheus:v2.55.1
+  target: stgregistry.suse.com/rancher/charts/prom-prometheus:v2.55.1
+  type: image
+- source: quay.io/prometheus/prometheus:v3.2.1
+  target: stgregistry.suse.com/rancher/charts/prom-prometheus:v3.2.1
+  type: image
+- source: quay.io/prometheus/prometheus:v3.5.0
+  target: stgregistry.suse.com/rancher/charts/prom-prometheus:v3.5.0
+  type: image
 - source: quay.io/s3gw/s3gw:v0.14.0
   target: docker.io/rancher/mirrored-s3gw-s3gw:v0.14.0
   type: image
@@ -17775,7 +29597,13 @@ sync:
   target: registry.suse.com/rancher/mirrored-s3gw-s3gw:v0.14.0
   type: image
 - source: quay.io/s3gw/s3gw:v0.14.0
+  target: registry.suse.com/rancher/charts/mirrored-s3gw-s3gw:v0.14.0
+  type: image
+- source: quay.io/s3gw/s3gw:v0.14.0
   target: stgregistry.suse.com/rancher/mirrored-s3gw-s3gw:v0.14.0
+  type: image
+- source: quay.io/s3gw/s3gw:v0.14.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-s3gw-s3gw:v0.14.0
   type: image
 - source: quay.io/skopeo/stable:v1.10.0
   target: docker.io/rancher/mirrored-skopeo-skopeo:v1.10.0
@@ -17790,10 +29618,22 @@ sync:
   target: registry.suse.com/rancher/mirrored-skopeo-skopeo:v1.13.2
   type: image
 - source: quay.io/skopeo/stable:v1.10.0
+  target: registry.suse.com/rancher/charts/mirrored-skopeo-skopeo:v1.10.0
+  type: image
+- source: quay.io/skopeo/stable:v1.13.2
+  target: registry.suse.com/rancher/charts/mirrored-skopeo-skopeo:v1.13.2
+  type: image
+- source: quay.io/skopeo/stable:v1.10.0
   target: stgregistry.suse.com/rancher/mirrored-skopeo-skopeo:v1.10.0
   type: image
 - source: quay.io/skopeo/stable:v1.13.2
   target: stgregistry.suse.com/rancher/mirrored-skopeo-skopeo:v1.13.2
+  type: image
+- source: quay.io/skopeo/stable:v1.10.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-skopeo-skopeo:v1.10.0
+  type: image
+- source: quay.io/skopeo/stable:v1.13.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-skopeo-skopeo:v1.13.2
   type: image
 - source: quay.io/thanos/thanos:v0.17.2
   target: docker.io/rancher/mirrored-thanos-thanos:v0.17.2
@@ -17838,6 +29678,27 @@ sync:
   target: registry.suse.com/rancher/mirrored-thanos-thanos:v0.37.2
   type: image
 - source: quay.io/thanos/thanos:v0.17.2
+  target: registry.suse.com/rancher/charts/mirrored-thanos-thanos:v0.17.2
+  type: image
+- source: quay.io/thanos/thanos:v0.28.0
+  target: registry.suse.com/rancher/charts/mirrored-thanos-thanos:v0.28.0
+  type: image
+- source: quay.io/thanos/thanos:v0.30.2
+  target: registry.suse.com/rancher/charts/mirrored-thanos-thanos:v0.30.2
+  type: image
+- source: quay.io/thanos/thanos:v0.34.1
+  target: registry.suse.com/rancher/charts/mirrored-thanos-thanos:v0.34.1
+  type: image
+- source: quay.io/thanos/thanos:v0.35.1
+  target: registry.suse.com/rancher/charts/mirrored-thanos-thanos:v0.35.1
+  type: image
+- source: quay.io/thanos/thanos:v0.36.1
+  target: registry.suse.com/rancher/charts/mirrored-thanos-thanos:v0.36.1
+  type: image
+- source: quay.io/thanos/thanos:v0.37.2
+  target: registry.suse.com/rancher/charts/mirrored-thanos-thanos:v0.37.2
+  type: image
+- source: quay.io/thanos/thanos:v0.17.2
   target: stgregistry.suse.com/rancher/mirrored-thanos-thanos:v0.17.2
   type: image
 - source: quay.io/thanos/thanos:v0.28.0
@@ -17857,6 +29718,27 @@ sync:
   type: image
 - source: quay.io/thanos/thanos:v0.37.2
   target: stgregistry.suse.com/rancher/mirrored-thanos-thanos:v0.37.2
+  type: image
+- source: quay.io/thanos/thanos:v0.17.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-thanos-thanos:v0.17.2
+  type: image
+- source: quay.io/thanos/thanos:v0.28.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-thanos-thanos:v0.28.0
+  type: image
+- source: quay.io/thanos/thanos:v0.30.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-thanos-thanos:v0.30.2
+  type: image
+- source: quay.io/thanos/thanos:v0.34.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-thanos-thanos:v0.34.1
+  type: image
+- source: quay.io/thanos/thanos:v0.35.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-thanos-thanos:v0.35.1
+  type: image
+- source: quay.io/thanos/thanos:v0.36.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-thanos-thanos:v0.36.1
+  type: image
+- source: quay.io/thanos/thanos:v0.37.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-thanos-thanos:v0.37.2
   type: image
 - source: quay.io/tigera/operator:v1.15.1
   target: docker.io/rancher/mirrored-calico-operator:v1.15.1
@@ -18105,6 +29987,129 @@ sync:
   target: registry.suse.com/rancher/mirrored-calico-operator:v1.38.6
   type: image
 - source: quay.io/tigera/operator:v1.15.1
+  target: registry.suse.com/rancher/charts/mirrored-calico-operator:v1.15.1
+  type: image
+- source: quay.io/tigera/operator:v1.17.2
+  target: registry.suse.com/rancher/charts/mirrored-calico-operator:v1.17.2
+  type: image
+- source: quay.io/tigera/operator:v1.17.4
+  target: registry.suse.com/rancher/charts/mirrored-calico-operator:v1.17.4
+  type: image
+- source: quay.io/tigera/operator:v1.17.6
+  target: registry.suse.com/rancher/charts/mirrored-calico-operator:v1.17.6
+  type: image
+- source: quay.io/tigera/operator:v1.20.3
+  target: registry.suse.com/rancher/charts/mirrored-calico-operator:v1.20.3
+  type: image
+- source: quay.io/tigera/operator:v1.20.4
+  target: registry.suse.com/rancher/charts/mirrored-calico-operator:v1.20.4
+  type: image
+- source: quay.io/tigera/operator:v1.23.3
+  target: registry.suse.com/rancher/charts/mirrored-calico-operator:v1.23.3
+  type: image
+- source: quay.io/tigera/operator:v1.23.5
+  target: registry.suse.com/rancher/charts/mirrored-calico-operator:v1.23.5
+  type: image
+- source: quay.io/tigera/operator:v1.23.6
+  target: registry.suse.com/rancher/charts/mirrored-calico-operator:v1.23.6
+  type: image
+- source: quay.io/tigera/operator:v1.23.7
+  target: registry.suse.com/rancher/charts/mirrored-calico-operator:v1.23.7
+  type: image
+- source: quay.io/tigera/operator:v1.25.0
+  target: registry.suse.com/rancher/charts/mirrored-calico-operator:v1.25.0
+  type: image
+- source: quay.io/tigera/operator:v1.25.13
+  target: registry.suse.com/rancher/charts/mirrored-calico-operator:v1.25.13
+  type: image
+- source: quay.io/tigera/operator:v1.25.3
+  target: registry.suse.com/rancher/charts/mirrored-calico-operator:v1.25.3
+  type: image
+- source: quay.io/tigera/operator:v1.25.4
+  target: registry.suse.com/rancher/charts/mirrored-calico-operator:v1.25.4
+  type: image
+- source: quay.io/tigera/operator:v1.25.8
+  target: registry.suse.com/rancher/charts/mirrored-calico-operator:v1.25.8
+  type: image
+- source: quay.io/tigera/operator:v1.27.0
+  target: registry.suse.com/rancher/charts/mirrored-calico-operator:v1.27.0
+  type: image
+- source: quay.io/tigera/operator:v1.27.1
+  target: registry.suse.com/rancher/charts/mirrored-calico-operator:v1.27.1
+  type: image
+- source: quay.io/tigera/operator:v1.27.12
+  target: registry.suse.com/rancher/charts/mirrored-calico-operator:v1.27.12
+  type: image
+- source: quay.io/tigera/operator:v1.28.1
+  target: registry.suse.com/rancher/charts/mirrored-calico-operator:v1.28.1
+  type: image
+- source: quay.io/tigera/operator:v1.28.5
+  target: registry.suse.com/rancher/charts/mirrored-calico-operator:v1.28.5
+  type: image
+- source: quay.io/tigera/operator:v1.29.0
+  target: registry.suse.com/rancher/charts/mirrored-calico-operator:v1.29.0
+  type: image
+- source: quay.io/tigera/operator:v1.29.6
+  target: registry.suse.com/rancher/charts/mirrored-calico-operator:v1.29.6
+  type: image
+- source: quay.io/tigera/operator:v1.30.4
+  target: registry.suse.com/rancher/charts/mirrored-calico-operator:v1.30.4
+  type: image
+- source: quay.io/tigera/operator:v1.30.5
+  target: registry.suse.com/rancher/charts/mirrored-calico-operator:v1.30.5
+  type: image
+- source: quay.io/tigera/operator:v1.30.7
+  target: registry.suse.com/rancher/charts/mirrored-calico-operator:v1.30.7
+  type: image
+- source: quay.io/tigera/operator:v1.31.0
+  target: registry.suse.com/rancher/charts/mirrored-calico-operator:v1.31.0
+  type: image
+- source: quay.io/tigera/operator:v1.31.1
+  target: registry.suse.com/rancher/charts/mirrored-calico-operator:v1.31.1
+  type: image
+- source: quay.io/tigera/operator:v1.32.3
+  target: registry.suse.com/rancher/charts/mirrored-calico-operator:v1.32.3
+  type: image
+- source: quay.io/tigera/operator:v1.32.5
+  target: registry.suse.com/rancher/charts/mirrored-calico-operator:v1.32.5
+  type: image
+- source: quay.io/tigera/operator:v1.32.7
+  target: registry.suse.com/rancher/charts/mirrored-calico-operator:v1.32.7
+  type: image
+- source: quay.io/tigera/operator:v1.34.0
+  target: registry.suse.com/rancher/charts/mirrored-calico-operator:v1.34.0
+  type: image
+- source: quay.io/tigera/operator:v1.34.3
+  target: registry.suse.com/rancher/charts/mirrored-calico-operator:v1.34.3
+  type: image
+- source: quay.io/tigera/operator:v1.34.5
+  target: registry.suse.com/rancher/charts/mirrored-calico-operator:v1.34.5
+  type: image
+- source: quay.io/tigera/operator:v1.36.0
+  target: registry.suse.com/rancher/charts/mirrored-calico-operator:v1.36.0
+  type: image
+- source: quay.io/tigera/operator:v1.36.2
+  target: registry.suse.com/rancher/charts/mirrored-calico-operator:v1.36.2
+  type: image
+- source: quay.io/tigera/operator:v1.36.5
+  target: registry.suse.com/rancher/charts/mirrored-calico-operator:v1.36.5
+  type: image
+- source: quay.io/tigera/operator:v1.36.7
+  target: registry.suse.com/rancher/charts/mirrored-calico-operator:v1.36.7
+  type: image
+- source: quay.io/tigera/operator:v1.38.0
+  target: registry.suse.com/rancher/charts/mirrored-calico-operator:v1.38.0
+  type: image
+- source: quay.io/tigera/operator:v1.38.1
+  target: registry.suse.com/rancher/charts/mirrored-calico-operator:v1.38.1
+  type: image
+- source: quay.io/tigera/operator:v1.38.3
+  target: registry.suse.com/rancher/charts/mirrored-calico-operator:v1.38.3
+  type: image
+- source: quay.io/tigera/operator:v1.38.6
+  target: registry.suse.com/rancher/charts/mirrored-calico-operator:v1.38.6
+  type: image
+- source: quay.io/tigera/operator:v1.15.1
   target: stgregistry.suse.com/rancher/mirrored-calico-operator:v1.15.1
   type: image
 - source: quay.io/tigera/operator:v1.17.2
@@ -18227,6 +30232,129 @@ sync:
 - source: quay.io/tigera/operator:v1.38.6
   target: stgregistry.suse.com/rancher/mirrored-calico-operator:v1.38.6
   type: image
+- source: quay.io/tigera/operator:v1.15.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-operator:v1.15.1
+  type: image
+- source: quay.io/tigera/operator:v1.17.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-operator:v1.17.2
+  type: image
+- source: quay.io/tigera/operator:v1.17.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-operator:v1.17.4
+  type: image
+- source: quay.io/tigera/operator:v1.17.6
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-operator:v1.17.6
+  type: image
+- source: quay.io/tigera/operator:v1.20.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-operator:v1.20.3
+  type: image
+- source: quay.io/tigera/operator:v1.20.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-operator:v1.20.4
+  type: image
+- source: quay.io/tigera/operator:v1.23.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-operator:v1.23.3
+  type: image
+- source: quay.io/tigera/operator:v1.23.5
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-operator:v1.23.5
+  type: image
+- source: quay.io/tigera/operator:v1.23.6
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-operator:v1.23.6
+  type: image
+- source: quay.io/tigera/operator:v1.23.7
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-operator:v1.23.7
+  type: image
+- source: quay.io/tigera/operator:v1.25.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-operator:v1.25.0
+  type: image
+- source: quay.io/tigera/operator:v1.25.13
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-operator:v1.25.13
+  type: image
+- source: quay.io/tigera/operator:v1.25.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-operator:v1.25.3
+  type: image
+- source: quay.io/tigera/operator:v1.25.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-operator:v1.25.4
+  type: image
+- source: quay.io/tigera/operator:v1.25.8
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-operator:v1.25.8
+  type: image
+- source: quay.io/tigera/operator:v1.27.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-operator:v1.27.0
+  type: image
+- source: quay.io/tigera/operator:v1.27.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-operator:v1.27.1
+  type: image
+- source: quay.io/tigera/operator:v1.27.12
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-operator:v1.27.12
+  type: image
+- source: quay.io/tigera/operator:v1.28.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-operator:v1.28.1
+  type: image
+- source: quay.io/tigera/operator:v1.28.5
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-operator:v1.28.5
+  type: image
+- source: quay.io/tigera/operator:v1.29.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-operator:v1.29.0
+  type: image
+- source: quay.io/tigera/operator:v1.29.6
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-operator:v1.29.6
+  type: image
+- source: quay.io/tigera/operator:v1.30.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-operator:v1.30.4
+  type: image
+- source: quay.io/tigera/operator:v1.30.5
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-operator:v1.30.5
+  type: image
+- source: quay.io/tigera/operator:v1.30.7
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-operator:v1.30.7
+  type: image
+- source: quay.io/tigera/operator:v1.31.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-operator:v1.31.0
+  type: image
+- source: quay.io/tigera/operator:v1.31.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-operator:v1.31.1
+  type: image
+- source: quay.io/tigera/operator:v1.32.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-operator:v1.32.3
+  type: image
+- source: quay.io/tigera/operator:v1.32.5
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-operator:v1.32.5
+  type: image
+- source: quay.io/tigera/operator:v1.32.7
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-operator:v1.32.7
+  type: image
+- source: quay.io/tigera/operator:v1.34.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-operator:v1.34.0
+  type: image
+- source: quay.io/tigera/operator:v1.34.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-operator:v1.34.3
+  type: image
+- source: quay.io/tigera/operator:v1.34.5
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-operator:v1.34.5
+  type: image
+- source: quay.io/tigera/operator:v1.36.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-operator:v1.36.0
+  type: image
+- source: quay.io/tigera/operator:v1.36.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-operator:v1.36.2
+  type: image
+- source: quay.io/tigera/operator:v1.36.5
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-operator:v1.36.5
+  type: image
+- source: quay.io/tigera/operator:v1.36.7
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-operator:v1.36.7
+  type: image
+- source: quay.io/tigera/operator:v1.38.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-operator:v1.38.0
+  type: image
+- source: quay.io/tigera/operator:v1.38.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-operator:v1.38.1
+  type: image
+- source: quay.io/tigera/operator:v1.38.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-operator:v1.38.3
+  type: image
+- source: quay.io/tigera/operator:v1.38.6
+  target: stgregistry.suse.com/rancher/charts/mirrored-calico-operator:v1.38.6
+  type: image
 - source: rancher/cluster-proportional-autoscaler:1.7.1
   target: docker.io/rancher/mirrored-cluster-proportional-autoscaler:1.7.1
   type: image
@@ -18240,10 +30368,22 @@ sync:
   target: registry.suse.com/rancher/mirrored-cluster-proportional-autoscaler:1.8.1
   type: image
 - source: rancher/cluster-proportional-autoscaler:1.7.1
+  target: registry.suse.com/rancher/charts/mirrored-cluster-proportional-autoscaler:1.7.1
+  type: image
+- source: rancher/cluster-proportional-autoscaler:1.8.1
+  target: registry.suse.com/rancher/charts/mirrored-cluster-proportional-autoscaler:1.8.1
+  type: image
+- source: rancher/cluster-proportional-autoscaler:1.7.1
   target: stgregistry.suse.com/rancher/mirrored-cluster-proportional-autoscaler:1.7.1
   type: image
 - source: rancher/cluster-proportional-autoscaler:1.8.1
   target: stgregistry.suse.com/rancher/mirrored-cluster-proportional-autoscaler:1.8.1
+  type: image
+- source: rancher/cluster-proportional-autoscaler:1.7.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-cluster-proportional-autoscaler:1.7.1
+  type: image
+- source: rancher/cluster-proportional-autoscaler:1.8.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-cluster-proportional-autoscaler:1.8.1
   type: image
 - source: rancher/coreos-etcd:v3.3.15-rancher1
   target: docker.io/rancher/mirrored-coreos-etcd:v3.3.15-rancher1
@@ -18282,6 +30422,24 @@ sync:
   target: registry.suse.com/rancher/mirrored-coreos-etcd:v3.4.3-rancher1
   type: image
 - source: rancher/coreos-etcd:v3.3.15-rancher1
+  target: registry.suse.com/rancher/charts/mirrored-coreos-etcd:v3.3.15-rancher1
+  type: image
+- source: rancher/coreos-etcd:v3.4.13-rancher1
+  target: registry.suse.com/rancher/charts/mirrored-coreos-etcd:v3.4.13-rancher1
+  type: image
+- source: rancher/coreos-etcd:v3.4.14-rancher1
+  target: registry.suse.com/rancher/charts/mirrored-coreos-etcd:v3.4.14-rancher1
+  type: image
+- source: rancher/coreos-etcd:v3.4.15-rancher1
+  target: registry.suse.com/rancher/charts/mirrored-coreos-etcd:v3.4.15-rancher1
+  type: image
+- source: rancher/coreos-etcd:v3.4.16-rancher1
+  target: registry.suse.com/rancher/charts/mirrored-coreos-etcd:v3.4.16-rancher1
+  type: image
+- source: rancher/coreos-etcd:v3.4.3-rancher1
+  target: registry.suse.com/rancher/charts/mirrored-coreos-etcd:v3.4.3-rancher1
+  type: image
+- source: rancher/coreos-etcd:v3.3.15-rancher1
   target: stgregistry.suse.com/rancher/mirrored-coreos-etcd:v3.3.15-rancher1
   type: image
 - source: rancher/coreos-etcd:v3.4.13-rancher1
@@ -18299,6 +30457,24 @@ sync:
 - source: rancher/coreos-etcd:v3.4.3-rancher1
   target: stgregistry.suse.com/rancher/mirrored-coreos-etcd:v3.4.3-rancher1
   type: image
+- source: rancher/coreos-etcd:v3.3.15-rancher1
+  target: stgregistry.suse.com/rancher/charts/mirrored-coreos-etcd:v3.3.15-rancher1
+  type: image
+- source: rancher/coreos-etcd:v3.4.13-rancher1
+  target: stgregistry.suse.com/rancher/charts/mirrored-coreos-etcd:v3.4.13-rancher1
+  type: image
+- source: rancher/coreos-etcd:v3.4.14-rancher1
+  target: stgregistry.suse.com/rancher/charts/mirrored-coreos-etcd:v3.4.14-rancher1
+  type: image
+- source: rancher/coreos-etcd:v3.4.15-rancher1
+  target: stgregistry.suse.com/rancher/charts/mirrored-coreos-etcd:v3.4.15-rancher1
+  type: image
+- source: rancher/coreos-etcd:v3.4.16-rancher1
+  target: stgregistry.suse.com/rancher/charts/mirrored-coreos-etcd:v3.4.16-rancher1
+  type: image
+- source: rancher/coreos-etcd:v3.4.3-rancher1
+  target: stgregistry.suse.com/rancher/charts/mirrored-coreos-etcd:v3.4.3-rancher1
+  type: image
 - source: rancher/coreos-flannel:v0.12.0
   target: docker.io/rancher/mirrored-coreos-flannel:v0.12.0
   type: image
@@ -18306,7 +30482,13 @@ sync:
   target: registry.suse.com/rancher/mirrored-coreos-flannel:v0.12.0
   type: image
 - source: rancher/coreos-flannel:v0.12.0
+  target: registry.suse.com/rancher/charts/mirrored-coreos-flannel:v0.12.0
+  type: image
+- source: rancher/coreos-flannel:v0.12.0
   target: stgregistry.suse.com/rancher/mirrored-coreos-flannel:v0.12.0
+  type: image
+- source: rancher/coreos-flannel:v0.12.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-coreos-flannel:v0.12.0
   type: image
 - source: rancher/metrics-server:v0.3.4
   target: docker.io/rancher/mirrored-metrics-server:v0.3.4
@@ -18321,10 +30503,22 @@ sync:
   target: registry.suse.com/rancher/mirrored-metrics-server:v0.3.6
   type: image
 - source: rancher/metrics-server:v0.3.4
+  target: registry.suse.com/rancher/charts/mirrored-metrics-server:v0.3.4
+  type: image
+- source: rancher/metrics-server:v0.3.6
+  target: registry.suse.com/rancher/charts/mirrored-metrics-server:v0.3.6
+  type: image
+- source: rancher/metrics-server:v0.3.4
   target: stgregistry.suse.com/rancher/mirrored-metrics-server:v0.3.4
   type: image
 - source: rancher/metrics-server:v0.3.6
   target: stgregistry.suse.com/rancher/mirrored-metrics-server:v0.3.6
+  type: image
+- source: rancher/metrics-server:v0.3.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-metrics-server:v0.3.4
+  type: image
+- source: rancher/metrics-server:v0.3.6
+  target: stgregistry.suse.com/rancher/charts/mirrored-metrics-server:v0.3.6
   type: image
 - source: rancher/nginx-ingress-controller-defaultbackend:1.5-rancher1
   target: docker.io/rancher/mirrored-nginx-ingress-controller-defaultbackend:1.5-rancher1
@@ -18339,10 +30533,22 @@ sync:
   target: registry.suse.com/rancher/mirrored-nginx-ingress-controller-defaultbackend:1.5-rancher2
   type: image
 - source: rancher/nginx-ingress-controller-defaultbackend:1.5-rancher1
+  target: registry.suse.com/rancher/charts/mirrored-nginx-ingress-controller-defaultbackend:1.5-rancher1
+  type: image
+- source: rancher/nginx-ingress-controller-defaultbackend:1.5-rancher2
+  target: registry.suse.com/rancher/charts/mirrored-nginx-ingress-controller-defaultbackend:1.5-rancher2
+  type: image
+- source: rancher/nginx-ingress-controller-defaultbackend:1.5-rancher1
   target: stgregistry.suse.com/rancher/mirrored-nginx-ingress-controller-defaultbackend:1.5-rancher1
   type: image
 - source: rancher/nginx-ingress-controller-defaultbackend:1.5-rancher2
   target: stgregistry.suse.com/rancher/mirrored-nginx-ingress-controller-defaultbackend:1.5-rancher2
+  type: image
+- source: rancher/nginx-ingress-controller-defaultbackend:1.5-rancher1
+  target: stgregistry.suse.com/rancher/charts/mirrored-nginx-ingress-controller-defaultbackend:1.5-rancher1
+  type: image
+- source: rancher/nginx-ingress-controller-defaultbackend:1.5-rancher2
+  target: stgregistry.suse.com/rancher/charts/mirrored-nginx-ingress-controller-defaultbackend:1.5-rancher2
   type: image
 - source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.30.0
   target: docker.io/rancher/mirrored-cloud-provider-vsphere:v1.30.0
@@ -18405,6 +30611,36 @@ sync:
   target: registry.suse.com/rancher/mirrored-cloud-provider-vsphere:v1.34.0
   type: image
 - source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.30.0
+  target: registry.suse.com/rancher/charts/mirrored-cloud-provider-vsphere:v1.30.0
+  type: image
+- source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.30.1
+  target: registry.suse.com/rancher/charts/mirrored-cloud-provider-vsphere:v1.30.1
+  type: image
+- source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.30.2
+  target: registry.suse.com/rancher/charts/mirrored-cloud-provider-vsphere:v1.30.2
+  type: image
+- source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.31.0
+  target: registry.suse.com/rancher/charts/mirrored-cloud-provider-vsphere:v1.31.0
+  type: image
+- source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.31.1
+  target: registry.suse.com/rancher/charts/mirrored-cloud-provider-vsphere:v1.31.1
+  type: image
+- source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.32.0
+  target: registry.suse.com/rancher/charts/mirrored-cloud-provider-vsphere:v1.32.0
+  type: image
+- source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.32.1
+  target: registry.suse.com/rancher/charts/mirrored-cloud-provider-vsphere:v1.32.1
+  type: image
+- source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.32.2
+  target: registry.suse.com/rancher/charts/mirrored-cloud-provider-vsphere:v1.32.2
+  type: image
+- source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.33.0
+  target: registry.suse.com/rancher/charts/mirrored-cloud-provider-vsphere:v1.33.0
+  type: image
+- source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.34.0
+  target: registry.suse.com/rancher/charts/mirrored-cloud-provider-vsphere:v1.34.0
+  type: image
+- source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.30.0
   target: stgregistry.suse.com/rancher/mirrored-cloud-provider-vsphere:v1.30.0
   type: image
 - source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.30.1
@@ -18433,6 +30669,36 @@ sync:
   type: image
 - source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.34.0
   target: stgregistry.suse.com/rancher/mirrored-cloud-provider-vsphere:v1.34.0
+  type: image
+- source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.30.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-cloud-provider-vsphere:v1.30.0
+  type: image
+- source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.30.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-cloud-provider-vsphere:v1.30.1
+  type: image
+- source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.30.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-cloud-provider-vsphere:v1.30.2
+  type: image
+- source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.31.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-cloud-provider-vsphere:v1.31.0
+  type: image
+- source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.31.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-cloud-provider-vsphere:v1.31.1
+  type: image
+- source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.32.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-cloud-provider-vsphere:v1.32.0
+  type: image
+- source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.32.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-cloud-provider-vsphere:v1.32.1
+  type: image
+- source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.32.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-cloud-provider-vsphere:v1.32.2
+  type: image
+- source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.33.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-cloud-provider-vsphere:v1.33.0
+  type: image
+- source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.34.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-cloud-provider-vsphere:v1.34.0
   type: image
 - source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.30.0
   target: docker.io/rancher/mirrored-cloud-pv-vsphere-cloud-provider-vsphere:v1.30.0
@@ -18495,6 +30761,36 @@ sync:
   target: registry.suse.com/rancher/mirrored-cloud-pv-vsphere-cloud-provider-vsphere:v1.34.0
   type: image
 - source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.30.0
+  target: registry.suse.com/rancher/charts/mirrored-cloud-pv-vsphere-cloud-provider-vsphere:v1.30.0
+  type: image
+- source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.30.1
+  target: registry.suse.com/rancher/charts/mirrored-cloud-pv-vsphere-cloud-provider-vsphere:v1.30.1
+  type: image
+- source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.30.2
+  target: registry.suse.com/rancher/charts/mirrored-cloud-pv-vsphere-cloud-provider-vsphere:v1.30.2
+  type: image
+- source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.31.0
+  target: registry.suse.com/rancher/charts/mirrored-cloud-pv-vsphere-cloud-provider-vsphere:v1.31.0
+  type: image
+- source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.31.1
+  target: registry.suse.com/rancher/charts/mirrored-cloud-pv-vsphere-cloud-provider-vsphere:v1.31.1
+  type: image
+- source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.32.0
+  target: registry.suse.com/rancher/charts/mirrored-cloud-pv-vsphere-cloud-provider-vsphere:v1.32.0
+  type: image
+- source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.32.1
+  target: registry.suse.com/rancher/charts/mirrored-cloud-pv-vsphere-cloud-provider-vsphere:v1.32.1
+  type: image
+- source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.32.2
+  target: registry.suse.com/rancher/charts/mirrored-cloud-pv-vsphere-cloud-provider-vsphere:v1.32.2
+  type: image
+- source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.33.0
+  target: registry.suse.com/rancher/charts/mirrored-cloud-pv-vsphere-cloud-provider-vsphere:v1.33.0
+  type: image
+- source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.34.0
+  target: registry.suse.com/rancher/charts/mirrored-cloud-pv-vsphere-cloud-provider-vsphere:v1.34.0
+  type: image
+- source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.30.0
   target: stgregistry.suse.com/rancher/mirrored-cloud-pv-vsphere-cloud-provider-vsphere:v1.30.0
   type: image
 - source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.30.1
@@ -18523,6 +30819,36 @@ sync:
   type: image
 - source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.34.0
   target: stgregistry.suse.com/rancher/mirrored-cloud-pv-vsphere-cloud-provider-vsphere:v1.34.0
+  type: image
+- source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.30.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-cloud-pv-vsphere-cloud-provider-vsphere:v1.30.0
+  type: image
+- source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.30.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-cloud-pv-vsphere-cloud-provider-vsphere:v1.30.1
+  type: image
+- source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.30.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-cloud-pv-vsphere-cloud-provider-vsphere:v1.30.2
+  type: image
+- source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.31.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-cloud-pv-vsphere-cloud-provider-vsphere:v1.31.0
+  type: image
+- source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.31.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-cloud-pv-vsphere-cloud-provider-vsphere:v1.31.1
+  type: image
+- source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.32.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-cloud-pv-vsphere-cloud-provider-vsphere:v1.32.0
+  type: image
+- source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.32.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-cloud-pv-vsphere-cloud-provider-vsphere:v1.32.1
+  type: image
+- source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.32.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-cloud-pv-vsphere-cloud-provider-vsphere:v1.32.2
+  type: image
+- source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.33.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-cloud-pv-vsphere-cloud-provider-vsphere:v1.33.0
+  type: image
+- source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.34.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-cloud-pv-vsphere-cloud-provider-vsphere:v1.34.0
   type: image
 - source: registry.k8s.io/cluster-api/cluster-api-controller:v1.10.2
   target: docker.io/rancher/mirrored-cluster-api-controller:v1.10.2
@@ -18591,6 +30917,39 @@ sync:
   target: registry.suse.com/rancher/mirrored-cluster-api-controller:v1.9.5
   type: image
 - source: registry.k8s.io/cluster-api/cluster-api-controller:v1.10.2
+  target: registry.suse.com/rancher/charts/mirrored-cluster-api-controller:v1.10.2
+  type: image
+- source: registry.k8s.io/cluster-api/cluster-api-controller:v1.10.6
+  target: registry.suse.com/rancher/charts/mirrored-cluster-api-controller:v1.10.6
+  type: image
+- source: registry.k8s.io/cluster-api/cluster-api-controller:v1.11.1
+  target: registry.suse.com/rancher/charts/mirrored-cluster-api-controller:v1.11.1
+  type: image
+- source: registry.k8s.io/cluster-api/cluster-api-controller:v1.4.4
+  target: registry.suse.com/rancher/charts/mirrored-cluster-api-controller:v1.4.4
+  type: image
+- source: registry.k8s.io/cluster-api/cluster-api-controller:v1.5.5
+  target: registry.suse.com/rancher/charts/mirrored-cluster-api-controller:v1.5.5
+  type: image
+- source: registry.k8s.io/cluster-api/cluster-api-controller:v1.6.4
+  target: registry.suse.com/rancher/charts/mirrored-cluster-api-controller:v1.6.4
+  type: image
+- source: registry.k8s.io/cluster-api/cluster-api-controller:v1.7.2
+  target: registry.suse.com/rancher/charts/mirrored-cluster-api-controller:v1.7.2
+  type: image
+- source: registry.k8s.io/cluster-api/cluster-api-controller:v1.7.3
+  target: registry.suse.com/rancher/charts/mirrored-cluster-api-controller:v1.7.3
+  type: image
+- source: registry.k8s.io/cluster-api/cluster-api-controller:v1.8.3
+  target: registry.suse.com/rancher/charts/mirrored-cluster-api-controller:v1.8.3
+  type: image
+- source: registry.k8s.io/cluster-api/cluster-api-controller:v1.9.4
+  target: registry.suse.com/rancher/charts/mirrored-cluster-api-controller:v1.9.4
+  type: image
+- source: registry.k8s.io/cluster-api/cluster-api-controller:v1.9.5
+  target: registry.suse.com/rancher/charts/mirrored-cluster-api-controller:v1.9.5
+  type: image
+- source: registry.k8s.io/cluster-api/cluster-api-controller:v1.10.2
   target: stgregistry.suse.com/rancher/mirrored-cluster-api-controller:v1.10.2
   type: image
 - source: registry.k8s.io/cluster-api/cluster-api-controller:v1.10.6
@@ -18623,6 +30982,39 @@ sync:
 - source: registry.k8s.io/cluster-api/cluster-api-controller:v1.9.5
   target: stgregistry.suse.com/rancher/mirrored-cluster-api-controller:v1.9.5
   type: image
+- source: registry.k8s.io/cluster-api/cluster-api-controller:v1.10.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-cluster-api-controller:v1.10.2
+  type: image
+- source: registry.k8s.io/cluster-api/cluster-api-controller:v1.10.6
+  target: stgregistry.suse.com/rancher/charts/mirrored-cluster-api-controller:v1.10.6
+  type: image
+- source: registry.k8s.io/cluster-api/cluster-api-controller:v1.11.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-cluster-api-controller:v1.11.1
+  type: image
+- source: registry.k8s.io/cluster-api/cluster-api-controller:v1.4.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-cluster-api-controller:v1.4.4
+  type: image
+- source: registry.k8s.io/cluster-api/cluster-api-controller:v1.5.5
+  target: stgregistry.suse.com/rancher/charts/mirrored-cluster-api-controller:v1.5.5
+  type: image
+- source: registry.k8s.io/cluster-api/cluster-api-controller:v1.6.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-cluster-api-controller:v1.6.4
+  type: image
+- source: registry.k8s.io/cluster-api/cluster-api-controller:v1.7.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-cluster-api-controller:v1.7.2
+  type: image
+- source: registry.k8s.io/cluster-api/cluster-api-controller:v1.7.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-cluster-api-controller:v1.7.3
+  type: image
+- source: registry.k8s.io/cluster-api/cluster-api-controller:v1.8.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-cluster-api-controller:v1.8.3
+  type: image
+- source: registry.k8s.io/cluster-api/cluster-api-controller:v1.9.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-cluster-api-controller:v1.9.4
+  type: image
+- source: registry.k8s.io/cluster-api/cluster-api-controller:v1.9.5
+  target: stgregistry.suse.com/rancher/charts/mirrored-cluster-api-controller:v1.9.5
+  type: image
 - source: registry.k8s.io/cpa/cluster-proportional-autoscaler:1.8.3
   target: docker.io/rancher/mirrored-cluster-proportional-autoscaler:1.8.3
   type: image
@@ -18654,6 +31046,21 @@ sync:
   target: registry.suse.com/rancher/mirrored-cluster-proportional-autoscaler:v1.9.0
   type: image
 - source: registry.k8s.io/cpa/cluster-proportional-autoscaler:1.8.3
+  target: registry.suse.com/rancher/charts/mirrored-cluster-proportional-autoscaler:1.8.3
+  type: image
+- source: registry.k8s.io/cpa/cluster-proportional-autoscaler:1.8.5
+  target: registry.suse.com/rancher/charts/mirrored-cluster-proportional-autoscaler:1.8.5
+  type: image
+- source: registry.k8s.io/cpa/cluster-proportional-autoscaler:1.8.6
+  target: registry.suse.com/rancher/charts/mirrored-cluster-proportional-autoscaler:1.8.6
+  type: image
+- source: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.8.9
+  target: registry.suse.com/rancher/charts/mirrored-cluster-proportional-autoscaler:v1.8.9
+  type: image
+- source: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.9.0
+  target: registry.suse.com/rancher/charts/mirrored-cluster-proportional-autoscaler:v1.9.0
+  type: image
+- source: registry.k8s.io/cpa/cluster-proportional-autoscaler:1.8.3
   target: stgregistry.suse.com/rancher/mirrored-cluster-proportional-autoscaler:1.8.3
   type: image
 - source: registry.k8s.io/cpa/cluster-proportional-autoscaler:1.8.5
@@ -18667,6 +31074,21 @@ sync:
   type: image
 - source: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.9.0
   target: stgregistry.suse.com/rancher/mirrored-cluster-proportional-autoscaler:v1.9.0
+  type: image
+- source: registry.k8s.io/cpa/cluster-proportional-autoscaler:1.8.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-cluster-proportional-autoscaler:1.8.3
+  type: image
+- source: registry.k8s.io/cpa/cluster-proportional-autoscaler:1.8.5
+  target: stgregistry.suse.com/rancher/charts/mirrored-cluster-proportional-autoscaler:1.8.5
+  type: image
+- source: registry.k8s.io/cpa/cluster-proportional-autoscaler:1.8.6
+  target: stgregistry.suse.com/rancher/charts/mirrored-cluster-proportional-autoscaler:1.8.6
+  type: image
+- source: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.8.9
+  target: stgregistry.suse.com/rancher/charts/mirrored-cluster-proportional-autoscaler:v1.8.9
+  type: image
+- source: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.9.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-cluster-proportional-autoscaler:v1.9.0
   type: image
 - source: registry.k8s.io/csi-vsphere/driver:v3.3.1
   target: docker.io/rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v3.3.1
@@ -18687,6 +31109,15 @@ sync:
   target: registry.suse.com/rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v3.5.0
   type: image
 - source: registry.k8s.io/csi-vsphere/driver:v3.3.1
+  target: registry.suse.com/rancher/charts/mirrored-cloud-provider-vsphere-csi-release-driver:v3.3.1
+  type: image
+- source: registry.k8s.io/csi-vsphere/driver:v3.4.0
+  target: registry.suse.com/rancher/charts/mirrored-cloud-provider-vsphere-csi-release-driver:v3.4.0
+  type: image
+- source: registry.k8s.io/csi-vsphere/driver:v3.5.0
+  target: registry.suse.com/rancher/charts/mirrored-cloud-provider-vsphere-csi-release-driver:v3.5.0
+  type: image
+- source: registry.k8s.io/csi-vsphere/driver:v3.3.1
   target: stgregistry.suse.com/rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v3.3.1
   type: image
 - source: registry.k8s.io/csi-vsphere/driver:v3.4.0
@@ -18694,6 +31125,15 @@ sync:
   type: image
 - source: registry.k8s.io/csi-vsphere/driver:v3.5.0
   target: stgregistry.suse.com/rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v3.5.0
+  type: image
+- source: registry.k8s.io/csi-vsphere/driver:v3.3.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-cloud-provider-vsphere-csi-release-driver:v3.3.1
+  type: image
+- source: registry.k8s.io/csi-vsphere/driver:v3.4.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-cloud-provider-vsphere-csi-release-driver:v3.4.0
+  type: image
+- source: registry.k8s.io/csi-vsphere/driver:v3.5.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-cloud-provider-vsphere-csi-release-driver:v3.5.0
   type: image
 - source: registry.k8s.io/csi-vsphere/syncer:v3.3.1
   target: docker.io/rancher/mirrored-cloud-provider-vsphere-csi-release-syncer:v3.3.1
@@ -18714,6 +31154,15 @@ sync:
   target: registry.suse.com/rancher/mirrored-cloud-provider-vsphere-csi-release-syncer:v3.5.0
   type: image
 - source: registry.k8s.io/csi-vsphere/syncer:v3.3.1
+  target: registry.suse.com/rancher/charts/mirrored-cloud-provider-vsphere-csi-release-syncer:v3.3.1
+  type: image
+- source: registry.k8s.io/csi-vsphere/syncer:v3.4.0
+  target: registry.suse.com/rancher/charts/mirrored-cloud-provider-vsphere-csi-release-syncer:v3.4.0
+  type: image
+- source: registry.k8s.io/csi-vsphere/syncer:v3.5.0
+  target: registry.suse.com/rancher/charts/mirrored-cloud-provider-vsphere-csi-release-syncer:v3.5.0
+  type: image
+- source: registry.k8s.io/csi-vsphere/syncer:v3.3.1
   target: stgregistry.suse.com/rancher/mirrored-cloud-provider-vsphere-csi-release-syncer:v3.3.1
   type: image
 - source: registry.k8s.io/csi-vsphere/syncer:v3.4.0
@@ -18721,6 +31170,15 @@ sync:
   type: image
 - source: registry.k8s.io/csi-vsphere/syncer:v3.5.0
   target: stgregistry.suse.com/rancher/mirrored-cloud-provider-vsphere-csi-release-syncer:v3.5.0
+  type: image
+- source: registry.k8s.io/csi-vsphere/syncer:v3.3.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-cloud-provider-vsphere-csi-release-syncer:v3.3.1
+  type: image
+- source: registry.k8s.io/csi-vsphere/syncer:v3.4.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-cloud-provider-vsphere-csi-release-syncer:v3.4.0
+  type: image
+- source: registry.k8s.io/csi-vsphere/syncer:v3.5.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-cloud-provider-vsphere-csi-release-syncer:v3.5.0
   type: image
 - source: registry.k8s.io/dns/k8s-dns-dnsmasq-nanny:1.17.3
   target: docker.io/rancher/mirrored-k8s-dns-dnsmasq-nanny:1.17.3
@@ -18765,6 +31223,27 @@ sync:
   target: registry.suse.com/rancher/mirrored-k8s-dns-dnsmasq-nanny:1.23.0
   type: image
 - source: registry.k8s.io/dns/k8s-dns-dnsmasq-nanny:1.17.3
+  target: registry.suse.com/rancher/charts/mirrored-k8s-dns-dnsmasq-nanny:1.17.3
+  type: image
+- source: registry.k8s.io/dns/k8s-dns-dnsmasq-nanny:1.17.4
+  target: registry.suse.com/rancher/charts/mirrored-k8s-dns-dnsmasq-nanny:1.17.4
+  type: image
+- source: registry.k8s.io/dns/k8s-dns-dnsmasq-nanny:1.21.1
+  target: registry.suse.com/rancher/charts/mirrored-k8s-dns-dnsmasq-nanny:1.21.1
+  type: image
+- source: registry.k8s.io/dns/k8s-dns-dnsmasq-nanny:1.22.20
+  target: registry.suse.com/rancher/charts/mirrored-k8s-dns-dnsmasq-nanny:1.22.20
+  type: image
+- source: registry.k8s.io/dns/k8s-dns-dnsmasq-nanny:1.22.28
+  target: registry.suse.com/rancher/charts/mirrored-k8s-dns-dnsmasq-nanny:1.22.28
+  type: image
+- source: registry.k8s.io/dns/k8s-dns-dnsmasq-nanny:1.22.8
+  target: registry.suse.com/rancher/charts/mirrored-k8s-dns-dnsmasq-nanny:1.22.8
+  type: image
+- source: registry.k8s.io/dns/k8s-dns-dnsmasq-nanny:1.23.0
+  target: registry.suse.com/rancher/charts/mirrored-k8s-dns-dnsmasq-nanny:1.23.0
+  type: image
+- source: registry.k8s.io/dns/k8s-dns-dnsmasq-nanny:1.17.3
   target: stgregistry.suse.com/rancher/mirrored-k8s-dns-dnsmasq-nanny:1.17.3
   type: image
 - source: registry.k8s.io/dns/k8s-dns-dnsmasq-nanny:1.17.4
@@ -18784,6 +31263,27 @@ sync:
   type: image
 - source: registry.k8s.io/dns/k8s-dns-dnsmasq-nanny:1.23.0
   target: stgregistry.suse.com/rancher/mirrored-k8s-dns-dnsmasq-nanny:1.23.0
+  type: image
+- source: registry.k8s.io/dns/k8s-dns-dnsmasq-nanny:1.17.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-k8s-dns-dnsmasq-nanny:1.17.3
+  type: image
+- source: registry.k8s.io/dns/k8s-dns-dnsmasq-nanny:1.17.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-k8s-dns-dnsmasq-nanny:1.17.4
+  type: image
+- source: registry.k8s.io/dns/k8s-dns-dnsmasq-nanny:1.21.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-k8s-dns-dnsmasq-nanny:1.21.1
+  type: image
+- source: registry.k8s.io/dns/k8s-dns-dnsmasq-nanny:1.22.20
+  target: stgregistry.suse.com/rancher/charts/mirrored-k8s-dns-dnsmasq-nanny:1.22.20
+  type: image
+- source: registry.k8s.io/dns/k8s-dns-dnsmasq-nanny:1.22.28
+  target: stgregistry.suse.com/rancher/charts/mirrored-k8s-dns-dnsmasq-nanny:1.22.28
+  type: image
+- source: registry.k8s.io/dns/k8s-dns-dnsmasq-nanny:1.22.8
+  target: stgregistry.suse.com/rancher/charts/mirrored-k8s-dns-dnsmasq-nanny:1.22.8
+  type: image
+- source: registry.k8s.io/dns/k8s-dns-dnsmasq-nanny:1.23.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-k8s-dns-dnsmasq-nanny:1.23.0
   type: image
 - source: registry.k8s.io/dns/k8s-dns-kube-dns:1.17.3
   target: docker.io/rancher/mirrored-k8s-dns-kube-dns:1.17.3
@@ -18828,6 +31328,27 @@ sync:
   target: registry.suse.com/rancher/mirrored-k8s-dns-kube-dns:1.23.0
   type: image
 - source: registry.k8s.io/dns/k8s-dns-kube-dns:1.17.3
+  target: registry.suse.com/rancher/charts/mirrored-k8s-dns-kube-dns:1.17.3
+  type: image
+- source: registry.k8s.io/dns/k8s-dns-kube-dns:1.17.4
+  target: registry.suse.com/rancher/charts/mirrored-k8s-dns-kube-dns:1.17.4
+  type: image
+- source: registry.k8s.io/dns/k8s-dns-kube-dns:1.21.1
+  target: registry.suse.com/rancher/charts/mirrored-k8s-dns-kube-dns:1.21.1
+  type: image
+- source: registry.k8s.io/dns/k8s-dns-kube-dns:1.22.20
+  target: registry.suse.com/rancher/charts/mirrored-k8s-dns-kube-dns:1.22.20
+  type: image
+- source: registry.k8s.io/dns/k8s-dns-kube-dns:1.22.28
+  target: registry.suse.com/rancher/charts/mirrored-k8s-dns-kube-dns:1.22.28
+  type: image
+- source: registry.k8s.io/dns/k8s-dns-kube-dns:1.22.8
+  target: registry.suse.com/rancher/charts/mirrored-k8s-dns-kube-dns:1.22.8
+  type: image
+- source: registry.k8s.io/dns/k8s-dns-kube-dns:1.23.0
+  target: registry.suse.com/rancher/charts/mirrored-k8s-dns-kube-dns:1.23.0
+  type: image
+- source: registry.k8s.io/dns/k8s-dns-kube-dns:1.17.3
   target: stgregistry.suse.com/rancher/mirrored-k8s-dns-kube-dns:1.17.3
   type: image
 - source: registry.k8s.io/dns/k8s-dns-kube-dns:1.17.4
@@ -18847,6 +31368,27 @@ sync:
   type: image
 - source: registry.k8s.io/dns/k8s-dns-kube-dns:1.23.0
   target: stgregistry.suse.com/rancher/mirrored-k8s-dns-kube-dns:1.23.0
+  type: image
+- source: registry.k8s.io/dns/k8s-dns-kube-dns:1.17.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-k8s-dns-kube-dns:1.17.3
+  type: image
+- source: registry.k8s.io/dns/k8s-dns-kube-dns:1.17.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-k8s-dns-kube-dns:1.17.4
+  type: image
+- source: registry.k8s.io/dns/k8s-dns-kube-dns:1.21.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-k8s-dns-kube-dns:1.21.1
+  type: image
+- source: registry.k8s.io/dns/k8s-dns-kube-dns:1.22.20
+  target: stgregistry.suse.com/rancher/charts/mirrored-k8s-dns-kube-dns:1.22.20
+  type: image
+- source: registry.k8s.io/dns/k8s-dns-kube-dns:1.22.28
+  target: stgregistry.suse.com/rancher/charts/mirrored-k8s-dns-kube-dns:1.22.28
+  type: image
+- source: registry.k8s.io/dns/k8s-dns-kube-dns:1.22.8
+  target: stgregistry.suse.com/rancher/charts/mirrored-k8s-dns-kube-dns:1.22.8
+  type: image
+- source: registry.k8s.io/dns/k8s-dns-kube-dns:1.23.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-k8s-dns-kube-dns:1.23.0
   type: image
 - source: registry.k8s.io/dns/k8s-dns-node-cache:1.17.3
   target: docker.io/rancher/mirrored-k8s-dns-node-cache:1.17.3
@@ -18897,6 +31439,30 @@ sync:
   target: registry.suse.com/rancher/mirrored-k8s-dns-node-cache:1.23.0
   type: image
 - source: registry.k8s.io/dns/k8s-dns-node-cache:1.17.3
+  target: registry.suse.com/rancher/charts/mirrored-k8s-dns-node-cache:1.17.3
+  type: image
+- source: registry.k8s.io/dns/k8s-dns-node-cache:1.17.4
+  target: registry.suse.com/rancher/charts/mirrored-k8s-dns-node-cache:1.17.4
+  type: image
+- source: registry.k8s.io/dns/k8s-dns-node-cache:1.18.0
+  target: registry.suse.com/rancher/charts/mirrored-k8s-dns-node-cache:1.18.0
+  type: image
+- source: registry.k8s.io/dns/k8s-dns-node-cache:1.21.1
+  target: registry.suse.com/rancher/charts/mirrored-k8s-dns-node-cache:1.21.1
+  type: image
+- source: registry.k8s.io/dns/k8s-dns-node-cache:1.22.10
+  target: registry.suse.com/rancher/charts/mirrored-k8s-dns-node-cache:1.22.10
+  type: image
+- source: registry.k8s.io/dns/k8s-dns-node-cache:1.22.20
+  target: registry.suse.com/rancher/charts/mirrored-k8s-dns-node-cache:1.22.20
+  type: image
+- source: registry.k8s.io/dns/k8s-dns-node-cache:1.22.28
+  target: registry.suse.com/rancher/charts/mirrored-k8s-dns-node-cache:1.22.28
+  type: image
+- source: registry.k8s.io/dns/k8s-dns-node-cache:1.23.0
+  target: registry.suse.com/rancher/charts/mirrored-k8s-dns-node-cache:1.23.0
+  type: image
+- source: registry.k8s.io/dns/k8s-dns-node-cache:1.17.3
   target: stgregistry.suse.com/rancher/mirrored-k8s-dns-node-cache:1.17.3
   type: image
 - source: registry.k8s.io/dns/k8s-dns-node-cache:1.17.4
@@ -18919,6 +31485,30 @@ sync:
   type: image
 - source: registry.k8s.io/dns/k8s-dns-node-cache:1.23.0
   target: stgregistry.suse.com/rancher/mirrored-k8s-dns-node-cache:1.23.0
+  type: image
+- source: registry.k8s.io/dns/k8s-dns-node-cache:1.17.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-k8s-dns-node-cache:1.17.3
+  type: image
+- source: registry.k8s.io/dns/k8s-dns-node-cache:1.17.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-k8s-dns-node-cache:1.17.4
+  type: image
+- source: registry.k8s.io/dns/k8s-dns-node-cache:1.18.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-k8s-dns-node-cache:1.18.0
+  type: image
+- source: registry.k8s.io/dns/k8s-dns-node-cache:1.21.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-k8s-dns-node-cache:1.21.1
+  type: image
+- source: registry.k8s.io/dns/k8s-dns-node-cache:1.22.10
+  target: stgregistry.suse.com/rancher/charts/mirrored-k8s-dns-node-cache:1.22.10
+  type: image
+- source: registry.k8s.io/dns/k8s-dns-node-cache:1.22.20
+  target: stgregistry.suse.com/rancher/charts/mirrored-k8s-dns-node-cache:1.22.20
+  type: image
+- source: registry.k8s.io/dns/k8s-dns-node-cache:1.22.28
+  target: stgregistry.suse.com/rancher/charts/mirrored-k8s-dns-node-cache:1.22.28
+  type: image
+- source: registry.k8s.io/dns/k8s-dns-node-cache:1.23.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-k8s-dns-node-cache:1.23.0
   type: image
 - source: registry.k8s.io/dns/k8s-dns-sidecar:1.17.3
   target: docker.io/rancher/mirrored-k8s-dns-sidecar:1.17.3
@@ -18963,6 +31553,27 @@ sync:
   target: registry.suse.com/rancher/mirrored-k8s-dns-sidecar:1.23.0
   type: image
 - source: registry.k8s.io/dns/k8s-dns-sidecar:1.17.3
+  target: registry.suse.com/rancher/charts/mirrored-k8s-dns-sidecar:1.17.3
+  type: image
+- source: registry.k8s.io/dns/k8s-dns-sidecar:1.17.4
+  target: registry.suse.com/rancher/charts/mirrored-k8s-dns-sidecar:1.17.4
+  type: image
+- source: registry.k8s.io/dns/k8s-dns-sidecar:1.21.1
+  target: registry.suse.com/rancher/charts/mirrored-k8s-dns-sidecar:1.21.1
+  type: image
+- source: registry.k8s.io/dns/k8s-dns-sidecar:1.22.20
+  target: registry.suse.com/rancher/charts/mirrored-k8s-dns-sidecar:1.22.20
+  type: image
+- source: registry.k8s.io/dns/k8s-dns-sidecar:1.22.28
+  target: registry.suse.com/rancher/charts/mirrored-k8s-dns-sidecar:1.22.28
+  type: image
+- source: registry.k8s.io/dns/k8s-dns-sidecar:1.22.8
+  target: registry.suse.com/rancher/charts/mirrored-k8s-dns-sidecar:1.22.8
+  type: image
+- source: registry.k8s.io/dns/k8s-dns-sidecar:1.23.0
+  target: registry.suse.com/rancher/charts/mirrored-k8s-dns-sidecar:1.23.0
+  type: image
+- source: registry.k8s.io/dns/k8s-dns-sidecar:1.17.3
   target: stgregistry.suse.com/rancher/mirrored-k8s-dns-sidecar:1.17.3
   type: image
 - source: registry.k8s.io/dns/k8s-dns-sidecar:1.17.4
@@ -18983,6 +31594,27 @@ sync:
 - source: registry.k8s.io/dns/k8s-dns-sidecar:1.23.0
   target: stgregistry.suse.com/rancher/mirrored-k8s-dns-sidecar:1.23.0
   type: image
+- source: registry.k8s.io/dns/k8s-dns-sidecar:1.17.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-k8s-dns-sidecar:1.17.3
+  type: image
+- source: registry.k8s.io/dns/k8s-dns-sidecar:1.17.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-k8s-dns-sidecar:1.17.4
+  type: image
+- source: registry.k8s.io/dns/k8s-dns-sidecar:1.21.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-k8s-dns-sidecar:1.21.1
+  type: image
+- source: registry.k8s.io/dns/k8s-dns-sidecar:1.22.20
+  target: stgregistry.suse.com/rancher/charts/mirrored-k8s-dns-sidecar:1.22.20
+  type: image
+- source: registry.k8s.io/dns/k8s-dns-sidecar:1.22.28
+  target: stgregistry.suse.com/rancher/charts/mirrored-k8s-dns-sidecar:1.22.28
+  type: image
+- source: registry.k8s.io/dns/k8s-dns-sidecar:1.22.8
+  target: stgregistry.suse.com/rancher/charts/mirrored-k8s-dns-sidecar:1.22.8
+  type: image
+- source: registry.k8s.io/dns/k8s-dns-sidecar:1.23.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-k8s-dns-sidecar:1.23.0
+  type: image
 - source: registry.k8s.io/git-sync/git-sync:v3.5.0
   target: docker.io/rancher/mirrored-git-sync:v3.5.0
   type: image
@@ -18990,7 +31622,13 @@ sync:
   target: registry.suse.com/rancher/mirrored-git-sync:v3.5.0
   type: image
 - source: registry.k8s.io/git-sync/git-sync:v3.5.0
+  target: registry.suse.com/rancher/charts/mirrored-git-sync:v3.5.0
+  type: image
+- source: registry.k8s.io/git-sync/git-sync:v3.5.0
   target: stgregistry.suse.com/rancher/mirrored-git-sync:v3.5.0
+  type: image
+- source: registry.k8s.io/git-sync/git-sync:v3.5.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-git-sync:v3.5.0
   type: image
 - source: registry.k8s.io/gmsa-webhook/k8s-gmsa-webhook:v0.13.0
   target: docker.io/rancher/mirrored-gmsa-webhook-k8s-gmsa-webhook:v0.13.0
@@ -19005,10 +31643,22 @@ sync:
   target: registry.suse.com/rancher/mirrored-gmsa-webhook-k8s-gmsa-webhook:v0.7.0
   type: image
 - source: registry.k8s.io/gmsa-webhook/k8s-gmsa-webhook:v0.13.0
+  target: registry.suse.com/rancher/charts/mirrored-gmsa-webhook-k8s-gmsa-webhook:v0.13.0
+  type: image
+- source: registry.k8s.io/gmsa-webhook/k8s-gmsa-webhook:v0.7.0
+  target: registry.suse.com/rancher/charts/mirrored-gmsa-webhook-k8s-gmsa-webhook:v0.7.0
+  type: image
+- source: registry.k8s.io/gmsa-webhook/k8s-gmsa-webhook:v0.13.0
   target: stgregistry.suse.com/rancher/mirrored-gmsa-webhook-k8s-gmsa-webhook:v0.13.0
   type: image
 - source: registry.k8s.io/gmsa-webhook/k8s-gmsa-webhook:v0.7.0
   target: stgregistry.suse.com/rancher/mirrored-gmsa-webhook-k8s-gmsa-webhook:v0.7.0
+  type: image
+- source: registry.k8s.io/gmsa-webhook/k8s-gmsa-webhook:v0.13.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-gmsa-webhook-k8s-gmsa-webhook:v0.13.0
+  type: image
+- source: registry.k8s.io/gmsa-webhook/k8s-gmsa-webhook:v0.7.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-gmsa-webhook-k8s-gmsa-webhook:v0.7.0
   type: image
 - source: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.0
   target: docker.io/rancher/mirrored-ingress-nginx-kube-webhook-certgen:v1.0
@@ -19137,6 +31787,69 @@ sync:
   target: registry.suse.com/rancher/mirrored-ingress-nginx-kube-webhook-certgen:v20231226-1a7112e06
   type: image
 - source: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.0
+  target: registry.suse.com/rancher/charts/mirrored-ingress-nginx-kube-webhook-certgen:v1.0
+  type: image
+- source: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.1.1
+  target: registry.suse.com/rancher/charts/mirrored-ingress-nginx-kube-webhook-certgen:v1.1.1
+  type: image
+- source: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.2.0
+  target: registry.suse.com/rancher/charts/mirrored-ingress-nginx-kube-webhook-certgen:v1.2.0
+  type: image
+- source: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.3.0
+  target: registry.suse.com/rancher/charts/mirrored-ingress-nginx-kube-webhook-certgen:v1.3.0
+  type: image
+- source: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.4.0
+  target: registry.suse.com/rancher/charts/mirrored-ingress-nginx-kube-webhook-certgen:v1.4.0
+  type: image
+- source: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.4.1
+  target: registry.suse.com/rancher/charts/mirrored-ingress-nginx-kube-webhook-certgen:v1.4.1
+  type: image
+- source: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.4.3
+  target: registry.suse.com/rancher/charts/mirrored-ingress-nginx-kube-webhook-certgen:v1.4.3
+  type: image
+- source: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.4.4
+  target: registry.suse.com/rancher/charts/mirrored-ingress-nginx-kube-webhook-certgen:v1.4.4
+  type: image
+- source: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.5.0
+  target: registry.suse.com/rancher/charts/mirrored-ingress-nginx-kube-webhook-certgen:v1.5.0
+  type: image
+- source: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.5.1
+  target: registry.suse.com/rancher/charts/mirrored-ingress-nginx-kube-webhook-certgen:v1.5.1
+  type: image
+- source: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.5.2
+  target: registry.suse.com/rancher/charts/mirrored-ingress-nginx-kube-webhook-certgen:v1.5.2
+  type: image
+- source: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.5.3
+  target: registry.suse.com/rancher/charts/mirrored-ingress-nginx-kube-webhook-certgen:v1.5.3
+  type: image
+- source: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.5.4
+  target: registry.suse.com/rancher/charts/mirrored-ingress-nginx-kube-webhook-certgen:v1.5.4
+  type: image
+- source: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.6.0
+  target: registry.suse.com/rancher/charts/mirrored-ingress-nginx-kube-webhook-certgen:v1.6.0
+  type: image
+- source: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.6.1
+  target: registry.suse.com/rancher/charts/mirrored-ingress-nginx-kube-webhook-certgen:v1.6.1
+  type: image
+- source: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.6.2
+  target: registry.suse.com/rancher/charts/mirrored-ingress-nginx-kube-webhook-certgen:v1.6.2
+  type: image
+- source: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.6.3
+  target: registry.suse.com/rancher/charts/mirrored-ingress-nginx-kube-webhook-certgen:v1.6.3
+  type: image
+- source: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v20221220-controller-v1.5.1-58-g787ea74b6
+  target: registry.suse.com/rancher/charts/mirrored-ingress-nginx-kube-webhook-certgen:v20221220-controller-v1.5.1-58-g787ea74b6
+  type: image
+- source: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v20230312-helm-chart-4.5.2-28-g66a760794
+  target: registry.suse.com/rancher/charts/mirrored-ingress-nginx-kube-webhook-certgen:v20230312-helm-chart-4.5.2-28-g66a760794
+  type: image
+- source: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v20231011-8b53cabe0
+  target: registry.suse.com/rancher/charts/mirrored-ingress-nginx-kube-webhook-certgen:v20231011-8b53cabe0
+  type: image
+- source: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v20231226-1a7112e06
+  target: registry.suse.com/rancher/charts/mirrored-ingress-nginx-kube-webhook-certgen:v20231226-1a7112e06
+  type: image
+- source: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.0
   target: stgregistry.suse.com/rancher/mirrored-ingress-nginx-kube-webhook-certgen:v1.0
   type: image
 - source: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.1.1
@@ -19199,6 +31912,69 @@ sync:
 - source: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v20231226-1a7112e06
   target: stgregistry.suse.com/rancher/mirrored-ingress-nginx-kube-webhook-certgen:v20231226-1a7112e06
   type: image
+- source: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-ingress-nginx-kube-webhook-certgen:v1.0
+  type: image
+- source: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.1.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-ingress-nginx-kube-webhook-certgen:v1.1.1
+  type: image
+- source: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.2.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-ingress-nginx-kube-webhook-certgen:v1.2.0
+  type: image
+- source: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.3.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-ingress-nginx-kube-webhook-certgen:v1.3.0
+  type: image
+- source: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.4.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-ingress-nginx-kube-webhook-certgen:v1.4.0
+  type: image
+- source: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.4.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-ingress-nginx-kube-webhook-certgen:v1.4.1
+  type: image
+- source: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.4.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-ingress-nginx-kube-webhook-certgen:v1.4.3
+  type: image
+- source: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.4.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-ingress-nginx-kube-webhook-certgen:v1.4.4
+  type: image
+- source: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.5.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-ingress-nginx-kube-webhook-certgen:v1.5.0
+  type: image
+- source: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.5.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-ingress-nginx-kube-webhook-certgen:v1.5.1
+  type: image
+- source: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.5.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-ingress-nginx-kube-webhook-certgen:v1.5.2
+  type: image
+- source: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.5.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-ingress-nginx-kube-webhook-certgen:v1.5.3
+  type: image
+- source: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.5.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-ingress-nginx-kube-webhook-certgen:v1.5.4
+  type: image
+- source: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.6.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-ingress-nginx-kube-webhook-certgen:v1.6.0
+  type: image
+- source: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.6.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-ingress-nginx-kube-webhook-certgen:v1.6.1
+  type: image
+- source: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.6.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-ingress-nginx-kube-webhook-certgen:v1.6.2
+  type: image
+- source: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.6.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-ingress-nginx-kube-webhook-certgen:v1.6.3
+  type: image
+- source: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v20221220-controller-v1.5.1-58-g787ea74b6
+  target: stgregistry.suse.com/rancher/charts/mirrored-ingress-nginx-kube-webhook-certgen:v20221220-controller-v1.5.1-58-g787ea74b6
+  type: image
+- source: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v20230312-helm-chart-4.5.2-28-g66a760794
+  target: stgregistry.suse.com/rancher/charts/mirrored-ingress-nginx-kube-webhook-certgen:v20230312-helm-chart-4.5.2-28-g66a760794
+  type: image
+- source: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v20231011-8b53cabe0
+  target: stgregistry.suse.com/rancher/charts/mirrored-ingress-nginx-kube-webhook-certgen:v20231011-8b53cabe0
+  type: image
+- source: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v20231226-1a7112e06
+  target: stgregistry.suse.com/rancher/charts/mirrored-ingress-nginx-kube-webhook-certgen:v20231226-1a7112e06
+  type: image
 - source: registry.k8s.io/kube-state-metrics/kube-state-metrics:v1.9.8
   target: docker.io/rancher/mirrored-kube-state-metrics-kube-state-metrics:v1.9.8
   type: image
@@ -19260,6 +32036,36 @@ sync:
   target: registry.suse.com/rancher/mirrored-kube-state-metrics-kube-state-metrics:v2.6.0
   type: image
 - source: registry.k8s.io/kube-state-metrics/kube-state-metrics:v1.9.8
+  target: registry.suse.com/rancher/charts/mirrored-kube-state-metrics-kube-state-metrics:v1.9.8
+  type: image
+- source: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.0.0
+  target: registry.suse.com/rancher/charts/mirrored-kube-state-metrics-kube-state-metrics:v2.0.0
+  type: image
+- source: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.10.1
+  target: registry.suse.com/rancher/charts/mirrored-kube-state-metrics-kube-state-metrics:v2.10.1
+  type: image
+- source: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.12.0
+  target: registry.suse.com/rancher/charts/mirrored-kube-state-metrics-kube-state-metrics:v2.12.0
+  type: image
+- source: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.13.0
+  target: registry.suse.com/rancher/charts/mirrored-kube-state-metrics-kube-state-metrics:v2.13.0
+  type: image
+- source: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.14.0
+  target: registry.suse.com/rancher/charts/mirrored-kube-state-metrics-kube-state-metrics:v2.14.0
+  type: image
+- source: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.15.0
+  target: registry.suse.com/rancher/charts/mirrored-kube-state-metrics-kube-state-metrics:v2.15.0
+  type: image
+- source: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.17.0
+  target: registry.suse.com/rancher/charts/mirrored-kube-state-metrics-kube-state-metrics:v2.17.0
+  type: image
+- source: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.2.0
+  target: registry.suse.com/rancher/charts/mirrored-kube-state-metrics-kube-state-metrics:v2.2.0
+  type: image
+- source: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.6.0
+  target: registry.suse.com/rancher/charts/mirrored-kube-state-metrics-kube-state-metrics:v2.6.0
+  type: image
+- source: registry.k8s.io/kube-state-metrics/kube-state-metrics:v1.9.8
   target: stgregistry.suse.com/rancher/mirrored-kube-state-metrics-kube-state-metrics:v1.9.8
   type: image
 - source: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.0.0
@@ -19289,6 +32095,36 @@ sync:
 - source: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.6.0
   target: stgregistry.suse.com/rancher/mirrored-kube-state-metrics-kube-state-metrics:v2.6.0
   type: image
+- source: registry.k8s.io/kube-state-metrics/kube-state-metrics:v1.9.8
+  target: stgregistry.suse.com/rancher/charts/mirrored-kube-state-metrics-kube-state-metrics:v1.9.8
+  type: image
+- source: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.0.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-kube-state-metrics-kube-state-metrics:v2.0.0
+  type: image
+- source: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.10.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-kube-state-metrics-kube-state-metrics:v2.10.1
+  type: image
+- source: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.12.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-kube-state-metrics-kube-state-metrics:v2.12.0
+  type: image
+- source: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.13.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-kube-state-metrics-kube-state-metrics:v2.13.0
+  type: image
+- source: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.14.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-kube-state-metrics-kube-state-metrics:v2.14.0
+  type: image
+- source: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.15.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-kube-state-metrics-kube-state-metrics:v2.15.0
+  type: image
+- source: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.17.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-kube-state-metrics-kube-state-metrics:v2.17.0
+  type: image
+- source: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.2.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-kube-state-metrics-kube-state-metrics:v2.2.0
+  type: image
+- source: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.6.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-kube-state-metrics-kube-state-metrics:v2.6.0
+  type: image
 - source: registry.k8s.io/metrics-server/metrics-server:v0.4.1
   target: docker.io/rancher/metrics-server:v0.4.1
   type: image
@@ -19296,7 +32132,13 @@ sync:
   target: registry.suse.com/rancher/metrics-server:v0.4.1
   type: image
 - source: registry.k8s.io/metrics-server/metrics-server:v0.4.1
+  target: registry.suse.com/rancher/charts/metrics-server:v0.4.1
+  type: image
+- source: registry.k8s.io/metrics-server/metrics-server:v0.4.1
   target: stgregistry.suse.com/rancher/metrics-server:v0.4.1
+  type: image
+- source: registry.k8s.io/metrics-server/metrics-server:v0.4.1
+  target: stgregistry.suse.com/rancher/charts/metrics-server:v0.4.1
   type: image
 - source: registry.k8s.io/metrics-server/metrics-server:v0.4.1
   target: docker.io/rancher/mirrored-metrics-server:v0.4.1
@@ -19377,6 +32219,45 @@ sync:
   target: registry.suse.com/rancher/mirrored-metrics-server:v0.8.0
   type: image
 - source: registry.k8s.io/metrics-server/metrics-server:v0.4.1
+  target: registry.suse.com/rancher/charts/mirrored-metrics-server:v0.4.1
+  type: image
+- source: registry.k8s.io/metrics-server/metrics-server:v0.4.4
+  target: registry.suse.com/rancher/charts/mirrored-metrics-server:v0.4.4
+  type: image
+- source: registry.k8s.io/metrics-server/metrics-server:v0.5.0
+  target: registry.suse.com/rancher/charts/mirrored-metrics-server:v0.5.0
+  type: image
+- source: registry.k8s.io/metrics-server/metrics-server:v0.5.1
+  target: registry.suse.com/rancher/charts/mirrored-metrics-server:v0.5.1
+  type: image
+- source: registry.k8s.io/metrics-server/metrics-server:v0.5.2
+  target: registry.suse.com/rancher/charts/mirrored-metrics-server:v0.5.2
+  type: image
+- source: registry.k8s.io/metrics-server/metrics-server:v0.6.1
+  target: registry.suse.com/rancher/charts/mirrored-metrics-server:v0.6.1
+  type: image
+- source: registry.k8s.io/metrics-server/metrics-server:v0.6.2
+  target: registry.suse.com/rancher/charts/mirrored-metrics-server:v0.6.2
+  type: image
+- source: registry.k8s.io/metrics-server/metrics-server:v0.6.3
+  target: registry.suse.com/rancher/charts/mirrored-metrics-server:v0.6.3
+  type: image
+- source: registry.k8s.io/metrics-server/metrics-server:v0.6.4
+  target: registry.suse.com/rancher/charts/mirrored-metrics-server:v0.6.4
+  type: image
+- source: registry.k8s.io/metrics-server/metrics-server:v0.7.0
+  target: registry.suse.com/rancher/charts/mirrored-metrics-server:v0.7.0
+  type: image
+- source: registry.k8s.io/metrics-server/metrics-server:v0.7.1
+  target: registry.suse.com/rancher/charts/mirrored-metrics-server:v0.7.1
+  type: image
+- source: registry.k8s.io/metrics-server/metrics-server:v0.7.2
+  target: registry.suse.com/rancher/charts/mirrored-metrics-server:v0.7.2
+  type: image
+- source: registry.k8s.io/metrics-server/metrics-server:v0.8.0
+  target: registry.suse.com/rancher/charts/mirrored-metrics-server:v0.8.0
+  type: image
+- source: registry.k8s.io/metrics-server/metrics-server:v0.4.1
   target: stgregistry.suse.com/rancher/mirrored-metrics-server:v0.4.1
   type: image
 - source: registry.k8s.io/metrics-server/metrics-server:v0.4.4
@@ -19414,6 +32295,45 @@ sync:
   type: image
 - source: registry.k8s.io/metrics-server/metrics-server:v0.8.0
   target: stgregistry.suse.com/rancher/mirrored-metrics-server:v0.8.0
+  type: image
+- source: registry.k8s.io/metrics-server/metrics-server:v0.4.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-metrics-server:v0.4.1
+  type: image
+- source: registry.k8s.io/metrics-server/metrics-server:v0.4.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-metrics-server:v0.4.4
+  type: image
+- source: registry.k8s.io/metrics-server/metrics-server:v0.5.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-metrics-server:v0.5.0
+  type: image
+- source: registry.k8s.io/metrics-server/metrics-server:v0.5.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-metrics-server:v0.5.1
+  type: image
+- source: registry.k8s.io/metrics-server/metrics-server:v0.5.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-metrics-server:v0.5.2
+  type: image
+- source: registry.k8s.io/metrics-server/metrics-server:v0.6.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-metrics-server:v0.6.1
+  type: image
+- source: registry.k8s.io/metrics-server/metrics-server:v0.6.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-metrics-server:v0.6.2
+  type: image
+- source: registry.k8s.io/metrics-server/metrics-server:v0.6.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-metrics-server:v0.6.3
+  type: image
+- source: registry.k8s.io/metrics-server/metrics-server:v0.6.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-metrics-server:v0.6.4
+  type: image
+- source: registry.k8s.io/metrics-server/metrics-server:v0.7.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-metrics-server:v0.7.0
+  type: image
+- source: registry.k8s.io/metrics-server/metrics-server:v0.7.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-metrics-server:v0.7.1
+  type: image
+- source: registry.k8s.io/metrics-server/metrics-server:v0.7.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-metrics-server:v0.7.2
+  type: image
+- source: registry.k8s.io/metrics-server/metrics-server:v0.8.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-metrics-server:v0.8.0
   type: image
 - source: registry.k8s.io/pause:3.10
   target: docker.io/rancher/mirrored-pause:3.10
@@ -19458,6 +32378,27 @@ sync:
   target: registry.suse.com/rancher/mirrored-pause:3.9
   type: image
 - source: registry.k8s.io/pause:3.10
+  target: registry.suse.com/rancher/charts/mirrored-pause:3.10
+  type: image
+- source: registry.k8s.io/pause:3.4.1
+  target: registry.suse.com/rancher/charts/mirrored-pause:3.4.1
+  type: image
+- source: registry.k8s.io/pause:3.5
+  target: registry.suse.com/rancher/charts/mirrored-pause:3.5
+  type: image
+- source: registry.k8s.io/pause:3.6
+  target: registry.suse.com/rancher/charts/mirrored-pause:3.6
+  type: image
+- source: registry.k8s.io/pause:3.7
+  target: registry.suse.com/rancher/charts/mirrored-pause:3.7
+  type: image
+- source: registry.k8s.io/pause:3.8
+  target: registry.suse.com/rancher/charts/mirrored-pause:3.8
+  type: image
+- source: registry.k8s.io/pause:3.9
+  target: registry.suse.com/rancher/charts/mirrored-pause:3.9
+  type: image
+- source: registry.k8s.io/pause:3.10
   target: stgregistry.suse.com/rancher/mirrored-pause:3.10
   type: image
 - source: registry.k8s.io/pause:3.4.1
@@ -19477,6 +32418,27 @@ sync:
   type: image
 - source: registry.k8s.io/pause:3.9
   target: stgregistry.suse.com/rancher/mirrored-pause:3.9
+  type: image
+- source: registry.k8s.io/pause:3.10
+  target: stgregistry.suse.com/rancher/charts/mirrored-pause:3.10
+  type: image
+- source: registry.k8s.io/pause:3.4.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-pause:3.4.1
+  type: image
+- source: registry.k8s.io/pause:3.5
+  target: stgregistry.suse.com/rancher/charts/mirrored-pause:3.5
+  type: image
+- source: registry.k8s.io/pause:3.6
+  target: stgregistry.suse.com/rancher/charts/mirrored-pause:3.6
+  type: image
+- source: registry.k8s.io/pause:3.7
+  target: stgregistry.suse.com/rancher/charts/mirrored-pause:3.7
+  type: image
+- source: registry.k8s.io/pause:3.8
+  target: stgregistry.suse.com/rancher/charts/mirrored-pause:3.8
+  type: image
+- source: registry.k8s.io/pause:3.9
+  target: stgregistry.suse.com/rancher/charts/mirrored-pause:3.9
   type: image
 - source: registry.k8s.io/prometheus-adapter/prometheus-adapter:v0.10.0
   target: docker.io/rancher/mirrored-prometheus-adapter-prometheus-adapter:v0.10.0
@@ -19503,6 +32465,18 @@ sync:
   target: registry.suse.com/rancher/mirrored-prometheus-adapter-prometheus-adapter:v0.9.0
   type: image
 - source: registry.k8s.io/prometheus-adapter/prometheus-adapter:v0.10.0
+  target: registry.suse.com/rancher/charts/mirrored-prometheus-adapter-prometheus-adapter:v0.10.0
+  type: image
+- source: registry.k8s.io/prometheus-adapter/prometheus-adapter:v0.11.2
+  target: registry.suse.com/rancher/charts/mirrored-prometheus-adapter-prometheus-adapter:v0.11.2
+  type: image
+- source: registry.k8s.io/prometheus-adapter/prometheus-adapter:v0.12.0
+  target: registry.suse.com/rancher/charts/mirrored-prometheus-adapter-prometheus-adapter:v0.12.0
+  type: image
+- source: registry.k8s.io/prometheus-adapter/prometheus-adapter:v0.9.0
+  target: registry.suse.com/rancher/charts/mirrored-prometheus-adapter-prometheus-adapter:v0.9.0
+  type: image
+- source: registry.k8s.io/prometheus-adapter/prometheus-adapter:v0.10.0
   target: stgregistry.suse.com/rancher/mirrored-prometheus-adapter-prometheus-adapter:v0.10.0
   type: image
 - source: registry.k8s.io/prometheus-adapter/prometheus-adapter:v0.11.2
@@ -19513,6 +32487,18 @@ sync:
   type: image
 - source: registry.k8s.io/prometheus-adapter/prometheus-adapter:v0.9.0
   target: stgregistry.suse.com/rancher/mirrored-prometheus-adapter-prometheus-adapter:v0.9.0
+  type: image
+- source: registry.k8s.io/prometheus-adapter/prometheus-adapter:v0.10.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-adapter-prometheus-adapter:v0.10.0
+  type: image
+- source: registry.k8s.io/prometheus-adapter/prometheus-adapter:v0.11.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-adapter-prometheus-adapter:v0.11.2
+  type: image
+- source: registry.k8s.io/prometheus-adapter/prometheus-adapter:v0.12.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-adapter-prometheus-adapter:v0.12.0
+  type: image
+- source: registry.k8s.io/prometheus-adapter/prometheus-adapter:v0.9.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-adapter-prometheus-adapter:v0.9.0
   type: image
 - source: registry.k8s.io/sig-storage/csi-attacher:v3.2.0
   target: docker.io/rancher/mirrored-sig-storage-csi-attacher:v3.2.0
@@ -19605,6 +32591,51 @@ sync:
   target: registry.suse.com/rancher/mirrored-sig-storage-csi-attacher:v4.9.0
   type: image
 - source: registry.k8s.io/sig-storage/csi-attacher:v3.2.0
+  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-attacher:v3.2.0
+  type: image
+- source: registry.k8s.io/sig-storage/csi-attacher:v3.3.0
+  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-attacher:v3.3.0
+  type: image
+- source: registry.k8s.io/sig-storage/csi-attacher:v3.4.0
+  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-attacher:v3.4.0
+  type: image
+- source: registry.k8s.io/sig-storage/csi-attacher:v3.5.0
+  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-attacher:v3.5.0
+  type: image
+- source: registry.k8s.io/sig-storage/csi-attacher:v4.2.0
+  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-attacher:v4.2.0
+  type: image
+- source: registry.k8s.io/sig-storage/csi-attacher:v4.3.0
+  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-attacher:v4.3.0
+  type: image
+- source: registry.k8s.io/sig-storage/csi-attacher:v4.4.0
+  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-attacher:v4.4.0
+  type: image
+- source: registry.k8s.io/sig-storage/csi-attacher:v4.4.1
+  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-attacher:v4.4.1
+  type: image
+- source: registry.k8s.io/sig-storage/csi-attacher:v4.4.2
+  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-attacher:v4.4.2
+  type: image
+- source: registry.k8s.io/sig-storage/csi-attacher:v4.5.0
+  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-attacher:v4.5.0
+  type: image
+- source: registry.k8s.io/sig-storage/csi-attacher:v4.5.1
+  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-attacher:v4.5.1
+  type: image
+- source: registry.k8s.io/sig-storage/csi-attacher:v4.7.0
+  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-attacher:v4.7.0
+  type: image
+- source: registry.k8s.io/sig-storage/csi-attacher:v4.8.0
+  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-attacher:v4.8.0
+  type: image
+- source: registry.k8s.io/sig-storage/csi-attacher:v4.8.1
+  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-attacher:v4.8.1
+  type: image
+- source: registry.k8s.io/sig-storage/csi-attacher:v4.9.0
+  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-attacher:v4.9.0
+  type: image
+- source: registry.k8s.io/sig-storage/csi-attacher:v3.2.0
   target: stgregistry.suse.com/rancher/mirrored-sig-storage-csi-attacher:v3.2.0
   type: image
 - source: registry.k8s.io/sig-storage/csi-attacher:v3.3.0
@@ -19648,6 +32679,51 @@ sync:
   type: image
 - source: registry.k8s.io/sig-storage/csi-attacher:v4.9.0
   target: stgregistry.suse.com/rancher/mirrored-sig-storage-csi-attacher:v4.9.0
+  type: image
+- source: registry.k8s.io/sig-storage/csi-attacher:v3.2.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-attacher:v3.2.0
+  type: image
+- source: registry.k8s.io/sig-storage/csi-attacher:v3.3.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-attacher:v3.3.0
+  type: image
+- source: registry.k8s.io/sig-storage/csi-attacher:v3.4.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-attacher:v3.4.0
+  type: image
+- source: registry.k8s.io/sig-storage/csi-attacher:v3.5.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-attacher:v3.5.0
+  type: image
+- source: registry.k8s.io/sig-storage/csi-attacher:v4.2.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-attacher:v4.2.0
+  type: image
+- source: registry.k8s.io/sig-storage/csi-attacher:v4.3.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-attacher:v4.3.0
+  type: image
+- source: registry.k8s.io/sig-storage/csi-attacher:v4.4.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-attacher:v4.4.0
+  type: image
+- source: registry.k8s.io/sig-storage/csi-attacher:v4.4.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-attacher:v4.4.1
+  type: image
+- source: registry.k8s.io/sig-storage/csi-attacher:v4.4.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-attacher:v4.4.2
+  type: image
+- source: registry.k8s.io/sig-storage/csi-attacher:v4.5.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-attacher:v4.5.0
+  type: image
+- source: registry.k8s.io/sig-storage/csi-attacher:v4.5.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-attacher:v4.5.1
+  type: image
+- source: registry.k8s.io/sig-storage/csi-attacher:v4.7.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-attacher:v4.7.0
+  type: image
+- source: registry.k8s.io/sig-storage/csi-attacher:v4.8.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-attacher:v4.8.0
+  type: image
+- source: registry.k8s.io/sig-storage/csi-attacher:v4.8.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-attacher:v4.8.1
+  type: image
+- source: registry.k8s.io/sig-storage/csi-attacher:v4.9.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-attacher:v4.9.0
   type: image
 - source: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.10.0
   target: docker.io/rancher/mirrored-sig-storage-csi-node-driver-registrar:v2.10.0
@@ -19728,6 +32804,45 @@ sync:
   target: registry.suse.com/rancher/mirrored-sig-storage-csi-node-driver-registrar:v2.9.1
   type: image
 - source: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.10.0
+  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-node-driver-registrar:v2.10.0
+  type: image
+- source: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.10.1
+  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-node-driver-registrar:v2.10.1
+  type: image
+- source: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.12.0
+  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-node-driver-registrar:v2.12.0
+  type: image
+- source: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.13.0
+  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-node-driver-registrar:v2.13.0
+  type: image
+- source: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.14.0
+  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-node-driver-registrar:v2.14.0
+  type: image
+- source: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.3.0
+  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-node-driver-registrar:v2.3.0
+  type: image
+- source: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.5.0
+  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-node-driver-registrar:v2.5.0
+  type: image
+- source: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.5.1
+  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-node-driver-registrar:v2.5.1
+  type: image
+- source: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.6.2
+  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-node-driver-registrar:v2.6.2
+  type: image
+- source: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.7.0
+  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-node-driver-registrar:v2.7.0
+  type: image
+- source: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.8.0
+  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-node-driver-registrar:v2.8.0
+  type: image
+- source: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.9.0
+  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-node-driver-registrar:v2.9.0
+  type: image
+- source: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.9.1
+  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-node-driver-registrar:v2.9.1
+  type: image
+- source: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.10.0
   target: stgregistry.suse.com/rancher/mirrored-sig-storage-csi-node-driver-registrar:v2.10.0
   type: image
 - source: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.10.1
@@ -19765,6 +32880,45 @@ sync:
   type: image
 - source: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.9.1
   target: stgregistry.suse.com/rancher/mirrored-sig-storage-csi-node-driver-registrar:v2.9.1
+  type: image
+- source: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.10.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-node-driver-registrar:v2.10.0
+  type: image
+- source: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.10.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-node-driver-registrar:v2.10.1
+  type: image
+- source: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.12.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-node-driver-registrar:v2.12.0
+  type: image
+- source: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.13.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-node-driver-registrar:v2.13.0
+  type: image
+- source: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.14.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-node-driver-registrar:v2.14.0
+  type: image
+- source: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.3.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-node-driver-registrar:v2.3.0
+  type: image
+- source: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.5.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-node-driver-registrar:v2.5.0
+  type: image
+- source: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.5.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-node-driver-registrar:v2.5.1
+  type: image
+- source: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.6.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-node-driver-registrar:v2.6.2
+  type: image
+- source: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.7.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-node-driver-registrar:v2.7.0
+  type: image
+- source: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.8.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-node-driver-registrar:v2.8.0
+  type: image
+- source: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.9.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-node-driver-registrar:v2.9.0
+  type: image
+- source: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.9.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-node-driver-registrar:v2.9.1
   type: image
 - source: registry.k8s.io/sig-storage/csi-provisioner:v2.2.0
   target: docker.io/rancher/mirrored-sig-storage-csi-provisioner:v2.2.0
@@ -19857,6 +33011,51 @@ sync:
   target: registry.suse.com/rancher/mirrored-sig-storage-csi-provisioner:v5.3.0
   type: image
 - source: registry.k8s.io/sig-storage/csi-provisioner:v2.2.0
+  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-provisioner:v2.2.0
+  type: image
+- source: registry.k8s.io/sig-storage/csi-provisioner:v3.0.0
+  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-provisioner:v3.0.0
+  type: image
+- source: registry.k8s.io/sig-storage/csi-provisioner:v3.1.0
+  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-provisioner:v3.1.0
+  type: image
+- source: registry.k8s.io/sig-storage/csi-provisioner:v3.2.1
+  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-provisioner:v3.2.1
+  type: image
+- source: registry.k8s.io/sig-storage/csi-provisioner:v3.3.0
+  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-provisioner:v3.3.0
+  type: image
+- source: registry.k8s.io/sig-storage/csi-provisioner:v3.4.0
+  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-provisioner:v3.4.0
+  type: image
+- source: registry.k8s.io/sig-storage/csi-provisioner:v3.5.0
+  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-provisioner:v3.5.0
+  type: image
+- source: registry.k8s.io/sig-storage/csi-provisioner:v3.6.0
+  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-provisioner:v3.6.0
+  type: image
+- source: registry.k8s.io/sig-storage/csi-provisioner:v3.6.1
+  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-provisioner:v3.6.1
+  type: image
+- source: registry.k8s.io/sig-storage/csi-provisioner:v3.6.2
+  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-provisioner:v3.6.2
+  type: image
+- source: registry.k8s.io/sig-storage/csi-provisioner:v4.0.0
+  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-provisioner:v4.0.0
+  type: image
+- source: registry.k8s.io/sig-storage/csi-provisioner:v4.0.1
+  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-provisioner:v4.0.1
+  type: image
+- source: registry.k8s.io/sig-storage/csi-provisioner:v5.1.0
+  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-provisioner:v5.1.0
+  type: image
+- source: registry.k8s.io/sig-storage/csi-provisioner:v5.2.0
+  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-provisioner:v5.2.0
+  type: image
+- source: registry.k8s.io/sig-storage/csi-provisioner:v5.3.0
+  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-provisioner:v5.3.0
+  type: image
+- source: registry.k8s.io/sig-storage/csi-provisioner:v2.2.0
   target: stgregistry.suse.com/rancher/mirrored-sig-storage-csi-provisioner:v2.2.0
   type: image
 - source: registry.k8s.io/sig-storage/csi-provisioner:v3.0.0
@@ -19900,6 +33099,51 @@ sync:
   type: image
 - source: registry.k8s.io/sig-storage/csi-provisioner:v5.3.0
   target: stgregistry.suse.com/rancher/mirrored-sig-storage-csi-provisioner:v5.3.0
+  type: image
+- source: registry.k8s.io/sig-storage/csi-provisioner:v2.2.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-provisioner:v2.2.0
+  type: image
+- source: registry.k8s.io/sig-storage/csi-provisioner:v3.0.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-provisioner:v3.0.0
+  type: image
+- source: registry.k8s.io/sig-storage/csi-provisioner:v3.1.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-provisioner:v3.1.0
+  type: image
+- source: registry.k8s.io/sig-storage/csi-provisioner:v3.2.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-provisioner:v3.2.1
+  type: image
+- source: registry.k8s.io/sig-storage/csi-provisioner:v3.3.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-provisioner:v3.3.0
+  type: image
+- source: registry.k8s.io/sig-storage/csi-provisioner:v3.4.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-provisioner:v3.4.0
+  type: image
+- source: registry.k8s.io/sig-storage/csi-provisioner:v3.5.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-provisioner:v3.5.0
+  type: image
+- source: registry.k8s.io/sig-storage/csi-provisioner:v3.6.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-provisioner:v3.6.0
+  type: image
+- source: registry.k8s.io/sig-storage/csi-provisioner:v3.6.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-provisioner:v3.6.1
+  type: image
+- source: registry.k8s.io/sig-storage/csi-provisioner:v3.6.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-provisioner:v3.6.2
+  type: image
+- source: registry.k8s.io/sig-storage/csi-provisioner:v4.0.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-provisioner:v4.0.0
+  type: image
+- source: registry.k8s.io/sig-storage/csi-provisioner:v4.0.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-provisioner:v4.0.1
+  type: image
+- source: registry.k8s.io/sig-storage/csi-provisioner:v5.1.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-provisioner:v5.1.0
+  type: image
+- source: registry.k8s.io/sig-storage/csi-provisioner:v5.2.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-provisioner:v5.2.0
+  type: image
+- source: registry.k8s.io/sig-storage/csi-provisioner:v5.3.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-provisioner:v5.3.0
   type: image
 - source: registry.k8s.io/sig-storage/csi-resizer:v1.10.0
   target: docker.io/rancher/mirrored-sig-storage-csi-resizer:v1.10.0
@@ -19980,6 +33224,45 @@ sync:
   target: registry.suse.com/rancher/mirrored-sig-storage-csi-resizer:v1.9.2
   type: image
 - source: registry.k8s.io/sig-storage/csi-resizer:v1.10.0
+  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-resizer:v1.10.0
+  type: image
+- source: registry.k8s.io/sig-storage/csi-resizer:v1.10.1
+  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-resizer:v1.10.1
+  type: image
+- source: registry.k8s.io/sig-storage/csi-resizer:v1.12.0
+  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-resizer:v1.12.0
+  type: image
+- source: registry.k8s.io/sig-storage/csi-resizer:v1.13.1
+  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-resizer:v1.13.1
+  type: image
+- source: registry.k8s.io/sig-storage/csi-resizer:v1.13.2
+  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-resizer:v1.13.2
+  type: image
+- source: registry.k8s.io/sig-storage/csi-resizer:v1.3.0
+  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-resizer:v1.3.0
+  type: image
+- source: registry.k8s.io/sig-storage/csi-resizer:v1.4.0
+  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-resizer:v1.4.0
+  type: image
+- source: registry.k8s.io/sig-storage/csi-resizer:v1.6.0
+  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-resizer:v1.6.0
+  type: image
+- source: registry.k8s.io/sig-storage/csi-resizer:v1.7.0
+  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-resizer:v1.7.0
+  type: image
+- source: registry.k8s.io/sig-storage/csi-resizer:v1.8.0
+  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-resizer:v1.8.0
+  type: image
+- source: registry.k8s.io/sig-storage/csi-resizer:v1.9.0
+  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-resizer:v1.9.0
+  type: image
+- source: registry.k8s.io/sig-storage/csi-resizer:v1.9.1
+  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-resizer:v1.9.1
+  type: image
+- source: registry.k8s.io/sig-storage/csi-resizer:v1.9.2
+  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-resizer:v1.9.2
+  type: image
+- source: registry.k8s.io/sig-storage/csi-resizer:v1.10.0
   target: stgregistry.suse.com/rancher/mirrored-sig-storage-csi-resizer:v1.10.0
   type: image
 - source: registry.k8s.io/sig-storage/csi-resizer:v1.10.1
@@ -20017,6 +33300,45 @@ sync:
   type: image
 - source: registry.k8s.io/sig-storage/csi-resizer:v1.9.2
   target: stgregistry.suse.com/rancher/mirrored-sig-storage-csi-resizer:v1.9.2
+  type: image
+- source: registry.k8s.io/sig-storage/csi-resizer:v1.10.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-resizer:v1.10.0
+  type: image
+- source: registry.k8s.io/sig-storage/csi-resizer:v1.10.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-resizer:v1.10.1
+  type: image
+- source: registry.k8s.io/sig-storage/csi-resizer:v1.12.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-resizer:v1.12.0
+  type: image
+- source: registry.k8s.io/sig-storage/csi-resizer:v1.13.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-resizer:v1.13.1
+  type: image
+- source: registry.k8s.io/sig-storage/csi-resizer:v1.13.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-resizer:v1.13.2
+  type: image
+- source: registry.k8s.io/sig-storage/csi-resizer:v1.3.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-resizer:v1.3.0
+  type: image
+- source: registry.k8s.io/sig-storage/csi-resizer:v1.4.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-resizer:v1.4.0
+  type: image
+- source: registry.k8s.io/sig-storage/csi-resizer:v1.6.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-resizer:v1.6.0
+  type: image
+- source: registry.k8s.io/sig-storage/csi-resizer:v1.7.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-resizer:v1.7.0
+  type: image
+- source: registry.k8s.io/sig-storage/csi-resizer:v1.8.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-resizer:v1.8.0
+  type: image
+- source: registry.k8s.io/sig-storage/csi-resizer:v1.9.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-resizer:v1.9.0
+  type: image
+- source: registry.k8s.io/sig-storage/csi-resizer:v1.9.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-resizer:v1.9.1
+  type: image
+- source: registry.k8s.io/sig-storage/csi-resizer:v1.9.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-resizer:v1.9.2
   type: image
 - source: registry.k8s.io/sig-storage/csi-snapshotter:v5.0.1
   target: docker.io/rancher/mirrored-sig-storage-csi-snapshotter:v5.0.1
@@ -20067,6 +33389,30 @@ sync:
   target: registry.suse.com/rancher/mirrored-sig-storage-csi-snapshotter:v8.2.0
   type: image
 - source: registry.k8s.io/sig-storage/csi-snapshotter:v5.0.1
+  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-snapshotter:v5.0.1
+  type: image
+- source: registry.k8s.io/sig-storage/csi-snapshotter:v6.0.1
+  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-snapshotter:v6.0.1
+  type: image
+- source: registry.k8s.io/sig-storage/csi-snapshotter:v6.2.1
+  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-snapshotter:v6.2.1
+  type: image
+- source: registry.k8s.io/sig-storage/csi-snapshotter:v6.2.2
+  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-snapshotter:v6.2.2
+  type: image
+- source: registry.k8s.io/sig-storage/csi-snapshotter:v7.0.1
+  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-snapshotter:v7.0.1
+  type: image
+- source: registry.k8s.io/sig-storage/csi-snapshotter:v7.0.2
+  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-snapshotter:v7.0.2
+  type: image
+- source: registry.k8s.io/sig-storage/csi-snapshotter:v8.1.0
+  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-snapshotter:v8.1.0
+  type: image
+- source: registry.k8s.io/sig-storage/csi-snapshotter:v8.2.0
+  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-snapshotter:v8.2.0
+  type: image
+- source: registry.k8s.io/sig-storage/csi-snapshotter:v5.0.1
   target: stgregistry.suse.com/rancher/mirrored-sig-storage-csi-snapshotter:v5.0.1
   type: image
 - source: registry.k8s.io/sig-storage/csi-snapshotter:v6.0.1
@@ -20089,6 +33435,30 @@ sync:
   type: image
 - source: registry.k8s.io/sig-storage/csi-snapshotter:v8.2.0
   target: stgregistry.suse.com/rancher/mirrored-sig-storage-csi-snapshotter:v8.2.0
+  type: image
+- source: registry.k8s.io/sig-storage/csi-snapshotter:v5.0.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-snapshotter:v5.0.1
+  type: image
+- source: registry.k8s.io/sig-storage/csi-snapshotter:v6.0.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-snapshotter:v6.0.1
+  type: image
+- source: registry.k8s.io/sig-storage/csi-snapshotter:v6.2.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-snapshotter:v6.2.1
+  type: image
+- source: registry.k8s.io/sig-storage/csi-snapshotter:v6.2.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-snapshotter:v6.2.2
+  type: image
+- source: registry.k8s.io/sig-storage/csi-snapshotter:v7.0.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-snapshotter:v7.0.1
+  type: image
+- source: registry.k8s.io/sig-storage/csi-snapshotter:v7.0.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-snapshotter:v7.0.2
+  type: image
+- source: registry.k8s.io/sig-storage/csi-snapshotter:v8.1.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-snapshotter:v8.1.0
+  type: image
+- source: registry.k8s.io/sig-storage/csi-snapshotter:v8.2.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-snapshotter:v8.2.0
   type: image
 - source: registry.k8s.io/sig-storage/livenessprobe:v2.10.0
   target: docker.io/rancher/mirrored-sig-storage-livenessprobe:v2.10.0
@@ -20157,6 +33527,39 @@ sync:
   target: registry.suse.com/rancher/mirrored-sig-storage-livenessprobe:v2.9.0
   type: image
 - source: registry.k8s.io/sig-storage/livenessprobe:v2.10.0
+  target: registry.suse.com/rancher/charts/mirrored-sig-storage-livenessprobe:v2.10.0
+  type: image
+- source: registry.k8s.io/sig-storage/livenessprobe:v2.11.0
+  target: registry.suse.com/rancher/charts/mirrored-sig-storage-livenessprobe:v2.11.0
+  type: image
+- source: registry.k8s.io/sig-storage/livenessprobe:v2.12.0
+  target: registry.suse.com/rancher/charts/mirrored-sig-storage-livenessprobe:v2.12.0
+  type: image
+- source: registry.k8s.io/sig-storage/livenessprobe:v2.14.0
+  target: registry.suse.com/rancher/charts/mirrored-sig-storage-livenessprobe:v2.14.0
+  type: image
+- source: registry.k8s.io/sig-storage/livenessprobe:v2.15.0
+  target: registry.suse.com/rancher/charts/mirrored-sig-storage-livenessprobe:v2.15.0
+  type: image
+- source: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+  target: registry.suse.com/rancher/charts/mirrored-sig-storage-livenessprobe:v2.16.0
+  type: image
+- source: registry.k8s.io/sig-storage/livenessprobe:v2.4.0
+  target: registry.suse.com/rancher/charts/mirrored-sig-storage-livenessprobe:v2.4.0
+  type: image
+- source: registry.k8s.io/sig-storage/livenessprobe:v2.6.0
+  target: registry.suse.com/rancher/charts/mirrored-sig-storage-livenessprobe:v2.6.0
+  type: image
+- source: registry.k8s.io/sig-storage/livenessprobe:v2.7.0
+  target: registry.suse.com/rancher/charts/mirrored-sig-storage-livenessprobe:v2.7.0
+  type: image
+- source: registry.k8s.io/sig-storage/livenessprobe:v2.8.0
+  target: registry.suse.com/rancher/charts/mirrored-sig-storage-livenessprobe:v2.8.0
+  type: image
+- source: registry.k8s.io/sig-storage/livenessprobe:v2.9.0
+  target: registry.suse.com/rancher/charts/mirrored-sig-storage-livenessprobe:v2.9.0
+  type: image
+- source: registry.k8s.io/sig-storage/livenessprobe:v2.10.0
   target: stgregistry.suse.com/rancher/mirrored-sig-storage-livenessprobe:v2.10.0
   type: image
 - source: registry.k8s.io/sig-storage/livenessprobe:v2.11.0
@@ -20189,6 +33592,39 @@ sync:
 - source: registry.k8s.io/sig-storage/livenessprobe:v2.9.0
   target: stgregistry.suse.com/rancher/mirrored-sig-storage-livenessprobe:v2.9.0
   type: image
+- source: registry.k8s.io/sig-storage/livenessprobe:v2.10.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-livenessprobe:v2.10.0
+  type: image
+- source: registry.k8s.io/sig-storage/livenessprobe:v2.11.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-livenessprobe:v2.11.0
+  type: image
+- source: registry.k8s.io/sig-storage/livenessprobe:v2.12.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-livenessprobe:v2.12.0
+  type: image
+- source: registry.k8s.io/sig-storage/livenessprobe:v2.14.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-livenessprobe:v2.14.0
+  type: image
+- source: registry.k8s.io/sig-storage/livenessprobe:v2.15.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-livenessprobe:v2.15.0
+  type: image
+- source: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-livenessprobe:v2.16.0
+  type: image
+- source: registry.k8s.io/sig-storage/livenessprobe:v2.4.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-livenessprobe:v2.4.0
+  type: image
+- source: registry.k8s.io/sig-storage/livenessprobe:v2.6.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-livenessprobe:v2.6.0
+  type: image
+- source: registry.k8s.io/sig-storage/livenessprobe:v2.7.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-livenessprobe:v2.7.0
+  type: image
+- source: registry.k8s.io/sig-storage/livenessprobe:v2.8.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-livenessprobe:v2.8.0
+  type: image
+- source: registry.k8s.io/sig-storage/livenessprobe:v2.9.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-livenessprobe:v2.9.0
+  type: image
 - source: registry.k8s.io/sig-storage/snapshot-controller:v6.1.0
   target: docker.io/rancher/mirrored-sig-storage-snapshot-controller:v6.1.0
   type: image
@@ -20214,6 +33650,18 @@ sync:
   target: registry.suse.com/rancher/mirrored-sig-storage-snapshot-controller:v8.2.0
   type: image
 - source: registry.k8s.io/sig-storage/snapshot-controller:v6.1.0
+  target: registry.suse.com/rancher/charts/mirrored-sig-storage-snapshot-controller:v6.1.0
+  type: image
+- source: registry.k8s.io/sig-storage/snapshot-controller:v6.2.1
+  target: registry.suse.com/rancher/charts/mirrored-sig-storage-snapshot-controller:v6.2.1
+  type: image
+- source: registry.k8s.io/sig-storage/snapshot-controller:v8.1.0
+  target: registry.suse.com/rancher/charts/mirrored-sig-storage-snapshot-controller:v8.1.0
+  type: image
+- source: registry.k8s.io/sig-storage/snapshot-controller:v8.2.0
+  target: registry.suse.com/rancher/charts/mirrored-sig-storage-snapshot-controller:v8.2.0
+  type: image
+- source: registry.k8s.io/sig-storage/snapshot-controller:v6.1.0
   target: stgregistry.suse.com/rancher/mirrored-sig-storage-snapshot-controller:v6.1.0
   type: image
 - source: registry.k8s.io/sig-storage/snapshot-controller:v6.2.1
@@ -20224,6 +33672,18 @@ sync:
   type: image
 - source: registry.k8s.io/sig-storage/snapshot-controller:v8.2.0
   target: stgregistry.suse.com/rancher/mirrored-sig-storage-snapshot-controller:v8.2.0
+  type: image
+- source: registry.k8s.io/sig-storage/snapshot-controller:v6.1.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-snapshot-controller:v6.1.0
+  type: image
+- source: registry.k8s.io/sig-storage/snapshot-controller:v6.2.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-snapshot-controller:v6.2.1
+  type: image
+- source: registry.k8s.io/sig-storage/snapshot-controller:v8.1.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-snapshot-controller:v8.1.0
+  type: image
+- source: registry.k8s.io/sig-storage/snapshot-controller:v8.2.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-snapshot-controller:v8.2.0
   type: image
 - source: registry.k8s.io/sig-storage/snapshot-validation-webhook:v6.1.0
   target: docker.io/rancher/mirrored-sig-storage-snapshot-validation-webhook:v6.1.0
@@ -20250,6 +33710,18 @@ sync:
   target: registry.suse.com/rancher/mirrored-sig-storage-snapshot-validation-webhook:v8.1.0
   type: image
 - source: registry.k8s.io/sig-storage/snapshot-validation-webhook:v6.1.0
+  target: registry.suse.com/rancher/charts/mirrored-sig-storage-snapshot-validation-webhook:v6.1.0
+  type: image
+- source: registry.k8s.io/sig-storage/snapshot-validation-webhook:v6.2.1
+  target: registry.suse.com/rancher/charts/mirrored-sig-storage-snapshot-validation-webhook:v6.2.1
+  type: image
+- source: registry.k8s.io/sig-storage/snapshot-validation-webhook:v6.2.2
+  target: registry.suse.com/rancher/charts/mirrored-sig-storage-snapshot-validation-webhook:v6.2.2
+  type: image
+- source: registry.k8s.io/sig-storage/snapshot-validation-webhook:v8.1.0
+  target: registry.suse.com/rancher/charts/mirrored-sig-storage-snapshot-validation-webhook:v8.1.0
+  type: image
+- source: registry.k8s.io/sig-storage/snapshot-validation-webhook:v6.1.0
   target: stgregistry.suse.com/rancher/mirrored-sig-storage-snapshot-validation-webhook:v6.1.0
   type: image
 - source: registry.k8s.io/sig-storage/snapshot-validation-webhook:v6.2.1
@@ -20260,6 +33732,18 @@ sync:
   type: image
 - source: registry.k8s.io/sig-storage/snapshot-validation-webhook:v8.1.0
   target: stgregistry.suse.com/rancher/mirrored-sig-storage-snapshot-validation-webhook:v8.1.0
+  type: image
+- source: registry.k8s.io/sig-storage/snapshot-validation-webhook:v6.1.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-snapshot-validation-webhook:v6.1.0
+  type: image
+- source: registry.k8s.io/sig-storage/snapshot-validation-webhook:v6.2.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-snapshot-validation-webhook:v6.2.1
+  type: image
+- source: registry.k8s.io/sig-storage/snapshot-validation-webhook:v6.2.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-snapshot-validation-webhook:v6.2.2
+  type: image
+- source: registry.k8s.io/sig-storage/snapshot-validation-webhook:v8.1.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-snapshot-validation-webhook:v8.1.0
   type: image
 - source: registry.suse.com/bci/bci-busybox:15.4.11.2
   target: docker.io/rancher/mirrored-bci-busybox:15.4.11.2
@@ -20280,6 +33764,15 @@ sync:
   target: registry.suse.com/rancher/mirrored-bci-busybox:15.6.24.2
   type: image
 - source: registry.suse.com/bci/bci-busybox:15.4.11.2
+  target: registry.suse.com/rancher/charts/mirrored-bci-busybox:15.4.11.2
+  type: image
+- source: registry.suse.com/bci/bci-busybox:15.6.19.1
+  target: registry.suse.com/rancher/charts/mirrored-bci-busybox:15.6.19.1
+  type: image
+- source: registry.suse.com/bci/bci-busybox:15.6.24.2
+  target: registry.suse.com/rancher/charts/mirrored-bci-busybox:15.6.24.2
+  type: image
+- source: registry.suse.com/bci/bci-busybox:15.4.11.2
   target: stgregistry.suse.com/rancher/mirrored-bci-busybox:15.4.11.2
   type: image
 - source: registry.suse.com/bci/bci-busybox:15.6.19.1
@@ -20287,6 +33780,15 @@ sync:
   type: image
 - source: registry.suse.com/bci/bci-busybox:15.6.24.2
   target: stgregistry.suse.com/rancher/mirrored-bci-busybox:15.6.24.2
+  type: image
+- source: registry.suse.com/bci/bci-busybox:15.4.11.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-bci-busybox:15.4.11.2
+  type: image
+- source: registry.suse.com/bci/bci-busybox:15.6.19.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-bci-busybox:15.6.19.1
+  type: image
+- source: registry.suse.com/bci/bci-busybox:15.6.24.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-bci-busybox:15.6.24.2
   type: image
 - source: registry.suse.com/bci/bci-micro:15.4.14.3
   target: docker.io/rancher/mirrored-bci-micro:15.4.14.3
@@ -20307,6 +33809,15 @@ sync:
   target: registry.suse.com/rancher/mirrored-bci-micro:15.6.24.2
   type: image
 - source: registry.suse.com/bci/bci-micro:15.4.14.3
+  target: registry.suse.com/rancher/charts/mirrored-bci-micro:15.4.14.3
+  type: image
+- source: registry.suse.com/bci/bci-micro:15.6.19.1
+  target: registry.suse.com/rancher/charts/mirrored-bci-micro:15.6.19.1
+  type: image
+- source: registry.suse.com/bci/bci-micro:15.6.24.2
+  target: registry.suse.com/rancher/charts/mirrored-bci-micro:15.6.24.2
+  type: image
+- source: registry.suse.com/bci/bci-micro:15.4.14.3
   target: stgregistry.suse.com/rancher/mirrored-bci-micro:15.4.14.3
   type: image
 - source: registry.suse.com/bci/bci-micro:15.6.19.1
@@ -20314,6 +33825,15 @@ sync:
   type: image
 - source: registry.suse.com/bci/bci-micro:15.6.24.2
   target: stgregistry.suse.com/rancher/mirrored-bci-micro:15.6.24.2
+  type: image
+- source: registry.suse.com/bci/bci-micro:15.4.14.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-bci-micro:15.4.14.3
+  type: image
+- source: registry.suse.com/bci/bci-micro:15.6.19.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-bci-micro:15.6.19.1
+  type: image
+- source: registry.suse.com/bci/bci-micro:15.6.24.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-bci-micro:15.6.24.2
   type: image
 - source: registry.suse.com/rancher/elemental-operator:1.4.2
   target: docker.io/rancher/mirrored-elemental-operator:1.4.2
@@ -20370,6 +33890,33 @@ sync:
   target: registry.suse.com/rancher/mirrored-elemental-operator:1.7.3
   type: image
 - source: registry.suse.com/rancher/elemental-operator:1.4.2
+  target: registry.suse.com/rancher/charts/mirrored-elemental-operator:1.4.2
+  type: image
+- source: registry.suse.com/rancher/elemental-operator:1.4.3
+  target: registry.suse.com/rancher/charts/mirrored-elemental-operator:1.4.3
+  type: image
+- source: registry.suse.com/rancher/elemental-operator:1.5.3
+  target: registry.suse.com/rancher/charts/mirrored-elemental-operator:1.5.3
+  type: image
+- source: registry.suse.com/rancher/elemental-operator:1.5.4
+  target: registry.suse.com/rancher/charts/mirrored-elemental-operator:1.5.4
+  type: image
+- source: registry.suse.com/rancher/elemental-operator:1.6.4
+  target: registry.suse.com/rancher/charts/mirrored-elemental-operator:1.6.4
+  type: image
+- source: registry.suse.com/rancher/elemental-operator:1.6.5
+  target: registry.suse.com/rancher/charts/mirrored-elemental-operator:1.6.5
+  type: image
+- source: registry.suse.com/rancher/elemental-operator:1.6.8
+  target: registry.suse.com/rancher/charts/mirrored-elemental-operator:1.6.8
+  type: image
+- source: registry.suse.com/rancher/elemental-operator:1.6.9
+  target: registry.suse.com/rancher/charts/mirrored-elemental-operator:1.6.9
+  type: image
+- source: registry.suse.com/rancher/elemental-operator:1.7.3
+  target: registry.suse.com/rancher/charts/mirrored-elemental-operator:1.7.3
+  type: image
+- source: registry.suse.com/rancher/elemental-operator:1.4.2
   target: stgregistry.suse.com/rancher/mirrored-elemental-operator:1.4.2
   type: image
 - source: registry.suse.com/rancher/elemental-operator:1.4.3
@@ -20395,6 +33942,33 @@ sync:
   type: image
 - source: registry.suse.com/rancher/elemental-operator:1.7.3
   target: stgregistry.suse.com/rancher/mirrored-elemental-operator:1.7.3
+  type: image
+- source: registry.suse.com/rancher/elemental-operator:1.4.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-elemental-operator:1.4.2
+  type: image
+- source: registry.suse.com/rancher/elemental-operator:1.4.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-elemental-operator:1.4.3
+  type: image
+- source: registry.suse.com/rancher/elemental-operator:1.5.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-elemental-operator:1.5.3
+  type: image
+- source: registry.suse.com/rancher/elemental-operator:1.5.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-elemental-operator:1.5.4
+  type: image
+- source: registry.suse.com/rancher/elemental-operator:1.6.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-elemental-operator:1.6.4
+  type: image
+- source: registry.suse.com/rancher/elemental-operator:1.6.5
+  target: stgregistry.suse.com/rancher/charts/mirrored-elemental-operator:1.6.5
+  type: image
+- source: registry.suse.com/rancher/elemental-operator:1.6.8
+  target: stgregistry.suse.com/rancher/charts/mirrored-elemental-operator:1.6.8
+  type: image
+- source: registry.suse.com/rancher/elemental-operator:1.6.9
+  target: stgregistry.suse.com/rancher/charts/mirrored-elemental-operator:1.6.9
+  type: image
+- source: registry.suse.com/rancher/elemental-operator:1.7.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-elemental-operator:1.7.3
   type: image
 - source: registry.suse.com/rancher/seedimage-builder:1.3.4
   target: docker.io/rancher/mirrored-elemental-seedimage-builder:1.3.4
@@ -20457,6 +34031,36 @@ sync:
   target: registry.suse.com/rancher/mirrored-elemental-seedimage-builder:1.7.3
   type: image
 - source: registry.suse.com/rancher/seedimage-builder:1.3.4
+  target: registry.suse.com/rancher/charts/mirrored-elemental-seedimage-builder:1.3.4
+  type: image
+- source: registry.suse.com/rancher/seedimage-builder:1.4.2
+  target: registry.suse.com/rancher/charts/mirrored-elemental-seedimage-builder:1.4.2
+  type: image
+- source: registry.suse.com/rancher/seedimage-builder:1.4.3
+  target: registry.suse.com/rancher/charts/mirrored-elemental-seedimage-builder:1.4.3
+  type: image
+- source: registry.suse.com/rancher/seedimage-builder:1.5.3
+  target: registry.suse.com/rancher/charts/mirrored-elemental-seedimage-builder:1.5.3
+  type: image
+- source: registry.suse.com/rancher/seedimage-builder:1.5.4
+  target: registry.suse.com/rancher/charts/mirrored-elemental-seedimage-builder:1.5.4
+  type: image
+- source: registry.suse.com/rancher/seedimage-builder:1.6.4
+  target: registry.suse.com/rancher/charts/mirrored-elemental-seedimage-builder:1.6.4
+  type: image
+- source: registry.suse.com/rancher/seedimage-builder:1.6.5
+  target: registry.suse.com/rancher/charts/mirrored-elemental-seedimage-builder:1.6.5
+  type: image
+- source: registry.suse.com/rancher/seedimage-builder:1.6.8
+  target: registry.suse.com/rancher/charts/mirrored-elemental-seedimage-builder:1.6.8
+  type: image
+- source: registry.suse.com/rancher/seedimage-builder:1.6.9
+  target: registry.suse.com/rancher/charts/mirrored-elemental-seedimage-builder:1.6.9
+  type: image
+- source: registry.suse.com/rancher/seedimage-builder:1.7.3
+  target: registry.suse.com/rancher/charts/mirrored-elemental-seedimage-builder:1.7.3
+  type: image
+- source: registry.suse.com/rancher/seedimage-builder:1.3.4
   target: stgregistry.suse.com/rancher/mirrored-elemental-seedimage-builder:1.3.4
   type: image
 - source: registry.suse.com/rancher/seedimage-builder:1.4.2
@@ -20486,6 +34090,36 @@ sync:
 - source: registry.suse.com/rancher/seedimage-builder:1.7.3
   target: stgregistry.suse.com/rancher/mirrored-elemental-seedimage-builder:1.7.3
   type: image
+- source: registry.suse.com/rancher/seedimage-builder:1.3.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-elemental-seedimage-builder:1.3.4
+  type: image
+- source: registry.suse.com/rancher/seedimage-builder:1.4.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-elemental-seedimage-builder:1.4.2
+  type: image
+- source: registry.suse.com/rancher/seedimage-builder:1.4.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-elemental-seedimage-builder:1.4.3
+  type: image
+- source: registry.suse.com/rancher/seedimage-builder:1.5.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-elemental-seedimage-builder:1.5.3
+  type: image
+- source: registry.suse.com/rancher/seedimage-builder:1.5.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-elemental-seedimage-builder:1.5.4
+  type: image
+- source: registry.suse.com/rancher/seedimage-builder:1.6.4
+  target: stgregistry.suse.com/rancher/charts/mirrored-elemental-seedimage-builder:1.6.4
+  type: image
+- source: registry.suse.com/rancher/seedimage-builder:1.6.5
+  target: stgregistry.suse.com/rancher/charts/mirrored-elemental-seedimage-builder:1.6.5
+  type: image
+- source: registry.suse.com/rancher/seedimage-builder:1.6.8
+  target: stgregistry.suse.com/rancher/charts/mirrored-elemental-seedimage-builder:1.6.8
+  type: image
+- source: registry.suse.com/rancher/seedimage-builder:1.6.9
+  target: stgregistry.suse.com/rancher/charts/mirrored-elemental-seedimage-builder:1.6.9
+  type: image
+- source: registry.suse.com/rancher/seedimage-builder:1.7.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-elemental-seedimage-builder:1.7.3
+  type: image
 - source: rpardini/docker-registry-proxy:0.6.1
   target: docker.io/rancher/rpardini-docker-registry-proxy:0.6.1
   type: image
@@ -20493,7 +34127,13 @@ sync:
   target: registry.suse.com/rancher/rpardini-docker-registry-proxy:0.6.1
   type: image
 - source: rpardini/docker-registry-proxy:0.6.1
+  target: registry.suse.com/rancher/charts/rpardini-docker-registry-proxy:0.6.1
+  type: image
+- source: rpardini/docker-registry-proxy:0.6.1
   target: stgregistry.suse.com/rancher/rpardini-docker-registry-proxy:0.6.1
+  type: image
+- source: rpardini/docker-registry-proxy:0.6.1
+  target: stgregistry.suse.com/rancher/charts/rpardini-docker-registry-proxy:0.6.1
   type: image
 - source: sigwindowstools/k8s-gmsa-webhook:v0.3.0
   target: docker.io/rancher/mirrored-sigwindowstools-k8s-gmsa-webhook:v0.3.0
@@ -20502,7 +34142,13 @@ sync:
   target: registry.suse.com/rancher/mirrored-sigwindowstools-k8s-gmsa-webhook:v0.3.0
   type: image
 - source: sigwindowstools/k8s-gmsa-webhook:v0.3.0
+  target: registry.suse.com/rancher/charts/mirrored-sigwindowstools-k8s-gmsa-webhook:v0.3.0
+  type: image
+- source: sigwindowstools/k8s-gmsa-webhook:v0.3.0
   target: stgregistry.suse.com/rancher/mirrored-sigwindowstools-k8s-gmsa-webhook:v0.3.0
+  type: image
+- source: sigwindowstools/k8s-gmsa-webhook:v0.3.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-sigwindowstools-k8s-gmsa-webhook:v0.3.0
   type: image
 - source: sonobuoy/sonobuoy:v0.16.3
   target: docker.io/rancher/mirrored-sonobuoy-sonobuoy:v0.16.3
@@ -20583,6 +34229,45 @@ sync:
   target: registry.suse.com/rancher/mirrored-sonobuoy-sonobuoy:v0.57.3
   type: image
 - source: sonobuoy/sonobuoy:v0.16.3
+  target: registry.suse.com/rancher/charts/mirrored-sonobuoy-sonobuoy:v0.16.3
+  type: image
+- source: sonobuoy/sonobuoy:v0.19.0
+  target: registry.suse.com/rancher/charts/mirrored-sonobuoy-sonobuoy:v0.19.0
+  type: image
+- source: sonobuoy/sonobuoy:v0.52.0
+  target: registry.suse.com/rancher/charts/mirrored-sonobuoy-sonobuoy:v0.52.0
+  type: image
+- source: sonobuoy/sonobuoy:v0.53.2
+  target: registry.suse.com/rancher/charts/mirrored-sonobuoy-sonobuoy:v0.53.2
+  type: image
+- source: sonobuoy/sonobuoy:v0.56.14
+  target: registry.suse.com/rancher/charts/mirrored-sonobuoy-sonobuoy:v0.56.14
+  type: image
+- source: sonobuoy/sonobuoy:v0.56.15
+  target: registry.suse.com/rancher/charts/mirrored-sonobuoy-sonobuoy:v0.56.15
+  type: image
+- source: sonobuoy/sonobuoy:v0.56.16
+  target: registry.suse.com/rancher/charts/mirrored-sonobuoy-sonobuoy:v0.56.16
+  type: image
+- source: sonobuoy/sonobuoy:v0.56.17
+  target: registry.suse.com/rancher/charts/mirrored-sonobuoy-sonobuoy:v0.56.17
+  type: image
+- source: sonobuoy/sonobuoy:v0.56.7
+  target: registry.suse.com/rancher/charts/mirrored-sonobuoy-sonobuoy:v0.56.7
+  type: image
+- source: sonobuoy/sonobuoy:v0.57.0
+  target: registry.suse.com/rancher/charts/mirrored-sonobuoy-sonobuoy:v0.57.0
+  type: image
+- source: sonobuoy/sonobuoy:v0.57.1
+  target: registry.suse.com/rancher/charts/mirrored-sonobuoy-sonobuoy:v0.57.1
+  type: image
+- source: sonobuoy/sonobuoy:v0.57.2
+  target: registry.suse.com/rancher/charts/mirrored-sonobuoy-sonobuoy:v0.57.2
+  type: image
+- source: sonobuoy/sonobuoy:v0.57.3
+  target: registry.suse.com/rancher/charts/mirrored-sonobuoy-sonobuoy:v0.57.3
+  type: image
+- source: sonobuoy/sonobuoy:v0.16.3
   target: stgregistry.suse.com/rancher/mirrored-sonobuoy-sonobuoy:v0.16.3
   type: image
 - source: sonobuoy/sonobuoy:v0.19.0
@@ -20621,6 +34306,45 @@ sync:
 - source: sonobuoy/sonobuoy:v0.57.3
   target: stgregistry.suse.com/rancher/mirrored-sonobuoy-sonobuoy:v0.57.3
   type: image
+- source: sonobuoy/sonobuoy:v0.16.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-sonobuoy-sonobuoy:v0.16.3
+  type: image
+- source: sonobuoy/sonobuoy:v0.19.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-sonobuoy-sonobuoy:v0.19.0
+  type: image
+- source: sonobuoy/sonobuoy:v0.52.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-sonobuoy-sonobuoy:v0.52.0
+  type: image
+- source: sonobuoy/sonobuoy:v0.53.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-sonobuoy-sonobuoy:v0.53.2
+  type: image
+- source: sonobuoy/sonobuoy:v0.56.14
+  target: stgregistry.suse.com/rancher/charts/mirrored-sonobuoy-sonobuoy:v0.56.14
+  type: image
+- source: sonobuoy/sonobuoy:v0.56.15
+  target: stgregistry.suse.com/rancher/charts/mirrored-sonobuoy-sonobuoy:v0.56.15
+  type: image
+- source: sonobuoy/sonobuoy:v0.56.16
+  target: stgregistry.suse.com/rancher/charts/mirrored-sonobuoy-sonobuoy:v0.56.16
+  type: image
+- source: sonobuoy/sonobuoy:v0.56.17
+  target: stgregistry.suse.com/rancher/charts/mirrored-sonobuoy-sonobuoy:v0.56.17
+  type: image
+- source: sonobuoy/sonobuoy:v0.56.7
+  target: stgregistry.suse.com/rancher/charts/mirrored-sonobuoy-sonobuoy:v0.56.7
+  type: image
+- source: sonobuoy/sonobuoy:v0.57.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-sonobuoy-sonobuoy:v0.57.0
+  type: image
+- source: sonobuoy/sonobuoy:v0.57.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-sonobuoy-sonobuoy:v0.57.1
+  type: image
+- source: sonobuoy/sonobuoy:v0.57.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-sonobuoy-sonobuoy:v0.57.2
+  type: image
+- source: sonobuoy/sonobuoy:v0.57.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-sonobuoy-sonobuoy:v0.57.3
+  type: image
 - source: sonobuoy/sonobuoy:v0.19.0
   target: docker.io/rancher/sonobuoy-sonobuoy:v0.19.0
   type: image
@@ -20628,7 +34352,13 @@ sync:
   target: registry.suse.com/rancher/sonobuoy-sonobuoy:v0.19.0
   type: image
 - source: sonobuoy/sonobuoy:v0.19.0
+  target: registry.suse.com/rancher/charts/sonobuoy-sonobuoy:v0.19.0
+  type: image
+- source: sonobuoy/sonobuoy:v0.19.0
   target: stgregistry.suse.com/rancher/sonobuoy-sonobuoy:v0.19.0
+  type: image
+- source: sonobuoy/sonobuoy:v0.19.0
+  target: stgregistry.suse.com/rancher/charts/sonobuoy-sonobuoy:v0.19.0
   type: image
 - source: squareup/ghostunnel:v1.5.2
   target: docker.io/rancher/mirrored-squareup-ghostunnel:v1.5.2
@@ -20637,7 +34367,13 @@ sync:
   target: registry.suse.com/rancher/mirrored-squareup-ghostunnel:v1.5.2
   type: image
 - source: squareup/ghostunnel:v1.5.2
+  target: registry.suse.com/rancher/charts/mirrored-squareup-ghostunnel:v1.5.2
+  type: image
+- source: squareup/ghostunnel:v1.5.2
   target: stgregistry.suse.com/rancher/mirrored-squareup-ghostunnel:v1.5.2
+  type: image
+- source: squareup/ghostunnel:v1.5.2
+  target: stgregistry.suse.com/rancher/charts/mirrored-squareup-ghostunnel:v1.5.2
   type: image
 - source: squareup/ghostunnel:v1.5.2
   target: docker.io/rancher/squareup-ghostunnel:v1.5.2
@@ -20646,7 +34382,13 @@ sync:
   target: registry.suse.com/rancher/squareup-ghostunnel:v1.5.2
   type: image
 - source: squareup/ghostunnel:v1.5.2
+  target: registry.suse.com/rancher/charts/squareup-ghostunnel:v1.5.2
+  type: image
+- source: squareup/ghostunnel:v1.5.2
   target: stgregistry.suse.com/rancher/squareup-ghostunnel:v1.5.2
+  type: image
+- source: squareup/ghostunnel:v1.5.2
+  target: stgregistry.suse.com/rancher/charts/squareup-ghostunnel:v1.5.2
   type: image
 - source: thanosio/thanos:v0.15.0
   target: docker.io/rancher/mirrored-thanosio-thanos:v0.15.0
@@ -20661,10 +34403,22 @@ sync:
   target: registry.suse.com/rancher/mirrored-thanosio-thanos:v0.21.1
   type: image
 - source: thanosio/thanos:v0.15.0
+  target: registry.suse.com/rancher/charts/mirrored-thanosio-thanos:v0.15.0
+  type: image
+- source: thanosio/thanos:v0.21.1
+  target: registry.suse.com/rancher/charts/mirrored-thanosio-thanos:v0.21.1
+  type: image
+- source: thanosio/thanos:v0.15.0
   target: stgregistry.suse.com/rancher/mirrored-thanosio-thanos:v0.15.0
   type: image
 - source: thanosio/thanos:v0.21.1
   target: stgregistry.suse.com/rancher/mirrored-thanosio-thanos:v0.21.1
+  type: image
+- source: thanosio/thanos:v0.15.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-thanosio-thanos:v0.15.0
+  type: image
+- source: thanosio/thanos:v0.21.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-thanosio-thanos:v0.21.1
   type: image
 - source: thanosio/thanos:v0.15.0
   target: docker.io/rancher/thanosio-thanos:v0.15.0
@@ -20673,7 +34427,13 @@ sync:
   target: registry.suse.com/rancher/thanosio-thanos:v0.15.0
   type: image
 - source: thanosio/thanos:v0.15.0
+  target: registry.suse.com/rancher/charts/thanosio-thanos:v0.15.0
+  type: image
+- source: thanosio/thanos:v0.15.0
   target: stgregistry.suse.com/rancher/thanosio-thanos:v0.15.0
+  type: image
+- source: thanosio/thanos:v0.15.0
+  target: stgregistry.suse.com/rancher/charts/thanosio-thanos:v0.15.0
   type: image
 - source: tonistiigi/xx:1.3.0
   target: docker.io/rancher/mirrored-tonistiigi-xx:1.3.0
@@ -20700,6 +34460,18 @@ sync:
   target: registry.suse.com/rancher/mirrored-tonistiigi-xx:1.6.1
   type: image
 - source: tonistiigi/xx:1.3.0
+  target: registry.suse.com/rancher/charts/mirrored-tonistiigi-xx:1.3.0
+  type: image
+- source: tonistiigi/xx:1.5.0
+  target: registry.suse.com/rancher/charts/mirrored-tonistiigi-xx:1.5.0
+  type: image
+- source: tonistiigi/xx:1.6.0
+  target: registry.suse.com/rancher/charts/mirrored-tonistiigi-xx:1.6.0
+  type: image
+- source: tonistiigi/xx:1.6.1
+  target: registry.suse.com/rancher/charts/mirrored-tonistiigi-xx:1.6.1
+  type: image
+- source: tonistiigi/xx:1.3.0
   target: stgregistry.suse.com/rancher/mirrored-tonistiigi-xx:1.3.0
   type: image
 - source: tonistiigi/xx:1.5.0
@@ -20711,6 +34483,18 @@ sync:
 - source: tonistiigi/xx:1.6.1
   target: stgregistry.suse.com/rancher/mirrored-tonistiigi-xx:1.6.1
   type: image
+- source: tonistiigi/xx:1.3.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-tonistiigi-xx:1.3.0
+  type: image
+- source: tonistiigi/xx:1.5.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-tonistiigi-xx:1.5.0
+  type: image
+- source: tonistiigi/xx:1.6.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-tonistiigi-xx:1.6.0
+  type: image
+- source: tonistiigi/xx:1.6.1
+  target: stgregistry.suse.com/rancher/charts/mirrored-tonistiigi-xx:1.6.1
+  type: image
 - source: us.gcr.io/k8s-artifacts-prod/external-dns/external-dns:v0.7.3
   target: docker.io/rancher/kubernetes-external-dns:v0.7.3
   type: image
@@ -20718,7 +34502,13 @@ sync:
   target: registry.suse.com/rancher/kubernetes-external-dns:v0.7.3
   type: image
 - source: us.gcr.io/k8s-artifacts-prod/external-dns/external-dns:v0.7.3
+  target: registry.suse.com/rancher/charts/kubernetes-external-dns:v0.7.3
+  type: image
+- source: us.gcr.io/k8s-artifacts-prod/external-dns/external-dns:v0.7.3
   target: stgregistry.suse.com/rancher/kubernetes-external-dns:v0.7.3
+  type: image
+- source: us.gcr.io/k8s-artifacts-prod/external-dns/external-dns:v0.7.3
+  target: stgregistry.suse.com/rancher/charts/kubernetes-external-dns:v0.7.3
   type: image
 - source: us.gcr.io/k8s-artifacts-prod/external-dns/external-dns:v0.7.3
   target: docker.io/rancher/mirrored-kubernetes-external-dns:v0.7.3
@@ -20727,5 +34517,11 @@ sync:
   target: registry.suse.com/rancher/mirrored-kubernetes-external-dns:v0.7.3
   type: image
 - source: us.gcr.io/k8s-artifacts-prod/external-dns/external-dns:v0.7.3
+  target: registry.suse.com/rancher/charts/mirrored-kubernetes-external-dns:v0.7.3
+  type: image
+- source: us.gcr.io/k8s-artifacts-prod/external-dns/external-dns:v0.7.3
   target: stgregistry.suse.com/rancher/mirrored-kubernetes-external-dns:v0.7.3
+  type: image
+- source: us.gcr.io/k8s-artifacts-prod/external-dns/external-dns:v0.7.3
+  target: stgregistry.suse.com/rancher/charts/mirrored-kubernetes-external-dns:v0.7.3
   type: image

--- a/regsync.yaml
+++ b/regsync.yaml
@@ -62,21 +62,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-amazon-aws-cli:2.9.14
   type: image
 - source: amazon/aws-cli:2.0.52
-  target: registry.suse.com/rancher/charts/mirrored-amazon-aws-cli:2.0.52
-  type: image
-- source: amazon/aws-cli:2.8.5
-  target: registry.suse.com/rancher/charts/mirrored-amazon-aws-cli:2.8.5
-  type: image
-- source: amazon/aws-cli:2.8.9
-  target: registry.suse.com/rancher/charts/mirrored-amazon-aws-cli:2.8.9
-  type: image
-- source: amazon/aws-cli:2.9.0
-  target: registry.suse.com/rancher/charts/mirrored-amazon-aws-cli:2.9.0
-  type: image
-- source: amazon/aws-cli:2.9.14
-  target: registry.suse.com/rancher/charts/mirrored-amazon-aws-cli:2.9.14
-  type: image
-- source: amazon/aws-cli:2.0.52
   target: stgregistry.suse.com/rancher/mirrored-amazon-aws-cli:2.0.52
   type: image
 - source: amazon/aws-cli:2.8.5
@@ -90,21 +75,6 @@ sync:
   type: image
 - source: amazon/aws-cli:2.9.14
   target: stgregistry.suse.com/rancher/mirrored-amazon-aws-cli:2.9.14
-  type: image
-- source: amazon/aws-cli:2.0.52
-  target: stgregistry.suse.com/rancher/charts/mirrored-amazon-aws-cli:2.0.52
-  type: image
-- source: amazon/aws-cli:2.8.5
-  target: stgregistry.suse.com/rancher/charts/mirrored-amazon-aws-cli:2.8.5
-  type: image
-- source: amazon/aws-cli:2.8.9
-  target: stgregistry.suse.com/rancher/charts/mirrored-amazon-aws-cli:2.8.9
-  type: image
-- source: amazon/aws-cli:2.9.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-amazon-aws-cli:2.9.0
-  type: image
-- source: amazon/aws-cli:2.9.14
-  target: stgregistry.suse.com/rancher/charts/mirrored-amazon-aws-cli:2.9.14
   type: image
 - source: banzaicloud/logging-operator:3.6.0
   target: docker.io/rancher/banzaicloud-logging-operator:3.6.0
@@ -143,24 +113,6 @@ sync:
   target: registry.suse.com/rancher/banzaicloud-logging-operator:3.9.0
   type: image
 - source: banzaicloud/logging-operator:3.6.0
-  target: registry.suse.com/rancher/charts/banzaicloud-logging-operator:3.6.0
-  type: image
-- source: banzaicloud/logging-operator:3.7.0
-  target: registry.suse.com/rancher/charts/banzaicloud-logging-operator:3.7.0
-  type: image
-- source: banzaicloud/logging-operator:3.7.3
-  target: registry.suse.com/rancher/charts/banzaicloud-logging-operator:3.7.3
-  type: image
-- source: banzaicloud/logging-operator:3.8.0
-  target: registry.suse.com/rancher/charts/banzaicloud-logging-operator:3.8.0
-  type: image
-- source: banzaicloud/logging-operator:3.8.2
-  target: registry.suse.com/rancher/charts/banzaicloud-logging-operator:3.8.2
-  type: image
-- source: banzaicloud/logging-operator:3.9.0
-  target: registry.suse.com/rancher/charts/banzaicloud-logging-operator:3.9.0
-  type: image
-- source: banzaicloud/logging-operator:3.6.0
   target: stgregistry.suse.com/rancher/banzaicloud-logging-operator:3.6.0
   type: image
 - source: banzaicloud/logging-operator:3.7.0
@@ -177,24 +129,6 @@ sync:
   type: image
 - source: banzaicloud/logging-operator:3.9.0
   target: stgregistry.suse.com/rancher/banzaicloud-logging-operator:3.9.0
-  type: image
-- source: banzaicloud/logging-operator:3.6.0
-  target: stgregistry.suse.com/rancher/charts/banzaicloud-logging-operator:3.6.0
-  type: image
-- source: banzaicloud/logging-operator:3.7.0
-  target: stgregistry.suse.com/rancher/charts/banzaicloud-logging-operator:3.7.0
-  type: image
-- source: banzaicloud/logging-operator:3.7.3
-  target: stgregistry.suse.com/rancher/charts/banzaicloud-logging-operator:3.7.3
-  type: image
-- source: banzaicloud/logging-operator:3.8.0
-  target: stgregistry.suse.com/rancher/charts/banzaicloud-logging-operator:3.8.0
-  type: image
-- source: banzaicloud/logging-operator:3.8.2
-  target: stgregistry.suse.com/rancher/charts/banzaicloud-logging-operator:3.8.2
-  type: image
-- source: banzaicloud/logging-operator:3.9.0
-  target: stgregistry.suse.com/rancher/charts/banzaicloud-logging-operator:3.9.0
   type: image
 - source: banzaicloud/logging-operator:3.10.0
   target: docker.io/rancher/mirrored-banzaicloud-logging-operator:3.10.0
@@ -227,21 +161,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-banzaicloud-logging-operator:3.9.5
   type: image
 - source: banzaicloud/logging-operator:3.10.0
-  target: registry.suse.com/rancher/charts/mirrored-banzaicloud-logging-operator:3.10.0
-  type: image
-- source: banzaicloud/logging-operator:3.12.0
-  target: registry.suse.com/rancher/charts/mirrored-banzaicloud-logging-operator:3.12.0
-  type: image
-- source: banzaicloud/logging-operator:3.9.0
-  target: registry.suse.com/rancher/charts/mirrored-banzaicloud-logging-operator:3.9.0
-  type: image
-- source: banzaicloud/logging-operator:3.9.4
-  target: registry.suse.com/rancher/charts/mirrored-banzaicloud-logging-operator:3.9.4
-  type: image
-- source: banzaicloud/logging-operator:3.9.5
-  target: registry.suse.com/rancher/charts/mirrored-banzaicloud-logging-operator:3.9.5
-  type: image
-- source: banzaicloud/logging-operator:3.10.0
   target: stgregistry.suse.com/rancher/mirrored-banzaicloud-logging-operator:3.10.0
   type: image
 - source: banzaicloud/logging-operator:3.12.0
@@ -256,21 +175,6 @@ sync:
 - source: banzaicloud/logging-operator:3.9.5
   target: stgregistry.suse.com/rancher/mirrored-banzaicloud-logging-operator:3.9.5
   type: image
-- source: banzaicloud/logging-operator:3.10.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-banzaicloud-logging-operator:3.10.0
-  type: image
-- source: banzaicloud/logging-operator:3.12.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-banzaicloud-logging-operator:3.12.0
-  type: image
-- source: banzaicloud/logging-operator:3.9.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-banzaicloud-logging-operator:3.9.0
-  type: image
-- source: banzaicloud/logging-operator:3.9.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-banzaicloud-logging-operator:3.9.4
-  type: image
-- source: banzaicloud/logging-operator:3.9.5
-  target: stgregistry.suse.com/rancher/charts/mirrored-banzaicloud-logging-operator:3.9.5
-  type: image
 - source: bats/bats:v1.1.0
   target: docker.io/rancher/bats-bats:v1.1.0
   type: image
@@ -278,13 +182,7 @@ sync:
   target: registry.suse.com/rancher/bats-bats:v1.1.0
   type: image
 - source: bats/bats:v1.1.0
-  target: registry.suse.com/rancher/charts/bats-bats:v1.1.0
-  type: image
-- source: bats/bats:v1.1.0
   target: stgregistry.suse.com/rancher/bats-bats:v1.1.0
-  type: image
-- source: bats/bats:v1.1.0
-  target: stgregistry.suse.com/rancher/charts/bats-bats:v1.1.0
   type: image
 - source: bats/bats:v1.1.0
   target: docker.io/rancher/mirrored-bats-bats:v1.1.0
@@ -299,22 +197,10 @@ sync:
   target: registry.suse.com/rancher/mirrored-bats-bats:v1.4.1
   type: image
 - source: bats/bats:v1.1.0
-  target: registry.suse.com/rancher/charts/mirrored-bats-bats:v1.1.0
-  type: image
-- source: bats/bats:v1.4.1
-  target: registry.suse.com/rancher/charts/mirrored-bats-bats:v1.4.1
-  type: image
-- source: bats/bats:v1.1.0
   target: stgregistry.suse.com/rancher/mirrored-bats-bats:v1.1.0
   type: image
 - source: bats/bats:v1.4.1
   target: stgregistry.suse.com/rancher/mirrored-bats-bats:v1.4.1
-  type: image
-- source: bats/bats:v1.1.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-bats-bats:v1.1.0
-  type: image
-- source: bats/bats:v1.4.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-bats-bats:v1.4.1
   type: image
 - source: coredns/coredns:1.7.0
   target: docker.io/rancher/coredns-coredns:1.7.0
@@ -341,18 +227,6 @@ sync:
   target: registry.suse.com/rancher/coredns-coredns:1.8.3
   type: image
 - source: coredns/coredns:1.7.0
-  target: registry.suse.com/rancher/charts/coredns-coredns:1.7.0
-  type: image
-- source: coredns/coredns:1.7.1
-  target: registry.suse.com/rancher/charts/coredns-coredns:1.7.1
-  type: image
-- source: coredns/coredns:1.8.0
-  target: registry.suse.com/rancher/charts/coredns-coredns:1.8.0
-  type: image
-- source: coredns/coredns:1.8.3
-  target: registry.suse.com/rancher/charts/coredns-coredns:1.8.3
-  type: image
-- source: coredns/coredns:1.7.0
   target: stgregistry.suse.com/rancher/coredns-coredns:1.7.0
   type: image
 - source: coredns/coredns:1.7.1
@@ -363,18 +237,6 @@ sync:
   type: image
 - source: coredns/coredns:1.8.3
   target: stgregistry.suse.com/rancher/coredns-coredns:1.8.3
-  type: image
-- source: coredns/coredns:1.7.0
-  target: stgregistry.suse.com/rancher/charts/coredns-coredns:1.7.0
-  type: image
-- source: coredns/coredns:1.7.1
-  target: stgregistry.suse.com/rancher/charts/coredns-coredns:1.7.1
-  type: image
-- source: coredns/coredns:1.8.0
-  target: stgregistry.suse.com/rancher/charts/coredns-coredns:1.8.0
-  type: image
-- source: coredns/coredns:1.8.3
-  target: stgregistry.suse.com/rancher/charts/coredns-coredns:1.8.3
   type: image
 - source: coredns/coredns:1.10.1
   target: docker.io/rancher/mirrored-coredns-coredns:1.10.1
@@ -503,69 +365,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-coredns-coredns:1.9.4
   type: image
 - source: coredns/coredns:1.10.1
-  target: registry.suse.com/rancher/charts/mirrored-coredns-coredns:1.10.1
-  type: image
-- source: coredns/coredns:1.11.1
-  target: registry.suse.com/rancher/charts/mirrored-coredns-coredns:1.11.1
-  type: image
-- source: coredns/coredns:1.11.3
-  target: registry.suse.com/rancher/charts/mirrored-coredns-coredns:1.11.3
-  type: image
-- source: coredns/coredns:1.11.4
-  target: registry.suse.com/rancher/charts/mirrored-coredns-coredns:1.11.4
-  type: image
-- source: coredns/coredns:1.12.0
-  target: registry.suse.com/rancher/charts/mirrored-coredns-coredns:1.12.0
-  type: image
-- source: coredns/coredns:1.12.1
-  target: registry.suse.com/rancher/charts/mirrored-coredns-coredns:1.12.1
-  type: image
-- source: coredns/coredns:1.12.3
-  target: registry.suse.com/rancher/charts/mirrored-coredns-coredns:1.12.3
-  type: image
-- source: coredns/coredns:1.12.4
-  target: registry.suse.com/rancher/charts/mirrored-coredns-coredns:1.12.4
-  type: image
-- source: coredns/coredns:1.13.1
-  target: registry.suse.com/rancher/charts/mirrored-coredns-coredns:1.13.1
-  type: image
-- source: coredns/coredns:1.6.2
-  target: registry.suse.com/rancher/charts/mirrored-coredns-coredns:1.6.2
-  type: image
-- source: coredns/coredns:1.6.5
-  target: registry.suse.com/rancher/charts/mirrored-coredns-coredns:1.6.5
-  type: image
-- source: coredns/coredns:1.6.9
-  target: registry.suse.com/rancher/charts/mirrored-coredns-coredns:1.6.9
-  type: image
-- source: coredns/coredns:1.7.0
-  target: registry.suse.com/rancher/charts/mirrored-coredns-coredns:1.7.0
-  type: image
-- source: coredns/coredns:1.8.0
-  target: registry.suse.com/rancher/charts/mirrored-coredns-coredns:1.8.0
-  type: image
-- source: coredns/coredns:1.8.3
-  target: registry.suse.com/rancher/charts/mirrored-coredns-coredns:1.8.3
-  type: image
-- source: coredns/coredns:1.8.4
-  target: registry.suse.com/rancher/charts/mirrored-coredns-coredns:1.8.4
-  type: image
-- source: coredns/coredns:1.8.6
-  target: registry.suse.com/rancher/charts/mirrored-coredns-coredns:1.8.6
-  type: image
-- source: coredns/coredns:1.9.0
-  target: registry.suse.com/rancher/charts/mirrored-coredns-coredns:1.9.0
-  type: image
-- source: coredns/coredns:1.9.1
-  target: registry.suse.com/rancher/charts/mirrored-coredns-coredns:1.9.1
-  type: image
-- source: coredns/coredns:1.9.3
-  target: registry.suse.com/rancher/charts/mirrored-coredns-coredns:1.9.3
-  type: image
-- source: coredns/coredns:1.9.4
-  target: registry.suse.com/rancher/charts/mirrored-coredns-coredns:1.9.4
-  type: image
-- source: coredns/coredns:1.10.1
   target: stgregistry.suse.com/rancher/mirrored-coredns-coredns:1.10.1
   type: image
 - source: coredns/coredns:1.11.1
@@ -628,69 +427,6 @@ sync:
 - source: coredns/coredns:1.9.4
   target: stgregistry.suse.com/rancher/mirrored-coredns-coredns:1.9.4
   type: image
-- source: coredns/coredns:1.10.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-coredns-coredns:1.10.1
-  type: image
-- source: coredns/coredns:1.11.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-coredns-coredns:1.11.1
-  type: image
-- source: coredns/coredns:1.11.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-coredns-coredns:1.11.3
-  type: image
-- source: coredns/coredns:1.11.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-coredns-coredns:1.11.4
-  type: image
-- source: coredns/coredns:1.12.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-coredns-coredns:1.12.0
-  type: image
-- source: coredns/coredns:1.12.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-coredns-coredns:1.12.1
-  type: image
-- source: coredns/coredns:1.12.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-coredns-coredns:1.12.3
-  type: image
-- source: coredns/coredns:1.12.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-coredns-coredns:1.12.4
-  type: image
-- source: coredns/coredns:1.13.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-coredns-coredns:1.13.1
-  type: image
-- source: coredns/coredns:1.6.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-coredns-coredns:1.6.2
-  type: image
-- source: coredns/coredns:1.6.5
-  target: stgregistry.suse.com/rancher/charts/mirrored-coredns-coredns:1.6.5
-  type: image
-- source: coredns/coredns:1.6.9
-  target: stgregistry.suse.com/rancher/charts/mirrored-coredns-coredns:1.6.9
-  type: image
-- source: coredns/coredns:1.7.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-coredns-coredns:1.7.0
-  type: image
-- source: coredns/coredns:1.8.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-coredns-coredns:1.8.0
-  type: image
-- source: coredns/coredns:1.8.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-coredns-coredns:1.8.3
-  type: image
-- source: coredns/coredns:1.8.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-coredns-coredns:1.8.4
-  type: image
-- source: coredns/coredns:1.8.6
-  target: stgregistry.suse.com/rancher/charts/mirrored-coredns-coredns:1.8.6
-  type: image
-- source: coredns/coredns:1.9.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-coredns-coredns:1.9.0
-  type: image
-- source: coredns/coredns:1.9.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-coredns-coredns:1.9.1
-  type: image
-- source: coredns/coredns:1.9.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-coredns-coredns:1.9.3
-  type: image
-- source: coredns/coredns:1.9.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-coredns-coredns:1.9.4
-  type: image
 - source: curlimages/curl:7.70.0
   target: docker.io/rancher/curlimages-curl:7.70.0
   type: image
@@ -704,22 +440,10 @@ sync:
   target: registry.suse.com/rancher/curlimages-curl:7.73.0
   type: image
 - source: curlimages/curl:7.70.0
-  target: registry.suse.com/rancher/charts/curlimages-curl:7.70.0
-  type: image
-- source: curlimages/curl:7.73.0
-  target: registry.suse.com/rancher/charts/curlimages-curl:7.73.0
-  type: image
-- source: curlimages/curl:7.70.0
   target: stgregistry.suse.com/rancher/curlimages-curl:7.70.0
   type: image
 - source: curlimages/curl:7.73.0
   target: stgregistry.suse.com/rancher/curlimages-curl:7.73.0
-  type: image
-- source: curlimages/curl:7.70.0
-  target: stgregistry.suse.com/rancher/charts/curlimages-curl:7.70.0
-  type: image
-- source: curlimages/curl:7.73.0
-  target: stgregistry.suse.com/rancher/charts/curlimages-curl:7.73.0
   type: image
 - source: curlimages/curl:7.70.0
   target: docker.io/rancher/mirrored-curlimages-curl:7.70.0
@@ -776,33 +500,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-curlimages-curl:8.9.1
   type: image
 - source: curlimages/curl:7.70.0
-  target: registry.suse.com/rancher/charts/mirrored-curlimages-curl:7.70.0
-  type: image
-- source: curlimages/curl:7.73.0
-  target: registry.suse.com/rancher/charts/mirrored-curlimages-curl:7.73.0
-  type: image
-- source: curlimages/curl:7.77.0
-  target: registry.suse.com/rancher/charts/mirrored-curlimages-curl:7.77.0
-  type: image
-- source: curlimages/curl:7.83.1
-  target: registry.suse.com/rancher/charts/mirrored-curlimages-curl:7.83.1
-  type: image
-- source: curlimages/curl:7.85.0
-  target: registry.suse.com/rancher/charts/mirrored-curlimages-curl:7.85.0
-  type: image
-- source: curlimages/curl:8.10.1
-  target: registry.suse.com/rancher/charts/mirrored-curlimages-curl:8.10.1
-  type: image
-- source: curlimages/curl:8.12.1
-  target: registry.suse.com/rancher/charts/mirrored-curlimages-curl:8.12.1
-  type: image
-- source: curlimages/curl:8.13.0
-  target: registry.suse.com/rancher/charts/mirrored-curlimages-curl:8.13.0
-  type: image
-- source: curlimages/curl:8.9.1
-  target: registry.suse.com/rancher/charts/mirrored-curlimages-curl:8.9.1
-  type: image
-- source: curlimages/curl:7.70.0
   target: stgregistry.suse.com/rancher/mirrored-curlimages-curl:7.70.0
   type: image
 - source: curlimages/curl:7.73.0
@@ -829,33 +526,6 @@ sync:
 - source: curlimages/curl:8.9.1
   target: stgregistry.suse.com/rancher/mirrored-curlimages-curl:8.9.1
   type: image
-- source: curlimages/curl:7.70.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-curlimages-curl:7.70.0
-  type: image
-- source: curlimages/curl:7.73.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-curlimages-curl:7.73.0
-  type: image
-- source: curlimages/curl:7.77.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-curlimages-curl:7.77.0
-  type: image
-- source: curlimages/curl:7.83.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-curlimages-curl:7.83.1
-  type: image
-- source: curlimages/curl:7.85.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-curlimages-curl:7.85.0
-  type: image
-- source: curlimages/curl:8.10.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-curlimages-curl:8.10.1
-  type: image
-- source: curlimages/curl:8.12.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-curlimages-curl:8.12.1
-  type: image
-- source: curlimages/curl:8.13.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-curlimages-curl:8.13.0
-  type: image
-- source: curlimages/curl:8.9.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-curlimages-curl:8.9.1
-  type: image
 - source: directxman12/k8s-prometheus-adapter:v0.8.3
   target: docker.io/rancher/mirrored-directxman12-k8s-prometheus-adapter:v0.8.3
   type: image
@@ -869,22 +539,10 @@ sync:
   target: registry.suse.com/rancher/mirrored-directxman12-k8s-prometheus-adapter:v0.8.4
   type: image
 - source: directxman12/k8s-prometheus-adapter:v0.8.3
-  target: registry.suse.com/rancher/charts/mirrored-directxman12-k8s-prometheus-adapter:v0.8.3
-  type: image
-- source: directxman12/k8s-prometheus-adapter:v0.8.4
-  target: registry.suse.com/rancher/charts/mirrored-directxman12-k8s-prometheus-adapter:v0.8.4
-  type: image
-- source: directxman12/k8s-prometheus-adapter:v0.8.3
   target: stgregistry.suse.com/rancher/mirrored-directxman12-k8s-prometheus-adapter:v0.8.3
   type: image
 - source: directxman12/k8s-prometheus-adapter:v0.8.4
   target: stgregistry.suse.com/rancher/mirrored-directxman12-k8s-prometheus-adapter:v0.8.4
-  type: image
-- source: directxman12/k8s-prometheus-adapter:v0.8.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-directxman12-k8s-prometheus-adapter:v0.8.3
-  type: image
-- source: directxman12/k8s-prometheus-adapter:v0.8.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-directxman12-k8s-prometheus-adapter:v0.8.4
   type: image
 - source: directxman12/k8s-prometheus-adapter-amd64:v0.6.0
   target: docker.io/rancher/directxman12-k8s-prometheus-adapter-amd64:v0.6.0
@@ -899,22 +557,10 @@ sync:
   target: registry.suse.com/rancher/directxman12-k8s-prometheus-adapter-amd64:v0.7.0
   type: image
 - source: directxman12/k8s-prometheus-adapter-amd64:v0.6.0
-  target: registry.suse.com/rancher/charts/directxman12-k8s-prometheus-adapter-amd64:v0.6.0
-  type: image
-- source: directxman12/k8s-prometheus-adapter-amd64:v0.7.0
-  target: registry.suse.com/rancher/charts/directxman12-k8s-prometheus-adapter-amd64:v0.7.0
-  type: image
-- source: directxman12/k8s-prometheus-adapter-amd64:v0.6.0
   target: stgregistry.suse.com/rancher/directxman12-k8s-prometheus-adapter-amd64:v0.6.0
   type: image
 - source: directxman12/k8s-prometheus-adapter-amd64:v0.7.0
   target: stgregistry.suse.com/rancher/directxman12-k8s-prometheus-adapter-amd64:v0.7.0
-  type: image
-- source: directxman12/k8s-prometheus-adapter-amd64:v0.6.0
-  target: stgregistry.suse.com/rancher/charts/directxman12-k8s-prometheus-adapter-amd64:v0.6.0
-  type: image
-- source: directxman12/k8s-prometheus-adapter-amd64:v0.7.0
-  target: stgregistry.suse.com/rancher/charts/directxman12-k8s-prometheus-adapter-amd64:v0.7.0
   type: image
 - source: directxman12/k8s-prometheus-adapter-amd64:v0.7.0
   target: docker.io/rancher/mirrored-directxman12-k8s-prometheus-adapter-amd64:v0.7.0
@@ -929,22 +575,10 @@ sync:
   target: registry.suse.com/rancher/mirrored-directxman12-k8s-prometheus-adapter-amd64:v0.8.3
   type: image
 - source: directxman12/k8s-prometheus-adapter-amd64:v0.7.0
-  target: registry.suse.com/rancher/charts/mirrored-directxman12-k8s-prometheus-adapter-amd64:v0.7.0
-  type: image
-- source: directxman12/k8s-prometheus-adapter-amd64:v0.8.3
-  target: registry.suse.com/rancher/charts/mirrored-directxman12-k8s-prometheus-adapter-amd64:v0.8.3
-  type: image
-- source: directxman12/k8s-prometheus-adapter-amd64:v0.7.0
   target: stgregistry.suse.com/rancher/mirrored-directxman12-k8s-prometheus-adapter-amd64:v0.7.0
   type: image
 - source: directxman12/k8s-prometheus-adapter-amd64:v0.8.3
   target: stgregistry.suse.com/rancher/mirrored-directxman12-k8s-prometheus-adapter-amd64:v0.8.3
-  type: image
-- source: directxman12/k8s-prometheus-adapter-amd64:v0.7.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-directxman12-k8s-prometheus-adapter-amd64:v0.7.0
-  type: image
-- source: directxman12/k8s-prometheus-adapter-amd64:v0.8.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-directxman12-k8s-prometheus-adapter-amd64:v0.8.3
   type: image
 - source: dp.apps.rancher.io/charts/kubernetes-cluster-autoscaler:9.50.1
   target: registry.suse.com/rancher/charts/appco-kubernetes-cluster-autoscaler:9.50.1
@@ -959,13 +593,7 @@ sync:
   target: registry.suse.com/rancher/appco-k8s-sidecar:1.30.7-11.3
   type: image
 - source: dp.apps.rancher.io/containers/k8s-sidecar:1.30.7-11.3
-  target: registry.suse.com/rancher/charts/appco-k8s-sidecar:1.30.7-11.3
-  type: image
-- source: dp.apps.rancher.io/containers/k8s-sidecar:1.30.7-11.3
   target: stgregistry.suse.com/rancher/appco-k8s-sidecar:1.30.7-11.3
-  type: image
-- source: dp.apps.rancher.io/containers/k8s-sidecar:1.30.7-11.3
-  target: stgregistry.suse.com/rancher/charts/appco-k8s-sidecar:1.30.7-11.3
   type: image
 - source: dp.apps.rancher.io/containers/kubernetes-cluster-autoscaler:1.32.3-1.5
   target: registry.suse.com/rancher/appco-kubernetes-cluster-autoscaler:1.32.3-1.5
@@ -992,13 +620,7 @@ sync:
   target: registry.suse.com/rancher/appco-redis:8.0.3-2.1
   type: image
 - source: dp.apps.rancher.io/containers/redis:8.0.3-2.1
-  target: registry.suse.com/rancher/charts/appco-redis:8.0.3-2.1
-  type: image
-- source: dp.apps.rancher.io/containers/redis:8.0.3-2.1
   target: stgregistry.suse.com/rancher/appco-redis:8.0.3-2.1
-  type: image
-- source: dp.apps.rancher.io/containers/redis:8.0.3-2.1
-  target: stgregistry.suse.com/rancher/charts/appco-redis:8.0.3-2.1
   type: image
 - source: flannel/flannel:v0.21.2
   target: docker.io/rancher/mirrored-flannel-flannel:v0.21.2
@@ -1151,81 +773,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-flannel-flannel:v0.27.4
   type: image
 - source: flannel/flannel:v0.21.2
-  target: registry.suse.com/rancher/charts/mirrored-flannel-flannel:v0.21.2
-  type: image
-- source: flannel/flannel:v0.21.4
-  target: registry.suse.com/rancher/charts/mirrored-flannel-flannel:v0.21.4
-  type: image
-- source: flannel/flannel:v0.21.5
-  target: registry.suse.com/rancher/charts/mirrored-flannel-flannel:v0.21.5
-  type: image
-- source: flannel/flannel:v0.22.0
-  target: registry.suse.com/rancher/charts/mirrored-flannel-flannel:v0.22.0
-  type: image
-- source: flannel/flannel:v0.22.1
-  target: registry.suse.com/rancher/charts/mirrored-flannel-flannel:v0.22.1
-  type: image
-- source: flannel/flannel:v0.22.2
-  target: registry.suse.com/rancher/charts/mirrored-flannel-flannel:v0.22.2
-  type: image
-- source: flannel/flannel:v0.22.3
-  target: registry.suse.com/rancher/charts/mirrored-flannel-flannel:v0.22.3
-  type: image
-- source: flannel/flannel:v0.23.0
-  target: registry.suse.com/rancher/charts/mirrored-flannel-flannel:v0.23.0
-  type: image
-- source: flannel/flannel:v0.24.2
-  target: registry.suse.com/rancher/charts/mirrored-flannel-flannel:v0.24.2
-  type: image
-- source: flannel/flannel:v0.25.1
-  target: registry.suse.com/rancher/charts/mirrored-flannel-flannel:v0.25.1
-  type: image
-- source: flannel/flannel:v0.25.2
-  target: registry.suse.com/rancher/charts/mirrored-flannel-flannel:v0.25.2
-  type: image
-- source: flannel/flannel:v0.25.5
-  target: registry.suse.com/rancher/charts/mirrored-flannel-flannel:v0.25.5
-  type: image
-- source: flannel/flannel:v0.25.7
-  target: registry.suse.com/rancher/charts/mirrored-flannel-flannel:v0.25.7
-  type: image
-- source: flannel/flannel:v0.26.1
-  target: registry.suse.com/rancher/charts/mirrored-flannel-flannel:v0.26.1
-  type: image
-- source: flannel/flannel:v0.26.2
-  target: registry.suse.com/rancher/charts/mirrored-flannel-flannel:v0.26.2
-  type: image
-- source: flannel/flannel:v0.26.3
-  target: registry.suse.com/rancher/charts/mirrored-flannel-flannel:v0.26.3
-  type: image
-- source: flannel/flannel:v0.26.4
-  target: registry.suse.com/rancher/charts/mirrored-flannel-flannel:v0.26.4
-  type: image
-- source: flannel/flannel:v0.26.5
-  target: registry.suse.com/rancher/charts/mirrored-flannel-flannel:v0.26.5
-  type: image
-- source: flannel/flannel:v0.26.6
-  target: registry.suse.com/rancher/charts/mirrored-flannel-flannel:v0.26.6
-  type: image
-- source: flannel/flannel:v0.26.7
-  target: registry.suse.com/rancher/charts/mirrored-flannel-flannel:v0.26.7
-  type: image
-- source: flannel/flannel:v0.27.0
-  target: registry.suse.com/rancher/charts/mirrored-flannel-flannel:v0.27.0
-  type: image
-- source: flannel/flannel:v0.27.1
-  target: registry.suse.com/rancher/charts/mirrored-flannel-flannel:v0.27.1
-  type: image
-- source: flannel/flannel:v0.27.2
-  target: registry.suse.com/rancher/charts/mirrored-flannel-flannel:v0.27.2
-  type: image
-- source: flannel/flannel:v0.27.3
-  target: registry.suse.com/rancher/charts/mirrored-flannel-flannel:v0.27.3
-  type: image
-- source: flannel/flannel:v0.27.4
-  target: registry.suse.com/rancher/charts/mirrored-flannel-flannel:v0.27.4
-  type: image
-- source: flannel/flannel:v0.21.2
   target: stgregistry.suse.com/rancher/mirrored-flannel-flannel:v0.21.2
   type: image
 - source: flannel/flannel:v0.21.4
@@ -1300,81 +847,6 @@ sync:
 - source: flannel/flannel:v0.27.4
   target: stgregistry.suse.com/rancher/mirrored-flannel-flannel:v0.27.4
   type: image
-- source: flannel/flannel:v0.21.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-flannel-flannel:v0.21.2
-  type: image
-- source: flannel/flannel:v0.21.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-flannel-flannel:v0.21.4
-  type: image
-- source: flannel/flannel:v0.21.5
-  target: stgregistry.suse.com/rancher/charts/mirrored-flannel-flannel:v0.21.5
-  type: image
-- source: flannel/flannel:v0.22.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-flannel-flannel:v0.22.0
-  type: image
-- source: flannel/flannel:v0.22.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-flannel-flannel:v0.22.1
-  type: image
-- source: flannel/flannel:v0.22.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-flannel-flannel:v0.22.2
-  type: image
-- source: flannel/flannel:v0.22.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-flannel-flannel:v0.22.3
-  type: image
-- source: flannel/flannel:v0.23.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-flannel-flannel:v0.23.0
-  type: image
-- source: flannel/flannel:v0.24.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-flannel-flannel:v0.24.2
-  type: image
-- source: flannel/flannel:v0.25.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-flannel-flannel:v0.25.1
-  type: image
-- source: flannel/flannel:v0.25.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-flannel-flannel:v0.25.2
-  type: image
-- source: flannel/flannel:v0.25.5
-  target: stgregistry.suse.com/rancher/charts/mirrored-flannel-flannel:v0.25.5
-  type: image
-- source: flannel/flannel:v0.25.7
-  target: stgregistry.suse.com/rancher/charts/mirrored-flannel-flannel:v0.25.7
-  type: image
-- source: flannel/flannel:v0.26.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-flannel-flannel:v0.26.1
-  type: image
-- source: flannel/flannel:v0.26.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-flannel-flannel:v0.26.2
-  type: image
-- source: flannel/flannel:v0.26.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-flannel-flannel:v0.26.3
-  type: image
-- source: flannel/flannel:v0.26.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-flannel-flannel:v0.26.4
-  type: image
-- source: flannel/flannel:v0.26.5
-  target: stgregistry.suse.com/rancher/charts/mirrored-flannel-flannel:v0.26.5
-  type: image
-- source: flannel/flannel:v0.26.6
-  target: stgregistry.suse.com/rancher/charts/mirrored-flannel-flannel:v0.26.6
-  type: image
-- source: flannel/flannel:v0.26.7
-  target: stgregistry.suse.com/rancher/charts/mirrored-flannel-flannel:v0.26.7
-  type: image
-- source: flannel/flannel:v0.27.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-flannel-flannel:v0.27.0
-  type: image
-- source: flannel/flannel:v0.27.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-flannel-flannel:v0.27.1
-  type: image
-- source: flannel/flannel:v0.27.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-flannel-flannel:v0.27.2
-  type: image
-- source: flannel/flannel:v0.27.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-flannel-flannel:v0.27.3
-  type: image
-- source: flannel/flannel:v0.27.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-flannel-flannel:v0.27.4
-  type: image
 - source: flannel/flannel-cni-plugin:v1.2.0
   target: docker.io/rancher/mirrored-flannel-flannel-cni-plugin:v1.2.0
   type: image
@@ -1418,27 +890,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-flannel-flannel-cni-plugin:v1.8.0-flannel1
   type: image
 - source: flannel/flannel-cni-plugin:v1.2.0
-  target: registry.suse.com/rancher/charts/mirrored-flannel-flannel-cni-plugin:v1.2.0
-  type: image
-- source: flannel/flannel-cni-plugin:v1.5.1-flannel1
-  target: registry.suse.com/rancher/charts/mirrored-flannel-flannel-cni-plugin:v1.5.1-flannel1
-  type: image
-- source: flannel/flannel-cni-plugin:v1.5.1-flannel2
-  target: registry.suse.com/rancher/charts/mirrored-flannel-flannel-cni-plugin:v1.5.1-flannel2
-  type: image
-- source: flannel/flannel-cni-plugin:v1.6.2-flannel1
-  target: registry.suse.com/rancher/charts/mirrored-flannel-flannel-cni-plugin:v1.6.2-flannel1
-  type: image
-- source: flannel/flannel-cni-plugin:v1.7.1-flannel1
-  target: registry.suse.com/rancher/charts/mirrored-flannel-flannel-cni-plugin:v1.7.1-flannel1
-  type: image
-- source: flannel/flannel-cni-plugin:v1.7.1-flannel2
-  target: registry.suse.com/rancher/charts/mirrored-flannel-flannel-cni-plugin:v1.7.1-flannel2
-  type: image
-- source: flannel/flannel-cni-plugin:v1.8.0-flannel1
-  target: registry.suse.com/rancher/charts/mirrored-flannel-flannel-cni-plugin:v1.8.0-flannel1
-  type: image
-- source: flannel/flannel-cni-plugin:v1.2.0
   target: stgregistry.suse.com/rancher/mirrored-flannel-flannel-cni-plugin:v1.2.0
   type: image
 - source: flannel/flannel-cni-plugin:v1.5.1-flannel1
@@ -1458,27 +909,6 @@ sync:
   type: image
 - source: flannel/flannel-cni-plugin:v1.8.0-flannel1
   target: stgregistry.suse.com/rancher/mirrored-flannel-flannel-cni-plugin:v1.8.0-flannel1
-  type: image
-- source: flannel/flannel-cni-plugin:v1.2.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-flannel-flannel-cni-plugin:v1.2.0
-  type: image
-- source: flannel/flannel-cni-plugin:v1.5.1-flannel1
-  target: stgregistry.suse.com/rancher/charts/mirrored-flannel-flannel-cni-plugin:v1.5.1-flannel1
-  type: image
-- source: flannel/flannel-cni-plugin:v1.5.1-flannel2
-  target: stgregistry.suse.com/rancher/charts/mirrored-flannel-flannel-cni-plugin:v1.5.1-flannel2
-  type: image
-- source: flannel/flannel-cni-plugin:v1.6.2-flannel1
-  target: stgregistry.suse.com/rancher/charts/mirrored-flannel-flannel-cni-plugin:v1.6.2-flannel1
-  type: image
-- source: flannel/flannel-cni-plugin:v1.7.1-flannel1
-  target: stgregistry.suse.com/rancher/charts/mirrored-flannel-flannel-cni-plugin:v1.7.1-flannel1
-  type: image
-- source: flannel/flannel-cni-plugin:v1.7.1-flannel2
-  target: stgregistry.suse.com/rancher/charts/mirrored-flannel-flannel-cni-plugin:v1.7.1-flannel2
-  type: image
-- source: flannel/flannel-cni-plugin:v1.8.0-flannel1
-  target: stgregistry.suse.com/rancher/charts/mirrored-flannel-flannel-cni-plugin:v1.8.0-flannel1
   type: image
 - source: flannelcni/flannel:v0.16.0
   target: docker.io/rancher/mirrored-flannelcni-flannel:v0.16.0
@@ -1559,45 +989,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-flannelcni-flannel:v0.20.2
   type: image
 - source: flannelcni/flannel:v0.16.0
-  target: registry.suse.com/rancher/charts/mirrored-flannelcni-flannel:v0.16.0
-  type: image
-- source: flannelcni/flannel:v0.16.1
-  target: registry.suse.com/rancher/charts/mirrored-flannelcni-flannel:v0.16.1
-  type: image
-- source: flannelcni/flannel:v0.16.2
-  target: registry.suse.com/rancher/charts/mirrored-flannelcni-flannel:v0.16.2
-  type: image
-- source: flannelcni/flannel:v0.16.3
-  target: registry.suse.com/rancher/charts/mirrored-flannelcni-flannel:v0.16.3
-  type: image
-- source: flannelcni/flannel:v0.17.0
-  target: registry.suse.com/rancher/charts/mirrored-flannelcni-flannel:v0.17.0
-  type: image
-- source: flannelcni/flannel:v0.18.0
-  target: registry.suse.com/rancher/charts/mirrored-flannelcni-flannel:v0.18.0
-  type: image
-- source: flannelcni/flannel:v0.18.1
-  target: registry.suse.com/rancher/charts/mirrored-flannelcni-flannel:v0.18.1
-  type: image
-- source: flannelcni/flannel:v0.19.0
-  target: registry.suse.com/rancher/charts/mirrored-flannelcni-flannel:v0.19.0
-  type: image
-- source: flannelcni/flannel:v0.19.1
-  target: registry.suse.com/rancher/charts/mirrored-flannelcni-flannel:v0.19.1
-  type: image
-- source: flannelcni/flannel:v0.19.2
-  target: registry.suse.com/rancher/charts/mirrored-flannelcni-flannel:v0.19.2
-  type: image
-- source: flannelcni/flannel:v0.20.0
-  target: registry.suse.com/rancher/charts/mirrored-flannelcni-flannel:v0.20.0
-  type: image
-- source: flannelcni/flannel:v0.20.1
-  target: registry.suse.com/rancher/charts/mirrored-flannelcni-flannel:v0.20.1
-  type: image
-- source: flannelcni/flannel:v0.20.2
-  target: registry.suse.com/rancher/charts/mirrored-flannelcni-flannel:v0.20.2
-  type: image
-- source: flannelcni/flannel:v0.16.0
   target: stgregistry.suse.com/rancher/mirrored-flannelcni-flannel:v0.16.0
   type: image
 - source: flannelcni/flannel:v0.16.1
@@ -1636,45 +1027,6 @@ sync:
 - source: flannelcni/flannel:v0.20.2
   target: stgregistry.suse.com/rancher/mirrored-flannelcni-flannel:v0.20.2
   type: image
-- source: flannelcni/flannel:v0.16.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-flannelcni-flannel:v0.16.0
-  type: image
-- source: flannelcni/flannel:v0.16.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-flannelcni-flannel:v0.16.1
-  type: image
-- source: flannelcni/flannel:v0.16.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-flannelcni-flannel:v0.16.2
-  type: image
-- source: flannelcni/flannel:v0.16.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-flannelcni-flannel:v0.16.3
-  type: image
-- source: flannelcni/flannel:v0.17.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-flannelcni-flannel:v0.17.0
-  type: image
-- source: flannelcni/flannel:v0.18.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-flannelcni-flannel:v0.18.0
-  type: image
-- source: flannelcni/flannel:v0.18.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-flannelcni-flannel:v0.18.1
-  type: image
-- source: flannelcni/flannel:v0.19.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-flannelcni-flannel:v0.19.0
-  type: image
-- source: flannelcni/flannel:v0.19.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-flannelcni-flannel:v0.19.1
-  type: image
-- source: flannelcni/flannel:v0.19.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-flannelcni-flannel:v0.19.2
-  type: image
-- source: flannelcni/flannel:v0.20.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-flannelcni-flannel:v0.20.0
-  type: image
-- source: flannelcni/flannel:v0.20.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-flannelcni-flannel:v0.20.1
-  type: image
-- source: flannelcni/flannel:v0.20.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-flannelcni-flannel:v0.20.2
-  type: image
 - source: flannelcni/flannel-cni-plugin:v1.0.0
   target: docker.io/rancher/mirrored-flannelcni-flannel-cni-plugin:v1.0.0
   type: image
@@ -1706,21 +1058,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-flannelcni-flannel-cni-plugin:v1.2.0
   type: image
 - source: flannelcni/flannel-cni-plugin:v1.0.0
-  target: registry.suse.com/rancher/charts/mirrored-flannelcni-flannel-cni-plugin:v1.0.0
-  type: image
-- source: flannelcni/flannel-cni-plugin:v1.0.1
-  target: registry.suse.com/rancher/charts/mirrored-flannelcni-flannel-cni-plugin:v1.0.1
-  type: image
-- source: flannelcni/flannel-cni-plugin:v1.1.0
-  target: registry.suse.com/rancher/charts/mirrored-flannelcni-flannel-cni-plugin:v1.1.0
-  type: image
-- source: flannelcni/flannel-cni-plugin:v1.1.2
-  target: registry.suse.com/rancher/charts/mirrored-flannelcni-flannel-cni-plugin:v1.1.2
-  type: image
-- source: flannelcni/flannel-cni-plugin:v1.2.0
-  target: registry.suse.com/rancher/charts/mirrored-flannelcni-flannel-cni-plugin:v1.2.0
-  type: image
-- source: flannelcni/flannel-cni-plugin:v1.0.0
   target: stgregistry.suse.com/rancher/mirrored-flannelcni-flannel-cni-plugin:v1.0.0
   type: image
 - source: flannelcni/flannel-cni-plugin:v1.0.1
@@ -1735,21 +1072,6 @@ sync:
 - source: flannelcni/flannel-cni-plugin:v1.2.0
   target: stgregistry.suse.com/rancher/mirrored-flannelcni-flannel-cni-plugin:v1.2.0
   type: image
-- source: flannelcni/flannel-cni-plugin:v1.0.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-flannelcni-flannel-cni-plugin:v1.0.0
-  type: image
-- source: flannelcni/flannel-cni-plugin:v1.0.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-flannelcni-flannel-cni-plugin:v1.0.1
-  type: image
-- source: flannelcni/flannel-cni-plugin:v1.1.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-flannelcni-flannel-cni-plugin:v1.1.0
-  type: image
-- source: flannelcni/flannel-cni-plugin:v1.1.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-flannelcni-flannel-cni-plugin:v1.1.2
-  type: image
-- source: flannelcni/flannel-cni-plugin:v1.2.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-flannelcni-flannel-cni-plugin:v1.2.0
-  type: image
 - source: fluent/fluent-bit:windows-2019-3.1.8
   target: docker.io/rancher/fluent-bit:windows-2019-3.1.8
   type: image
@@ -1763,22 +1085,10 @@ sync:
   target: registry.suse.com/rancher/fluent-bit:windows-2022-3.1.8
   type: image
 - source: fluent/fluent-bit:windows-2019-3.1.8
-  target: registry.suse.com/rancher/charts/fluent-bit:windows-2019-3.1.8
-  type: image
-- source: fluent/fluent-bit:windows-2022-3.1.8
-  target: registry.suse.com/rancher/charts/fluent-bit:windows-2022-3.1.8
-  type: image
-- source: fluent/fluent-bit:windows-2019-3.1.8
   target: stgregistry.suse.com/rancher/fluent-bit:windows-2019-3.1.8
   type: image
 - source: fluent/fluent-bit:windows-2022-3.1.8
   target: stgregistry.suse.com/rancher/fluent-bit:windows-2022-3.1.8
-  type: image
-- source: fluent/fluent-bit:windows-2019-3.1.8
-  target: stgregistry.suse.com/rancher/charts/fluent-bit:windows-2019-3.1.8
-  type: image
-- source: fluent/fluent-bit:windows-2022-3.1.8
-  target: stgregistry.suse.com/rancher/charts/fluent-bit:windows-2022-3.1.8
   type: image
 - source: fluent/fluent-bit:1.5.4
   target: docker.io/rancher/fluent-fluent-bit:1.5.4
@@ -1835,33 +1145,6 @@ sync:
   target: registry.suse.com/rancher/fluent-fluent-bit:1.8.5-debug
   type: image
 - source: fluent/fluent-bit:1.5.4
-  target: registry.suse.com/rancher/charts/fluent-fluent-bit:1.5.4
-  type: image
-- source: fluent/fluent-bit:1.5.4-debug
-  target: registry.suse.com/rancher/charts/fluent-fluent-bit:1.5.4-debug
-  type: image
-- source: fluent/fluent-bit:1.6.1
-  target: registry.suse.com/rancher/charts/fluent-fluent-bit:1.6.1
-  type: image
-- source: fluent/fluent-bit:1.6.1-debug
-  target: registry.suse.com/rancher/charts/fluent-fluent-bit:1.6.1-debug
-  type: image
-- source: fluent/fluent-bit:1.6.10
-  target: registry.suse.com/rancher/charts/fluent-fluent-bit:1.6.10
-  type: image
-- source: fluent/fluent-bit:1.6.10-debug
-  target: registry.suse.com/rancher/charts/fluent-fluent-bit:1.6.10-debug
-  type: image
-- source: fluent/fluent-bit:1.6.4
-  target: registry.suse.com/rancher/charts/fluent-fluent-bit:1.6.4
-  type: image
-- source: fluent/fluent-bit:1.6.4-debug
-  target: registry.suse.com/rancher/charts/fluent-fluent-bit:1.6.4-debug
-  type: image
-- source: fluent/fluent-bit:1.8.5-debug
-  target: registry.suse.com/rancher/charts/fluent-fluent-bit:1.8.5-debug
-  type: image
-- source: fluent/fluent-bit:1.5.4
   target: stgregistry.suse.com/rancher/fluent-fluent-bit:1.5.4
   type: image
 - source: fluent/fluent-bit:1.5.4-debug
@@ -1887,33 +1170,6 @@ sync:
   type: image
 - source: fluent/fluent-bit:1.8.5-debug
   target: stgregistry.suse.com/rancher/fluent-fluent-bit:1.8.5-debug
-  type: image
-- source: fluent/fluent-bit:1.5.4
-  target: stgregistry.suse.com/rancher/charts/fluent-fluent-bit:1.5.4
-  type: image
-- source: fluent/fluent-bit:1.5.4-debug
-  target: stgregistry.suse.com/rancher/charts/fluent-fluent-bit:1.5.4-debug
-  type: image
-- source: fluent/fluent-bit:1.6.1
-  target: stgregistry.suse.com/rancher/charts/fluent-fluent-bit:1.6.1
-  type: image
-- source: fluent/fluent-bit:1.6.1-debug
-  target: stgregistry.suse.com/rancher/charts/fluent-fluent-bit:1.6.1-debug
-  type: image
-- source: fluent/fluent-bit:1.6.10
-  target: stgregistry.suse.com/rancher/charts/fluent-fluent-bit:1.6.10
-  type: image
-- source: fluent/fluent-bit:1.6.10-debug
-  target: stgregistry.suse.com/rancher/charts/fluent-fluent-bit:1.6.10-debug
-  type: image
-- source: fluent/fluent-bit:1.6.4
-  target: stgregistry.suse.com/rancher/charts/fluent-fluent-bit:1.6.4
-  type: image
-- source: fluent/fluent-bit:1.6.4-debug
-  target: stgregistry.suse.com/rancher/charts/fluent-fluent-bit:1.6.4-debug
-  type: image
-- source: fluent/fluent-bit:1.8.5-debug
-  target: stgregistry.suse.com/rancher/charts/fluent-fluent-bit:1.8.5-debug
   type: image
 - source: fluent/fluent-bit:1.6.10
   target: docker.io/rancher/mirrored-fluent-fluent-bit:1.6.10
@@ -2072,84 +1328,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-fluent-fluent-bit:3.1.8-debug
   type: image
 - source: fluent/fluent-bit:1.6.10
-  target: registry.suse.com/rancher/charts/mirrored-fluent-fluent-bit:1.6.10
-  type: image
-- source: fluent/fluent-bit:1.6.10-debug
-  target: registry.suse.com/rancher/charts/mirrored-fluent-fluent-bit:1.6.10-debug
-  type: image
-- source: fluent/fluent-bit:1.7.4
-  target: registry.suse.com/rancher/charts/mirrored-fluent-fluent-bit:1.7.4
-  type: image
-- source: fluent/fluent-bit:1.7.4-debug
-  target: registry.suse.com/rancher/charts/mirrored-fluent-fluent-bit:1.7.4-debug
-  type: image
-- source: fluent/fluent-bit:1.7.9
-  target: registry.suse.com/rancher/charts/mirrored-fluent-fluent-bit:1.7.9
-  type: image
-- source: fluent/fluent-bit:1.7.9-debug
-  target: registry.suse.com/rancher/charts/mirrored-fluent-fluent-bit:1.7.9-debug
-  type: image
-- source: fluent/fluent-bit:1.8.15
-  target: registry.suse.com/rancher/charts/mirrored-fluent-fluent-bit:1.8.15
-  type: image
-- source: fluent/fluent-bit:1.8.15-debug
-  target: registry.suse.com/rancher/charts/mirrored-fluent-fluent-bit:1.8.15-debug
-  type: image
-- source: fluent/fluent-bit:1.8.5
-  target: registry.suse.com/rancher/charts/mirrored-fluent-fluent-bit:1.8.5
-  type: image
-- source: fluent/fluent-bit:1.8.5-debug
-  target: registry.suse.com/rancher/charts/mirrored-fluent-fluent-bit:1.8.5-debug
-  type: image
-- source: fluent/fluent-bit:1.8.7
-  target: registry.suse.com/rancher/charts/mirrored-fluent-fluent-bit:1.8.7
-  type: image
-- source: fluent/fluent-bit:1.8.7-debug
-  target: registry.suse.com/rancher/charts/mirrored-fluent-fluent-bit:1.8.7-debug
-  type: image
-- source: fluent/fluent-bit:1.8.8
-  target: registry.suse.com/rancher/charts/mirrored-fluent-fluent-bit:1.8.8
-  type: image
-- source: fluent/fluent-bit:1.8.8-debug
-  target: registry.suse.com/rancher/charts/mirrored-fluent-fluent-bit:1.8.8-debug
-  type: image
-- source: fluent/fluent-bit:1.8.9
-  target: registry.suse.com/rancher/charts/mirrored-fluent-fluent-bit:1.8.9
-  type: image
-- source: fluent/fluent-bit:1.8.9-debug
-  target: registry.suse.com/rancher/charts/mirrored-fluent-fluent-bit:1.8.9-debug
-  type: image
-- source: fluent/fluent-bit:1.9.3
-  target: registry.suse.com/rancher/charts/mirrored-fluent-fluent-bit:1.9.3
-  type: image
-- source: fluent/fluent-bit:1.9.3-debug
-  target: registry.suse.com/rancher/charts/mirrored-fluent-fluent-bit:1.9.3-debug
-  type: image
-- source: fluent/fluent-bit:1.9.5
-  target: registry.suse.com/rancher/charts/mirrored-fluent-fluent-bit:1.9.5
-  type: image
-- source: fluent/fluent-bit:1.9.5-debug
-  target: registry.suse.com/rancher/charts/mirrored-fluent-fluent-bit:1.9.5-debug
-  type: image
-- source: fluent/fluent-bit:2.2.0
-  target: registry.suse.com/rancher/charts/mirrored-fluent-fluent-bit:2.2.0
-  type: image
-- source: fluent/fluent-bit:2.2.0-debug
-  target: registry.suse.com/rancher/charts/mirrored-fluent-fluent-bit:2.2.0-debug
-  type: image
-- source: fluent/fluent-bit:3.0.4
-  target: registry.suse.com/rancher/charts/mirrored-fluent-fluent-bit:3.0.4
-  type: image
-- source: fluent/fluent-bit:3.0.4-debug
-  target: registry.suse.com/rancher/charts/mirrored-fluent-fluent-bit:3.0.4-debug
-  type: image
-- source: fluent/fluent-bit:3.1.8
-  target: registry.suse.com/rancher/charts/mirrored-fluent-fluent-bit:3.1.8
-  type: image
-- source: fluent/fluent-bit:3.1.8-debug
-  target: registry.suse.com/rancher/charts/mirrored-fluent-fluent-bit:3.1.8-debug
-  type: image
-- source: fluent/fluent-bit:1.6.10
   target: stgregistry.suse.com/rancher/mirrored-fluent-fluent-bit:1.6.10
   type: image
 - source: fluent/fluent-bit:1.6.10-debug
@@ -2227,84 +1405,6 @@ sync:
 - source: fluent/fluent-bit:3.1.8-debug
   target: stgregistry.suse.com/rancher/mirrored-fluent-fluent-bit:3.1.8-debug
   type: image
-- source: fluent/fluent-bit:1.6.10
-  target: stgregistry.suse.com/rancher/charts/mirrored-fluent-fluent-bit:1.6.10
-  type: image
-- source: fluent/fluent-bit:1.6.10-debug
-  target: stgregistry.suse.com/rancher/charts/mirrored-fluent-fluent-bit:1.6.10-debug
-  type: image
-- source: fluent/fluent-bit:1.7.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-fluent-fluent-bit:1.7.4
-  type: image
-- source: fluent/fluent-bit:1.7.4-debug
-  target: stgregistry.suse.com/rancher/charts/mirrored-fluent-fluent-bit:1.7.4-debug
-  type: image
-- source: fluent/fluent-bit:1.7.9
-  target: stgregistry.suse.com/rancher/charts/mirrored-fluent-fluent-bit:1.7.9
-  type: image
-- source: fluent/fluent-bit:1.7.9-debug
-  target: stgregistry.suse.com/rancher/charts/mirrored-fluent-fluent-bit:1.7.9-debug
-  type: image
-- source: fluent/fluent-bit:1.8.15
-  target: stgregistry.suse.com/rancher/charts/mirrored-fluent-fluent-bit:1.8.15
-  type: image
-- source: fluent/fluent-bit:1.8.15-debug
-  target: stgregistry.suse.com/rancher/charts/mirrored-fluent-fluent-bit:1.8.15-debug
-  type: image
-- source: fluent/fluent-bit:1.8.5
-  target: stgregistry.suse.com/rancher/charts/mirrored-fluent-fluent-bit:1.8.5
-  type: image
-- source: fluent/fluent-bit:1.8.5-debug
-  target: stgregistry.suse.com/rancher/charts/mirrored-fluent-fluent-bit:1.8.5-debug
-  type: image
-- source: fluent/fluent-bit:1.8.7
-  target: stgregistry.suse.com/rancher/charts/mirrored-fluent-fluent-bit:1.8.7
-  type: image
-- source: fluent/fluent-bit:1.8.7-debug
-  target: stgregistry.suse.com/rancher/charts/mirrored-fluent-fluent-bit:1.8.7-debug
-  type: image
-- source: fluent/fluent-bit:1.8.8
-  target: stgregistry.suse.com/rancher/charts/mirrored-fluent-fluent-bit:1.8.8
-  type: image
-- source: fluent/fluent-bit:1.8.8-debug
-  target: stgregistry.suse.com/rancher/charts/mirrored-fluent-fluent-bit:1.8.8-debug
-  type: image
-- source: fluent/fluent-bit:1.8.9
-  target: stgregistry.suse.com/rancher/charts/mirrored-fluent-fluent-bit:1.8.9
-  type: image
-- source: fluent/fluent-bit:1.8.9-debug
-  target: stgregistry.suse.com/rancher/charts/mirrored-fluent-fluent-bit:1.8.9-debug
-  type: image
-- source: fluent/fluent-bit:1.9.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-fluent-fluent-bit:1.9.3
-  type: image
-- source: fluent/fluent-bit:1.9.3-debug
-  target: stgregistry.suse.com/rancher/charts/mirrored-fluent-fluent-bit:1.9.3-debug
-  type: image
-- source: fluent/fluent-bit:1.9.5
-  target: stgregistry.suse.com/rancher/charts/mirrored-fluent-fluent-bit:1.9.5
-  type: image
-- source: fluent/fluent-bit:1.9.5-debug
-  target: stgregistry.suse.com/rancher/charts/mirrored-fluent-fluent-bit:1.9.5-debug
-  type: image
-- source: fluent/fluent-bit:2.2.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-fluent-fluent-bit:2.2.0
-  type: image
-- source: fluent/fluent-bit:2.2.0-debug
-  target: stgregistry.suse.com/rancher/charts/mirrored-fluent-fluent-bit:2.2.0-debug
-  type: image
-- source: fluent/fluent-bit:3.0.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-fluent-fluent-bit:3.0.4
-  type: image
-- source: fluent/fluent-bit:3.0.4-debug
-  target: stgregistry.suse.com/rancher/charts/mirrored-fluent-fluent-bit:3.0.4-debug
-  type: image
-- source: fluent/fluent-bit:3.1.8
-  target: stgregistry.suse.com/rancher/charts/mirrored-fluent-fluent-bit:3.1.8
-  type: image
-- source: fluent/fluent-bit:3.1.8-debug
-  target: stgregistry.suse.com/rancher/charts/mirrored-fluent-fluent-bit:3.1.8-debug
-  type: image
 - source: gcr.io/google-containers/k8s-dns-node-cache:1.15.13
   target: docker.io/rancher/mirrored-k8s-dns-node-cache:1.15.13
   type: image
@@ -2318,22 +1418,10 @@ sync:
   target: registry.suse.com/rancher/mirrored-k8s-dns-node-cache:1.15.7
   type: image
 - source: gcr.io/google-containers/k8s-dns-node-cache:1.15.13
-  target: registry.suse.com/rancher/charts/mirrored-k8s-dns-node-cache:1.15.13
-  type: image
-- source: gcr.io/google-containers/k8s-dns-node-cache:1.15.7
-  target: registry.suse.com/rancher/charts/mirrored-k8s-dns-node-cache:1.15.7
-  type: image
-- source: gcr.io/google-containers/k8s-dns-node-cache:1.15.13
   target: stgregistry.suse.com/rancher/mirrored-k8s-dns-node-cache:1.15.13
   type: image
 - source: gcr.io/google-containers/k8s-dns-node-cache:1.15.7
   target: stgregistry.suse.com/rancher/mirrored-k8s-dns-node-cache:1.15.7
-  type: image
-- source: gcr.io/google-containers/k8s-dns-node-cache:1.15.13
-  target: stgregistry.suse.com/rancher/charts/mirrored-k8s-dns-node-cache:1.15.13
-  type: image
-- source: gcr.io/google-containers/k8s-dns-node-cache:1.15.7
-  target: stgregistry.suse.com/rancher/charts/mirrored-k8s-dns-node-cache:1.15.7
   type: image
 - source: gcr.io/google_containers/k8s-dns-dnsmasq-nanny:1.15.0
   target: docker.io/rancher/mirrored-k8s-dns-dnsmasq-nanny:1.15.0
@@ -2354,15 +1442,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-k8s-dns-dnsmasq-nanny:1.15.2
   type: image
 - source: gcr.io/google_containers/k8s-dns-dnsmasq-nanny:1.15.0
-  target: registry.suse.com/rancher/charts/mirrored-k8s-dns-dnsmasq-nanny:1.15.0
-  type: image
-- source: gcr.io/google_containers/k8s-dns-dnsmasq-nanny:1.15.10
-  target: registry.suse.com/rancher/charts/mirrored-k8s-dns-dnsmasq-nanny:1.15.10
-  type: image
-- source: gcr.io/google_containers/k8s-dns-dnsmasq-nanny:1.15.2
-  target: registry.suse.com/rancher/charts/mirrored-k8s-dns-dnsmasq-nanny:1.15.2
-  type: image
-- source: gcr.io/google_containers/k8s-dns-dnsmasq-nanny:1.15.0
   target: stgregistry.suse.com/rancher/mirrored-k8s-dns-dnsmasq-nanny:1.15.0
   type: image
 - source: gcr.io/google_containers/k8s-dns-dnsmasq-nanny:1.15.10
@@ -2370,15 +1449,6 @@ sync:
   type: image
 - source: gcr.io/google_containers/k8s-dns-dnsmasq-nanny:1.15.2
   target: stgregistry.suse.com/rancher/mirrored-k8s-dns-dnsmasq-nanny:1.15.2
-  type: image
-- source: gcr.io/google_containers/k8s-dns-dnsmasq-nanny:1.15.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-k8s-dns-dnsmasq-nanny:1.15.0
-  type: image
-- source: gcr.io/google_containers/k8s-dns-dnsmasq-nanny:1.15.10
-  target: stgregistry.suse.com/rancher/charts/mirrored-k8s-dns-dnsmasq-nanny:1.15.10
-  type: image
-- source: gcr.io/google_containers/k8s-dns-dnsmasq-nanny:1.15.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-k8s-dns-dnsmasq-nanny:1.15.2
   type: image
 - source: gcr.io/google_containers/k8s-dns-kube-dns:1.15.0
   target: docker.io/rancher/mirrored-k8s-dns-kube-dns:1.15.0
@@ -2399,15 +1469,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-k8s-dns-kube-dns:1.15.2
   type: image
 - source: gcr.io/google_containers/k8s-dns-kube-dns:1.15.0
-  target: registry.suse.com/rancher/charts/mirrored-k8s-dns-kube-dns:1.15.0
-  type: image
-- source: gcr.io/google_containers/k8s-dns-kube-dns:1.15.10
-  target: registry.suse.com/rancher/charts/mirrored-k8s-dns-kube-dns:1.15.10
-  type: image
-- source: gcr.io/google_containers/k8s-dns-kube-dns:1.15.2
-  target: registry.suse.com/rancher/charts/mirrored-k8s-dns-kube-dns:1.15.2
-  type: image
-- source: gcr.io/google_containers/k8s-dns-kube-dns:1.15.0
   target: stgregistry.suse.com/rancher/mirrored-k8s-dns-kube-dns:1.15.0
   type: image
 - source: gcr.io/google_containers/k8s-dns-kube-dns:1.15.10
@@ -2415,15 +1476,6 @@ sync:
   type: image
 - source: gcr.io/google_containers/k8s-dns-kube-dns:1.15.2
   target: stgregistry.suse.com/rancher/mirrored-k8s-dns-kube-dns:1.15.2
-  type: image
-- source: gcr.io/google_containers/k8s-dns-kube-dns:1.15.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-k8s-dns-kube-dns:1.15.0
-  type: image
-- source: gcr.io/google_containers/k8s-dns-kube-dns:1.15.10
-  target: stgregistry.suse.com/rancher/charts/mirrored-k8s-dns-kube-dns:1.15.10
-  type: image
-- source: gcr.io/google_containers/k8s-dns-kube-dns:1.15.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-k8s-dns-kube-dns:1.15.2
   type: image
 - source: gcr.io/google_containers/k8s-dns-sidecar:1.15.0
   target: docker.io/rancher/mirrored-k8s-dns-sidecar:1.15.0
@@ -2444,15 +1496,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-k8s-dns-sidecar:1.15.2
   type: image
 - source: gcr.io/google_containers/k8s-dns-sidecar:1.15.0
-  target: registry.suse.com/rancher/charts/mirrored-k8s-dns-sidecar:1.15.0
-  type: image
-- source: gcr.io/google_containers/k8s-dns-sidecar:1.15.10
-  target: registry.suse.com/rancher/charts/mirrored-k8s-dns-sidecar:1.15.10
-  type: image
-- source: gcr.io/google_containers/k8s-dns-sidecar:1.15.2
-  target: registry.suse.com/rancher/charts/mirrored-k8s-dns-sidecar:1.15.2
-  type: image
-- source: gcr.io/google_containers/k8s-dns-sidecar:1.15.0
   target: stgregistry.suse.com/rancher/mirrored-k8s-dns-sidecar:1.15.0
   type: image
 - source: gcr.io/google_containers/k8s-dns-sidecar:1.15.10
@@ -2460,15 +1503,6 @@ sync:
   type: image
 - source: gcr.io/google_containers/k8s-dns-sidecar:1.15.2
   target: stgregistry.suse.com/rancher/mirrored-k8s-dns-sidecar:1.15.2
-  type: image
-- source: gcr.io/google_containers/k8s-dns-sidecar:1.15.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-k8s-dns-sidecar:1.15.0
-  type: image
-- source: gcr.io/google_containers/k8s-dns-sidecar:1.15.10
-  target: stgregistry.suse.com/rancher/charts/mirrored-k8s-dns-sidecar:1.15.10
-  type: image
-- source: gcr.io/google_containers/k8s-dns-sidecar:1.15.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-k8s-dns-sidecar:1.15.2
   type: image
 - source: gcr.io/google_containers/pause:3.1
   target: docker.io/rancher/mirrored-pause:3.1
@@ -2483,22 +1517,10 @@ sync:
   target: registry.suse.com/rancher/mirrored-pause:3.2
   type: image
 - source: gcr.io/google_containers/pause:3.1
-  target: registry.suse.com/rancher/charts/mirrored-pause:3.1
-  type: image
-- source: gcr.io/google_containers/pause:3.2
-  target: registry.suse.com/rancher/charts/mirrored-pause:3.2
-  type: image
-- source: gcr.io/google_containers/pause:3.1
   target: stgregistry.suse.com/rancher/mirrored-pause:3.1
   type: image
 - source: gcr.io/google_containers/pause:3.2
   target: stgregistry.suse.com/rancher/mirrored-pause:3.2
-  type: image
-- source: gcr.io/google_containers/pause:3.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-pause:3.1
-  type: image
-- source: gcr.io/google_containers/pause:3.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-pause:3.2
   type: image
 - source: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
   target: docker.io/rancher/kube-rbac-proxy:v0.5.0
@@ -2507,13 +1529,7 @@ sync:
   target: registry.suse.com/rancher/kube-rbac-proxy:v0.5.0
   type: image
 - source: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
-  target: registry.suse.com/rancher/charts/kube-rbac-proxy:v0.5.0
-  type: image
-- source: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
   target: stgregistry.suse.com/rancher/kube-rbac-proxy:v0.5.0
-  type: image
-- source: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
-  target: stgregistry.suse.com/rancher/charts/kube-rbac-proxy:v0.5.0
   type: image
 - source: gcr.io/kubebuilder/kube-rbac-proxy:v0.14.0
   target: docker.io/rancher/mirrored-kube-rbac-proxy:v0.14.0
@@ -2534,15 +1550,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-kube-rbac-proxy:v0.5.0
   type: image
 - source: gcr.io/kubebuilder/kube-rbac-proxy:v0.14.0
-  target: registry.suse.com/rancher/charts/mirrored-kube-rbac-proxy:v0.14.0
-  type: image
-- source: gcr.io/kubebuilder/kube-rbac-proxy:v0.15.0
-  target: registry.suse.com/rancher/charts/mirrored-kube-rbac-proxy:v0.15.0
-  type: image
-- source: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
-  target: registry.suse.com/rancher/charts/mirrored-kube-rbac-proxy:v0.5.0
-  type: image
-- source: gcr.io/kubebuilder/kube-rbac-proxy:v0.14.0
   target: stgregistry.suse.com/rancher/mirrored-kube-rbac-proxy:v0.14.0
   type: image
 - source: gcr.io/kubebuilder/kube-rbac-proxy:v0.15.0
@@ -2550,15 +1557,6 @@ sync:
   type: image
 - source: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
   target: stgregistry.suse.com/rancher/mirrored-kube-rbac-proxy:v0.5.0
-  type: image
-- source: gcr.io/kubebuilder/kube-rbac-proxy:v0.14.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-kube-rbac-proxy:v0.14.0
-  type: image
-- source: gcr.io/kubebuilder/kube-rbac-proxy:v0.15.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-kube-rbac-proxy:v0.15.0
-  type: image
-- source: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-kube-rbac-proxy:v0.5.0
   type: image
 - source: ghcr.io/banzaicloud/fluentd:v1.12.4-alpine-1
   target: docker.io/rancher/mirrored-banzaicloud-fluentd:v1.12.4-alpine-1
@@ -2597,24 +1595,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-banzaicloud-fluentd:v1.14.6-alpine-5
   type: image
 - source: ghcr.io/banzaicloud/fluentd:v1.12.4-alpine-1
-  target: registry.suse.com/rancher/charts/mirrored-banzaicloud-fluentd:v1.12.4-alpine-1
-  type: image
-- source: ghcr.io/banzaicloud/fluentd:v1.13.3-alpine-1
-  target: registry.suse.com/rancher/charts/mirrored-banzaicloud-fluentd:v1.13.3-alpine-1
-  type: image
-- source: ghcr.io/banzaicloud/fluentd:v1.13.3-alpine-11
-  target: registry.suse.com/rancher/charts/mirrored-banzaicloud-fluentd:v1.13.3-alpine-11
-  type: image
-- source: ghcr.io/banzaicloud/fluentd:v1.14.4-alpine-2
-  target: registry.suse.com/rancher/charts/mirrored-banzaicloud-fluentd:v1.14.4-alpine-2
-  type: image
-- source: ghcr.io/banzaicloud/fluentd:v1.14.5-alpine-1
-  target: registry.suse.com/rancher/charts/mirrored-banzaicloud-fluentd:v1.14.5-alpine-1
-  type: image
-- source: ghcr.io/banzaicloud/fluentd:v1.14.6-alpine-5
-  target: registry.suse.com/rancher/charts/mirrored-banzaicloud-fluentd:v1.14.6-alpine-5
-  type: image
-- source: ghcr.io/banzaicloud/fluentd:v1.12.4-alpine-1
   target: stgregistry.suse.com/rancher/mirrored-banzaicloud-fluentd:v1.12.4-alpine-1
   type: image
 - source: ghcr.io/banzaicloud/fluentd:v1.13.3-alpine-1
@@ -2631,24 +1611,6 @@ sync:
   type: image
 - source: ghcr.io/banzaicloud/fluentd:v1.14.6-alpine-5
   target: stgregistry.suse.com/rancher/mirrored-banzaicloud-fluentd:v1.14.6-alpine-5
-  type: image
-- source: ghcr.io/banzaicloud/fluentd:v1.12.4-alpine-1
-  target: stgregistry.suse.com/rancher/charts/mirrored-banzaicloud-fluentd:v1.12.4-alpine-1
-  type: image
-- source: ghcr.io/banzaicloud/fluentd:v1.13.3-alpine-1
-  target: stgregistry.suse.com/rancher/charts/mirrored-banzaicloud-fluentd:v1.13.3-alpine-1
-  type: image
-- source: ghcr.io/banzaicloud/fluentd:v1.13.3-alpine-11
-  target: stgregistry.suse.com/rancher/charts/mirrored-banzaicloud-fluentd:v1.13.3-alpine-11
-  type: image
-- source: ghcr.io/banzaicloud/fluentd:v1.14.4-alpine-2
-  target: stgregistry.suse.com/rancher/charts/mirrored-banzaicloud-fluentd:v1.14.4-alpine-2
-  type: image
-- source: ghcr.io/banzaicloud/fluentd:v1.14.5-alpine-1
-  target: stgregistry.suse.com/rancher/charts/mirrored-banzaicloud-fluentd:v1.14.5-alpine-1
-  type: image
-- source: ghcr.io/banzaicloud/fluentd:v1.14.6-alpine-5
-  target: stgregistry.suse.com/rancher/charts/mirrored-banzaicloud-fluentd:v1.14.6-alpine-5
   type: image
 - source: ghcr.io/banzaicloud/logging-operator:3.14.0
   target: docker.io/rancher/mirrored-banzaicloud-logging-operator:3.14.0
@@ -2705,33 +1667,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-banzaicloud-logging-operator:3.17.9
   type: image
 - source: ghcr.io/banzaicloud/logging-operator:3.14.0
-  target: registry.suse.com/rancher/charts/mirrored-banzaicloud-logging-operator:3.14.0
-  type: image
-- source: ghcr.io/banzaicloud/logging-operator:3.15.0
-  target: registry.suse.com/rancher/charts/mirrored-banzaicloud-logging-operator:3.15.0
-  type: image
-- source: ghcr.io/banzaicloud/logging-operator:3.17.1
-  target: registry.suse.com/rancher/charts/mirrored-banzaicloud-logging-operator:3.17.1
-  type: image
-- source: ghcr.io/banzaicloud/logging-operator:3.17.10
-  target: registry.suse.com/rancher/charts/mirrored-banzaicloud-logging-operator:3.17.10
-  type: image
-- source: ghcr.io/banzaicloud/logging-operator:3.17.3
-  target: registry.suse.com/rancher/charts/mirrored-banzaicloud-logging-operator:3.17.3
-  type: image
-- source: ghcr.io/banzaicloud/logging-operator:3.17.4
-  target: registry.suse.com/rancher/charts/mirrored-banzaicloud-logging-operator:3.17.4
-  type: image
-- source: ghcr.io/banzaicloud/logging-operator:3.17.7
-  target: registry.suse.com/rancher/charts/mirrored-banzaicloud-logging-operator:3.17.7
-  type: image
-- source: ghcr.io/banzaicloud/logging-operator:3.17.8
-  target: registry.suse.com/rancher/charts/mirrored-banzaicloud-logging-operator:3.17.8
-  type: image
-- source: ghcr.io/banzaicloud/logging-operator:3.17.9
-  target: registry.suse.com/rancher/charts/mirrored-banzaicloud-logging-operator:3.17.9
-  type: image
-- source: ghcr.io/banzaicloud/logging-operator:3.14.0
   target: stgregistry.suse.com/rancher/mirrored-banzaicloud-logging-operator:3.14.0
   type: image
 - source: ghcr.io/banzaicloud/logging-operator:3.15.0
@@ -2758,33 +1693,6 @@ sync:
 - source: ghcr.io/banzaicloud/logging-operator:3.17.9
   target: stgregistry.suse.com/rancher/mirrored-banzaicloud-logging-operator:3.17.9
   type: image
-- source: ghcr.io/banzaicloud/logging-operator:3.14.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-banzaicloud-logging-operator:3.14.0
-  type: image
-- source: ghcr.io/banzaicloud/logging-operator:3.15.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-banzaicloud-logging-operator:3.15.0
-  type: image
-- source: ghcr.io/banzaicloud/logging-operator:3.17.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-banzaicloud-logging-operator:3.17.1
-  type: image
-- source: ghcr.io/banzaicloud/logging-operator:3.17.10
-  target: stgregistry.suse.com/rancher/charts/mirrored-banzaicloud-logging-operator:3.17.10
-  type: image
-- source: ghcr.io/banzaicloud/logging-operator:3.17.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-banzaicloud-logging-operator:3.17.3
-  type: image
-- source: ghcr.io/banzaicloud/logging-operator:3.17.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-banzaicloud-logging-operator:3.17.4
-  type: image
-- source: ghcr.io/banzaicloud/logging-operator:3.17.7
-  target: stgregistry.suse.com/rancher/charts/mirrored-banzaicloud-logging-operator:3.17.7
-  type: image
-- source: ghcr.io/banzaicloud/logging-operator:3.17.8
-  target: stgregistry.suse.com/rancher/charts/mirrored-banzaicloud-logging-operator:3.17.8
-  type: image
-- source: ghcr.io/banzaicloud/logging-operator:3.17.9
-  target: stgregistry.suse.com/rancher/charts/mirrored-banzaicloud-logging-operator:3.17.9
-  type: image
 - source: ghcr.io/dexidp/dex:v2.35.3
   target: docker.io/rancher/mirrored-dexidp-dex:v2.35.3
   type: image
@@ -2804,15 +1712,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-dexidp-dex:v2.37.0
   type: image
 - source: ghcr.io/dexidp/dex:v2.35.3
-  target: registry.suse.com/rancher/charts/mirrored-dexidp-dex:v2.35.3
-  type: image
-- source: ghcr.io/dexidp/dex:v2.36.0
-  target: registry.suse.com/rancher/charts/mirrored-dexidp-dex:v2.36.0
-  type: image
-- source: ghcr.io/dexidp/dex:v2.37.0
-  target: registry.suse.com/rancher/charts/mirrored-dexidp-dex:v2.37.0
-  type: image
-- source: ghcr.io/dexidp/dex:v2.35.3
   target: stgregistry.suse.com/rancher/mirrored-dexidp-dex:v2.35.3
   type: image
 - source: ghcr.io/dexidp/dex:v2.36.0
@@ -2820,15 +1719,6 @@ sync:
   type: image
 - source: ghcr.io/dexidp/dex:v2.37.0
   target: stgregistry.suse.com/rancher/mirrored-dexidp-dex:v2.37.0
-  type: image
-- source: ghcr.io/dexidp/dex:v2.35.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-dexidp-dex:v2.35.3
-  type: image
-- source: ghcr.io/dexidp/dex:v2.36.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-dexidp-dex:v2.36.0
-  type: image
-- source: ghcr.io/dexidp/dex:v2.37.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-dexidp-dex:v2.37.0
   type: image
 - source: ghcr.io/epinio/epinio-server:v0.7.1
   target: docker.io/rancher/mirrored-epinio-epinio-server:v0.7.1
@@ -2891,36 +1781,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-epinio-epinio-server:v1.9.0
   type: image
 - source: ghcr.io/epinio/epinio-server:v0.7.1
-  target: registry.suse.com/rancher/charts/mirrored-epinio-epinio-server:v0.7.1
-  type: image
-- source: ghcr.io/epinio/epinio-server:v1.0.0
-  target: registry.suse.com/rancher/charts/mirrored-epinio-epinio-server:v1.0.0
-  type: image
-- source: ghcr.io/epinio/epinio-server:v1.10.0
-  target: registry.suse.com/rancher/charts/mirrored-epinio-epinio-server:v1.10.0
-  type: image
-- source: ghcr.io/epinio/epinio-server:v1.2.0
-  target: registry.suse.com/rancher/charts/mirrored-epinio-epinio-server:v1.2.0
-  type: image
-- source: ghcr.io/epinio/epinio-server:v1.4.0
-  target: registry.suse.com/rancher/charts/mirrored-epinio-epinio-server:v1.4.0
-  type: image
-- source: ghcr.io/epinio/epinio-server:v1.5.1
-  target: registry.suse.com/rancher/charts/mirrored-epinio-epinio-server:v1.5.1
-  type: image
-- source: ghcr.io/epinio/epinio-server:v1.6.1
-  target: registry.suse.com/rancher/charts/mirrored-epinio-epinio-server:v1.6.1
-  type: image
-- source: ghcr.io/epinio/epinio-server:v1.6.2
-  target: registry.suse.com/rancher/charts/mirrored-epinio-epinio-server:v1.6.2
-  type: image
-- source: ghcr.io/epinio/epinio-server:v1.8.1
-  target: registry.suse.com/rancher/charts/mirrored-epinio-epinio-server:v1.8.1
-  type: image
-- source: ghcr.io/epinio/epinio-server:v1.9.0
-  target: registry.suse.com/rancher/charts/mirrored-epinio-epinio-server:v1.9.0
-  type: image
-- source: ghcr.io/epinio/epinio-server:v0.7.1
   target: stgregistry.suse.com/rancher/mirrored-epinio-epinio-server:v0.7.1
   type: image
 - source: ghcr.io/epinio/epinio-server:v1.0.0
@@ -2949,36 +1809,6 @@ sync:
   type: image
 - source: ghcr.io/epinio/epinio-server:v1.9.0
   target: stgregistry.suse.com/rancher/mirrored-epinio-epinio-server:v1.9.0
-  type: image
-- source: ghcr.io/epinio/epinio-server:v0.7.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-epinio-epinio-server:v0.7.1
-  type: image
-- source: ghcr.io/epinio/epinio-server:v1.0.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-epinio-epinio-server:v1.0.0
-  type: image
-- source: ghcr.io/epinio/epinio-server:v1.10.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-epinio-epinio-server:v1.10.0
-  type: image
-- source: ghcr.io/epinio/epinio-server:v1.2.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-epinio-epinio-server:v1.2.0
-  type: image
-- source: ghcr.io/epinio/epinio-server:v1.4.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-epinio-epinio-server:v1.4.0
-  type: image
-- source: ghcr.io/epinio/epinio-server:v1.5.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-epinio-epinio-server:v1.5.1
-  type: image
-- source: ghcr.io/epinio/epinio-server:v1.6.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-epinio-epinio-server:v1.6.1
-  type: image
-- source: ghcr.io/epinio/epinio-server:v1.6.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-epinio-epinio-server:v1.6.2
-  type: image
-- source: ghcr.io/epinio/epinio-server:v1.8.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-epinio-epinio-server:v1.8.1
-  type: image
-- source: ghcr.io/epinio/epinio-server:v1.9.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-epinio-epinio-server:v1.9.0
   type: image
 - source: ghcr.io/epinio/epinio-ui:v0.6.2-0.0.1
   target: docker.io/rancher/mirrored-epinio-epinio-ui:v0.6.2-0.0.1
@@ -3023,27 +1853,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-epinio-epinio-ui:v1.9.0-0.0.3
   type: image
 - source: ghcr.io/epinio/epinio-ui:v0.6.2-0.0.1
-  target: registry.suse.com/rancher/charts/mirrored-epinio-epinio-ui:v0.6.2-0.0.1
-  type: image
-- source: ghcr.io/epinio/epinio-ui:v1.0.0-0.0.4
-  target: registry.suse.com/rancher/charts/mirrored-epinio-epinio-ui:v1.0.0-0.0.4
-  type: image
-- source: ghcr.io/epinio/epinio-ui:v1.10.0-0.0.1
-  target: registry.suse.com/rancher/charts/mirrored-epinio-epinio-ui:v1.10.0-0.0.1
-  type: image
-- source: ghcr.io/epinio/epinio-ui:v1.2.0-0.0.1
-  target: registry.suse.com/rancher/charts/mirrored-epinio-epinio-ui:v1.2.0-0.0.1
-  type: image
-- source: ghcr.io/epinio/epinio-ui:v1.5.1-0.0.3
-  target: registry.suse.com/rancher/charts/mirrored-epinio-epinio-ui:v1.5.1-0.0.3
-  type: image
-- source: ghcr.io/epinio/epinio-ui:v1.8.1-0.0.1
-  target: registry.suse.com/rancher/charts/mirrored-epinio-epinio-ui:v1.8.1-0.0.1
-  type: image
-- source: ghcr.io/epinio/epinio-ui:v1.9.0-0.0.3
-  target: registry.suse.com/rancher/charts/mirrored-epinio-epinio-ui:v1.9.0-0.0.3
-  type: image
-- source: ghcr.io/epinio/epinio-ui:v0.6.2-0.0.1
   target: stgregistry.suse.com/rancher/mirrored-epinio-epinio-ui:v0.6.2-0.0.1
   type: image
 - source: ghcr.io/epinio/epinio-ui:v1.0.0-0.0.4
@@ -3063,27 +1872,6 @@ sync:
   type: image
 - source: ghcr.io/epinio/epinio-ui:v1.9.0-0.0.3
   target: stgregistry.suse.com/rancher/mirrored-epinio-epinio-ui:v1.9.0-0.0.3
-  type: image
-- source: ghcr.io/epinio/epinio-ui:v0.6.2-0.0.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-epinio-epinio-ui:v0.6.2-0.0.1
-  type: image
-- source: ghcr.io/epinio/epinio-ui:v1.0.0-0.0.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-epinio-epinio-ui:v1.0.0-0.0.4
-  type: image
-- source: ghcr.io/epinio/epinio-ui:v1.10.0-0.0.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-epinio-epinio-ui:v1.10.0-0.0.1
-  type: image
-- source: ghcr.io/epinio/epinio-ui:v1.2.0-0.0.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-epinio-epinio-ui:v1.2.0-0.0.1
-  type: image
-- source: ghcr.io/epinio/epinio-ui:v1.5.1-0.0.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-epinio-epinio-ui:v1.5.1-0.0.3
-  type: image
-- source: ghcr.io/epinio/epinio-ui:v1.8.1-0.0.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-epinio-epinio-ui:v1.8.1-0.0.1
-  type: image
-- source: ghcr.io/epinio/epinio-ui:v1.9.0-0.0.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-epinio-epinio-ui:v1.9.0-0.0.3
   type: image
 - source: ghcr.io/epinio/epinio-unpacker:v1.10.0
   target: docker.io/rancher/mirrored-epinio-epinio-unpacker:v1.10.0
@@ -3116,21 +1904,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-epinio-epinio-unpacker:v1.9.0
   type: image
 - source: ghcr.io/epinio/epinio-unpacker:v1.10.0
-  target: registry.suse.com/rancher/charts/mirrored-epinio-epinio-unpacker:v1.10.0
-  type: image
-- source: ghcr.io/epinio/epinio-unpacker:v1.6.1
-  target: registry.suse.com/rancher/charts/mirrored-epinio-epinio-unpacker:v1.6.1
-  type: image
-- source: ghcr.io/epinio/epinio-unpacker:v1.6.2
-  target: registry.suse.com/rancher/charts/mirrored-epinio-epinio-unpacker:v1.6.2
-  type: image
-- source: ghcr.io/epinio/epinio-unpacker:v1.8.1
-  target: registry.suse.com/rancher/charts/mirrored-epinio-epinio-unpacker:v1.8.1
-  type: image
-- source: ghcr.io/epinio/epinio-unpacker:v1.9.0
-  target: registry.suse.com/rancher/charts/mirrored-epinio-epinio-unpacker:v1.9.0
-  type: image
-- source: ghcr.io/epinio/epinio-unpacker:v1.10.0
   target: stgregistry.suse.com/rancher/mirrored-epinio-epinio-unpacker:v1.10.0
   type: image
 - source: ghcr.io/epinio/epinio-unpacker:v1.6.1
@@ -3145,21 +1918,6 @@ sync:
 - source: ghcr.io/epinio/epinio-unpacker:v1.9.0
   target: stgregistry.suse.com/rancher/mirrored-epinio-epinio-unpacker:v1.9.0
   type: image
-- source: ghcr.io/epinio/epinio-unpacker:v1.10.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-epinio-epinio-unpacker:v1.10.0
-  type: image
-- source: ghcr.io/epinio/epinio-unpacker:v1.6.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-epinio-epinio-unpacker:v1.6.1
-  type: image
-- source: ghcr.io/epinio/epinio-unpacker:v1.6.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-epinio-epinio-unpacker:v1.6.2
-  type: image
-- source: ghcr.io/epinio/epinio-unpacker:v1.8.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-epinio-epinio-unpacker:v1.8.1
-  type: image
-- source: ghcr.io/epinio/epinio-unpacker:v1.9.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-epinio-epinio-unpacker:v1.9.0
-  type: image
 - source: ghcr.io/jimmidyson/configmap-reload:v0.13.1
   target: docker.io/rancher/mirrored-jimmidyson-configmap-reload:v0.13.1
   type: image
@@ -3167,13 +1925,7 @@ sync:
   target: registry.suse.com/rancher/mirrored-jimmidyson-configmap-reload:v0.13.1
   type: image
 - source: ghcr.io/jimmidyson/configmap-reload:v0.13.1
-  target: registry.suse.com/rancher/charts/mirrored-jimmidyson-configmap-reload:v0.13.1
-  type: image
-- source: ghcr.io/jimmidyson/configmap-reload:v0.13.1
   target: stgregistry.suse.com/rancher/mirrored-jimmidyson-configmap-reload:v0.13.1
-  type: image
-- source: ghcr.io/jimmidyson/configmap-reload:v0.13.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-jimmidyson-configmap-reload:v0.13.1
   type: image
 - source: ghcr.io/kube-logging/config-reloader:v0.0.5
   target: docker.io/rancher/mirrored-kube-logging-config-reloader:v0.0.5
@@ -3188,22 +1940,10 @@ sync:
   target: registry.suse.com/rancher/mirrored-kube-logging-config-reloader:v0.0.6
   type: image
 - source: ghcr.io/kube-logging/config-reloader:v0.0.5
-  target: registry.suse.com/rancher/charts/mirrored-kube-logging-config-reloader:v0.0.5
-  type: image
-- source: ghcr.io/kube-logging/config-reloader:v0.0.6
-  target: registry.suse.com/rancher/charts/mirrored-kube-logging-config-reloader:v0.0.6
-  type: image
-- source: ghcr.io/kube-logging/config-reloader:v0.0.5
   target: stgregistry.suse.com/rancher/mirrored-kube-logging-config-reloader:v0.0.5
   type: image
 - source: ghcr.io/kube-logging/config-reloader:v0.0.6
   target: stgregistry.suse.com/rancher/mirrored-kube-logging-config-reloader:v0.0.6
-  type: image
-- source: ghcr.io/kube-logging/config-reloader:v0.0.5
-  target: stgregistry.suse.com/rancher/charts/mirrored-kube-logging-config-reloader:v0.0.5
-  type: image
-- source: ghcr.io/kube-logging/config-reloader:v0.0.6
-  target: stgregistry.suse.com/rancher/charts/mirrored-kube-logging-config-reloader:v0.0.6
   type: image
 - source: ghcr.io/kube-logging/fluentd:v1.16-4.10-full
   target: docker.io/rancher/mirrored-kube-logging-fluentd:v1.16-4.10-full
@@ -3230,18 +1970,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-kube-logging-fluentd:v1.16-ruby3.3-full-build.140
   type: image
 - source: ghcr.io/kube-logging/fluentd:v1.16-4.10-full
-  target: registry.suse.com/rancher/charts/mirrored-kube-logging-fluentd:v1.16-4.10-full
-  type: image
-- source: ghcr.io/kube-logging/fluentd:v1.16-4.11-full
-  target: registry.suse.com/rancher/charts/mirrored-kube-logging-fluentd:v1.16-4.11-full
-  type: image
-- source: ghcr.io/kube-logging/fluentd:v1.16-4.8-full
-  target: registry.suse.com/rancher/charts/mirrored-kube-logging-fluentd:v1.16-4.8-full
-  type: image
-- source: ghcr.io/kube-logging/fluentd:v1.16-ruby3.3-full-build.140
-  target: registry.suse.com/rancher/charts/mirrored-kube-logging-fluentd:v1.16-ruby3.3-full-build.140
-  type: image
-- source: ghcr.io/kube-logging/fluentd:v1.16-4.10-full
   target: stgregistry.suse.com/rancher/mirrored-kube-logging-fluentd:v1.16-4.10-full
   type: image
 - source: ghcr.io/kube-logging/fluentd:v1.16-4.11-full
@@ -3252,18 +1980,6 @@ sync:
   type: image
 - source: ghcr.io/kube-logging/fluentd:v1.16-ruby3.3-full-build.140
   target: stgregistry.suse.com/rancher/mirrored-kube-logging-fluentd:v1.16-ruby3.3-full-build.140
-  type: image
-- source: ghcr.io/kube-logging/fluentd:v1.16-4.10-full
-  target: stgregistry.suse.com/rancher/charts/mirrored-kube-logging-fluentd:v1.16-4.10-full
-  type: image
-- source: ghcr.io/kube-logging/fluentd:v1.16-4.11-full
-  target: stgregistry.suse.com/rancher/charts/mirrored-kube-logging-fluentd:v1.16-4.11-full
-  type: image
-- source: ghcr.io/kube-logging/fluentd:v1.16-4.8-full
-  target: stgregistry.suse.com/rancher/charts/mirrored-kube-logging-fluentd:v1.16-4.8-full
-  type: image
-- source: ghcr.io/kube-logging/fluentd:v1.16-ruby3.3-full-build.140
-  target: stgregistry.suse.com/rancher/charts/mirrored-kube-logging-fluentd:v1.16-ruby3.3-full-build.140
   type: image
 - source: ghcr.io/kube-logging/logging-operator:4.10.0
   target: docker.io/rancher/mirrored-kube-logging-logging-operator:4.10.0
@@ -3296,21 +2012,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-kube-logging-logging-operator:4.9.1
   type: image
 - source: ghcr.io/kube-logging/logging-operator:4.10.0
-  target: registry.suse.com/rancher/charts/mirrored-kube-logging-logging-operator:4.10.0
-  type: image
-- source: ghcr.io/kube-logging/logging-operator:4.11.4
-  target: registry.suse.com/rancher/charts/mirrored-kube-logging-logging-operator:4.11.4
-  type: image
-- source: ghcr.io/kube-logging/logging-operator:4.4.0
-  target: registry.suse.com/rancher/charts/mirrored-kube-logging-logging-operator:4.4.0
-  type: image
-- source: ghcr.io/kube-logging/logging-operator:4.8.0
-  target: registry.suse.com/rancher/charts/mirrored-kube-logging-logging-operator:4.8.0
-  type: image
-- source: ghcr.io/kube-logging/logging-operator:4.9.1
-  target: registry.suse.com/rancher/charts/mirrored-kube-logging-logging-operator:4.9.1
-  type: image
-- source: ghcr.io/kube-logging/logging-operator:4.10.0
   target: stgregistry.suse.com/rancher/mirrored-kube-logging-logging-operator:4.10.0
   type: image
 - source: ghcr.io/kube-logging/logging-operator:4.11.4
@@ -3324,21 +2025,6 @@ sync:
   type: image
 - source: ghcr.io/kube-logging/logging-operator:4.9.1
   target: stgregistry.suse.com/rancher/mirrored-kube-logging-logging-operator:4.9.1
-  type: image
-- source: ghcr.io/kube-logging/logging-operator:4.10.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-kube-logging-logging-operator:4.10.0
-  type: image
-- source: ghcr.io/kube-logging/logging-operator:4.11.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-kube-logging-logging-operator:4.11.4
-  type: image
-- source: ghcr.io/kube-logging/logging-operator:4.4.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-kube-logging-logging-operator:4.4.0
-  type: image
-- source: ghcr.io/kube-logging/logging-operator:4.8.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-kube-logging-logging-operator:4.8.0
-  type: image
-- source: ghcr.io/kube-logging/logging-operator:4.9.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-kube-logging-logging-operator:4.9.1
   type: image
 - source: ghcr.io/kube-vip/kube-vip-iptables:v0.6.0
   target: docker.io/rancher/mirrored-kube-vip-kube-vip-iptables:v0.6.0
@@ -3413,42 +2099,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-kube-vip-kube-vip-iptables:v1.0.1
   type: image
 - source: ghcr.io/kube-vip/kube-vip-iptables:v0.6.0
-  target: registry.suse.com/rancher/charts/mirrored-kube-vip-kube-vip-iptables:v0.6.0
-  type: image
-- source: ghcr.io/kube-vip/kube-vip-iptables:v0.8.10
-  target: registry.suse.com/rancher/charts/mirrored-kube-vip-kube-vip-iptables:v0.8.10
-  type: image
-- source: ghcr.io/kube-vip/kube-vip-iptables:v0.8.4
-  target: registry.suse.com/rancher/charts/mirrored-kube-vip-kube-vip-iptables:v0.8.4
-  type: image
-- source: ghcr.io/kube-vip/kube-vip-iptables:v0.8.6
-  target: registry.suse.com/rancher/charts/mirrored-kube-vip-kube-vip-iptables:v0.8.6
-  type: image
-- source: ghcr.io/kube-vip/kube-vip-iptables:v0.8.7
-  target: registry.suse.com/rancher/charts/mirrored-kube-vip-kube-vip-iptables:v0.8.7
-  type: image
-- source: ghcr.io/kube-vip/kube-vip-iptables:v0.8.8
-  target: registry.suse.com/rancher/charts/mirrored-kube-vip-kube-vip-iptables:v0.8.8
-  type: image
-- source: ghcr.io/kube-vip/kube-vip-iptables:v0.8.9
-  target: registry.suse.com/rancher/charts/mirrored-kube-vip-kube-vip-iptables:v0.8.9
-  type: image
-- source: ghcr.io/kube-vip/kube-vip-iptables:v0.9.0
-  target: registry.suse.com/rancher/charts/mirrored-kube-vip-kube-vip-iptables:v0.9.0
-  type: image
-- source: ghcr.io/kube-vip/kube-vip-iptables:v0.9.1
-  target: registry.suse.com/rancher/charts/mirrored-kube-vip-kube-vip-iptables:v0.9.1
-  type: image
-- source: ghcr.io/kube-vip/kube-vip-iptables:v0.9.2
-  target: registry.suse.com/rancher/charts/mirrored-kube-vip-kube-vip-iptables:v0.9.2
-  type: image
-- source: ghcr.io/kube-vip/kube-vip-iptables:v1.0.0
-  target: registry.suse.com/rancher/charts/mirrored-kube-vip-kube-vip-iptables:v1.0.0
-  type: image
-- source: ghcr.io/kube-vip/kube-vip-iptables:v1.0.1
-  target: registry.suse.com/rancher/charts/mirrored-kube-vip-kube-vip-iptables:v1.0.1
-  type: image
-- source: ghcr.io/kube-vip/kube-vip-iptables:v0.6.0
   target: stgregistry.suse.com/rancher/mirrored-kube-vip-kube-vip-iptables:v0.6.0
   type: image
 - source: ghcr.io/kube-vip/kube-vip-iptables:v0.8.10
@@ -3484,42 +2134,6 @@ sync:
 - source: ghcr.io/kube-vip/kube-vip-iptables:v1.0.1
   target: stgregistry.suse.com/rancher/mirrored-kube-vip-kube-vip-iptables:v1.0.1
   type: image
-- source: ghcr.io/kube-vip/kube-vip-iptables:v0.6.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-kube-vip-kube-vip-iptables:v0.6.0
-  type: image
-- source: ghcr.io/kube-vip/kube-vip-iptables:v0.8.10
-  target: stgregistry.suse.com/rancher/charts/mirrored-kube-vip-kube-vip-iptables:v0.8.10
-  type: image
-- source: ghcr.io/kube-vip/kube-vip-iptables:v0.8.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-kube-vip-kube-vip-iptables:v0.8.4
-  type: image
-- source: ghcr.io/kube-vip/kube-vip-iptables:v0.8.6
-  target: stgregistry.suse.com/rancher/charts/mirrored-kube-vip-kube-vip-iptables:v0.8.6
-  type: image
-- source: ghcr.io/kube-vip/kube-vip-iptables:v0.8.7
-  target: stgregistry.suse.com/rancher/charts/mirrored-kube-vip-kube-vip-iptables:v0.8.7
-  type: image
-- source: ghcr.io/kube-vip/kube-vip-iptables:v0.8.8
-  target: stgregistry.suse.com/rancher/charts/mirrored-kube-vip-kube-vip-iptables:v0.8.8
-  type: image
-- source: ghcr.io/kube-vip/kube-vip-iptables:v0.8.9
-  target: stgregistry.suse.com/rancher/charts/mirrored-kube-vip-kube-vip-iptables:v0.8.9
-  type: image
-- source: ghcr.io/kube-vip/kube-vip-iptables:v0.9.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-kube-vip-kube-vip-iptables:v0.9.0
-  type: image
-- source: ghcr.io/kube-vip/kube-vip-iptables:v0.9.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-kube-vip-kube-vip-iptables:v0.9.1
-  type: image
-- source: ghcr.io/kube-vip/kube-vip-iptables:v0.9.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-kube-vip-kube-vip-iptables:v0.9.2
-  type: image
-- source: ghcr.io/kube-vip/kube-vip-iptables:v1.0.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-kube-vip-kube-vip-iptables:v1.0.0
-  type: image
-- source: ghcr.io/kube-vip/kube-vip-iptables:v1.0.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-kube-vip-kube-vip-iptables:v1.0.1
-  type: image
 - source: ghcr.io/prometheus-community/windows-exporter:0.25.1
   target: docker.io/rancher/mirrored-prometheus-windows-exporter:0.25.1
   type: image
@@ -3551,21 +2165,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-prometheus-windows-exporter:0.31.3
   type: image
 - source: ghcr.io/prometheus-community/windows-exporter:0.25.1
-  target: registry.suse.com/rancher/charts/mirrored-prometheus-windows-exporter:0.25.1
-  type: image
-- source: ghcr.io/prometheus-community/windows-exporter:0.29.2
-  target: registry.suse.com/rancher/charts/mirrored-prometheus-windows-exporter:0.29.2
-  type: image
-- source: ghcr.io/prometheus-community/windows-exporter:0.30.5
-  target: registry.suse.com/rancher/charts/mirrored-prometheus-windows-exporter:0.30.5
-  type: image
-- source: ghcr.io/prometheus-community/windows-exporter:0.31.2
-  target: registry.suse.com/rancher/charts/mirrored-prometheus-windows-exporter:0.31.2
-  type: image
-- source: ghcr.io/prometheus-community/windows-exporter:0.31.3
-  target: registry.suse.com/rancher/charts/mirrored-prometheus-windows-exporter:0.31.3
-  type: image
-- source: ghcr.io/prometheus-community/windows-exporter:0.25.1
   target: stgregistry.suse.com/rancher/mirrored-prometheus-windows-exporter:0.25.1
   type: image
 - source: ghcr.io/prometheus-community/windows-exporter:0.29.2
@@ -3580,21 +2179,6 @@ sync:
 - source: ghcr.io/prometheus-community/windows-exporter:0.31.3
   target: stgregistry.suse.com/rancher/mirrored-prometheus-windows-exporter:0.31.3
   type: image
-- source: ghcr.io/prometheus-community/windows-exporter:0.25.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-windows-exporter:0.25.1
-  type: image
-- source: ghcr.io/prometheus-community/windows-exporter:0.29.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-windows-exporter:0.29.2
-  type: image
-- source: ghcr.io/prometheus-community/windows-exporter:0.30.5
-  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-windows-exporter:0.30.5
-  type: image
-- source: ghcr.io/prometheus-community/windows-exporter:0.31.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-windows-exporter:0.31.2
-  type: image
-- source: ghcr.io/prometheus-community/windows-exporter:0.31.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-windows-exporter:0.31.3
-  type: image
 - source: grafana/grafana:7.1.5
   target: docker.io/rancher/grafana-grafana:7.1.5
   type: image
@@ -3608,22 +2192,10 @@ sync:
   target: registry.suse.com/rancher/grafana-grafana:7.2.1
   type: image
 - source: grafana/grafana:7.1.5
-  target: registry.suse.com/rancher/charts/grafana-grafana:7.1.5
-  type: image
-- source: grafana/grafana:7.2.1
-  target: registry.suse.com/rancher/charts/grafana-grafana:7.2.1
-  type: image
-- source: grafana/grafana:7.1.5
   target: stgregistry.suse.com/rancher/grafana-grafana:7.1.5
   type: image
 - source: grafana/grafana:7.2.1
   target: stgregistry.suse.com/rancher/grafana-grafana:7.2.1
-  type: image
-- source: grafana/grafana:7.1.5
-  target: stgregistry.suse.com/rancher/charts/grafana-grafana:7.1.5
-  type: image
-- source: grafana/grafana:7.2.1
-  target: stgregistry.suse.com/rancher/charts/grafana-grafana:7.2.1
   type: image
 - source: grafana/grafana:10.3.3
   target: docker.io/rancher/mirrored-grafana-grafana:10.3.3
@@ -3728,57 +2300,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-grafana-grafana:9.5.14
   type: image
 - source: grafana/grafana:10.3.3
-  target: registry.suse.com/rancher/charts/mirrored-grafana-grafana:10.3.3
-  type: image
-- source: grafana/grafana:10.4.9
-  target: registry.suse.com/rancher/charts/mirrored-grafana-grafana:10.4.9
-  type: image
-- source: grafana/grafana:11.1.0
-  target: registry.suse.com/rancher/charts/mirrored-grafana-grafana:11.1.0
-  type: image
-- source: grafana/grafana:11.3.0
-  target: registry.suse.com/rancher/charts/mirrored-grafana-grafana:11.3.0
-  type: image
-- source: grafana/grafana:11.4.0
-  target: registry.suse.com/rancher/charts/mirrored-grafana-grafana:11.4.0
-  type: image
-- source: grafana/grafana:11.4.5
-  target: registry.suse.com/rancher/charts/mirrored-grafana-grafana:11.4.5
-  type: image
-- source: grafana/grafana:11.5.2
-  target: registry.suse.com/rancher/charts/mirrored-grafana-grafana:11.5.2
-  type: image
-- source: grafana/grafana:11.5.5
-  target: registry.suse.com/rancher/charts/mirrored-grafana-grafana:11.5.5
-  type: image
-- source: grafana/grafana:12.1.1
-  target: registry.suse.com/rancher/charts/mirrored-grafana-grafana:12.1.1
-  type: image
-- source: grafana/grafana:6.7.4
-  target: registry.suse.com/rancher/charts/mirrored-grafana-grafana:6.7.4
-  type: image
-- source: grafana/grafana:7.1.5
-  target: registry.suse.com/rancher/charts/mirrored-grafana-grafana:7.1.5
-  type: image
-- source: grafana/grafana:7.4.5
-  target: registry.suse.com/rancher/charts/mirrored-grafana-grafana:7.4.5
-  type: image
-- source: grafana/grafana:7.5.11
-  target: registry.suse.com/rancher/charts/mirrored-grafana-grafana:7.5.11
-  type: image
-- source: grafana/grafana:7.5.8
-  target: registry.suse.com/rancher/charts/mirrored-grafana-grafana:7.5.8
-  type: image
-- source: grafana/grafana:8.5.3
-  target: registry.suse.com/rancher/charts/mirrored-grafana-grafana:8.5.3
-  type: image
-- source: grafana/grafana:9.1.5
-  target: registry.suse.com/rancher/charts/mirrored-grafana-grafana:9.1.5
-  type: image
-- source: grafana/grafana:9.5.14
-  target: registry.suse.com/rancher/charts/mirrored-grafana-grafana:9.5.14
-  type: image
-- source: grafana/grafana:10.3.3
   target: stgregistry.suse.com/rancher/mirrored-grafana-grafana:10.3.3
   type: image
 - source: grafana/grafana:10.4.9
@@ -3829,57 +2350,6 @@ sync:
 - source: grafana/grafana:9.5.14
   target: stgregistry.suse.com/rancher/mirrored-grafana-grafana:9.5.14
   type: image
-- source: grafana/grafana:10.3.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-grafana-grafana:10.3.3
-  type: image
-- source: grafana/grafana:10.4.9
-  target: stgregistry.suse.com/rancher/charts/mirrored-grafana-grafana:10.4.9
-  type: image
-- source: grafana/grafana:11.1.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-grafana-grafana:11.1.0
-  type: image
-- source: grafana/grafana:11.3.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-grafana-grafana:11.3.0
-  type: image
-- source: grafana/grafana:11.4.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-grafana-grafana:11.4.0
-  type: image
-- source: grafana/grafana:11.4.5
-  target: stgregistry.suse.com/rancher/charts/mirrored-grafana-grafana:11.4.5
-  type: image
-- source: grafana/grafana:11.5.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-grafana-grafana:11.5.2
-  type: image
-- source: grafana/grafana:11.5.5
-  target: stgregistry.suse.com/rancher/charts/mirrored-grafana-grafana:11.5.5
-  type: image
-- source: grafana/grafana:12.1.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-grafana-grafana:12.1.1
-  type: image
-- source: grafana/grafana:6.7.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-grafana-grafana:6.7.4
-  type: image
-- source: grafana/grafana:7.1.5
-  target: stgregistry.suse.com/rancher/charts/mirrored-grafana-grafana:7.1.5
-  type: image
-- source: grafana/grafana:7.4.5
-  target: stgregistry.suse.com/rancher/charts/mirrored-grafana-grafana:7.4.5
-  type: image
-- source: grafana/grafana:7.5.11
-  target: stgregistry.suse.com/rancher/charts/mirrored-grafana-grafana:7.5.11
-  type: image
-- source: grafana/grafana:7.5.8
-  target: stgregistry.suse.com/rancher/charts/mirrored-grafana-grafana:7.5.8
-  type: image
-- source: grafana/grafana:8.5.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-grafana-grafana:8.5.3
-  type: image
-- source: grafana/grafana:9.1.5
-  target: stgregistry.suse.com/rancher/charts/mirrored-grafana-grafana:9.1.5
-  type: image
-- source: grafana/grafana:9.5.14
-  target: stgregistry.suse.com/rancher/charts/mirrored-grafana-grafana:9.5.14
-  type: image
 - source: grafana/grafana-image-renderer:2.0.0
   target: docker.io/rancher/grafana-grafana-image-renderer:2.0.0
   type: image
@@ -3887,13 +2357,7 @@ sync:
   target: registry.suse.com/rancher/grafana-grafana-image-renderer:2.0.0
   type: image
 - source: grafana/grafana-image-renderer:2.0.0
-  target: registry.suse.com/rancher/charts/grafana-grafana-image-renderer:2.0.0
-  type: image
-- source: grafana/grafana-image-renderer:2.0.0
   target: stgregistry.suse.com/rancher/grafana-grafana-image-renderer:2.0.0
-  type: image
-- source: grafana/grafana-image-renderer:2.0.0
-  target: stgregistry.suse.com/rancher/charts/grafana-grafana-image-renderer:2.0.0
   type: image
 - source: grafana/grafana-image-renderer:2.0.1
   target: docker.io/rancher/mirrored-grafana-grafana-image-renderer:2.0.1
@@ -3962,39 +2426,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-grafana-grafana-image-renderer:v4.0.5
   type: image
 - source: grafana/grafana-image-renderer:2.0.1
-  target: registry.suse.com/rancher/charts/mirrored-grafana-grafana-image-renderer:2.0.1
-  type: image
-- source: grafana/grafana-image-renderer:3.0.1
-  target: registry.suse.com/rancher/charts/mirrored-grafana-grafana-image-renderer:3.0.1
-  type: image
-- source: grafana/grafana-image-renderer:3.10.1
-  target: registry.suse.com/rancher/charts/mirrored-grafana-grafana-image-renderer:3.10.1
-  type: image
-- source: grafana/grafana-image-renderer:3.10.5
-  target: registry.suse.com/rancher/charts/mirrored-grafana-grafana-image-renderer:3.10.5
-  type: image
-- source: grafana/grafana-image-renderer:3.11.1
-  target: registry.suse.com/rancher/charts/mirrored-grafana-grafana-image-renderer:3.11.1
-  type: image
-- source: grafana/grafana-image-renderer:3.11.6
-  target: registry.suse.com/rancher/charts/mirrored-grafana-grafana-image-renderer:3.11.6
-  type: image
-- source: grafana/grafana-image-renderer:3.12.3
-  target: registry.suse.com/rancher/charts/mirrored-grafana-grafana-image-renderer:3.12.3
-  type: image
-- source: grafana/grafana-image-renderer:3.12.6
-  target: registry.suse.com/rancher/charts/mirrored-grafana-grafana-image-renderer:3.12.6
-  type: image
-- source: grafana/grafana-image-renderer:3.8.0
-  target: registry.suse.com/rancher/charts/mirrored-grafana-grafana-image-renderer:3.8.0
-  type: image
-- source: grafana/grafana-image-renderer:v4.0.15
-  target: registry.suse.com/rancher/charts/mirrored-grafana-grafana-image-renderer:v4.0.15
-  type: image
-- source: grafana/grafana-image-renderer:v4.0.5
-  target: registry.suse.com/rancher/charts/mirrored-grafana-grafana-image-renderer:v4.0.5
-  type: image
-- source: grafana/grafana-image-renderer:2.0.1
   target: stgregistry.suse.com/rancher/mirrored-grafana-grafana-image-renderer:2.0.1
   type: image
 - source: grafana/grafana-image-renderer:3.0.1
@@ -4027,39 +2458,6 @@ sync:
 - source: grafana/grafana-image-renderer:v4.0.5
   target: stgregistry.suse.com/rancher/mirrored-grafana-grafana-image-renderer:v4.0.5
   type: image
-- source: grafana/grafana-image-renderer:2.0.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-grafana-grafana-image-renderer:2.0.1
-  type: image
-- source: grafana/grafana-image-renderer:3.0.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-grafana-grafana-image-renderer:3.0.1
-  type: image
-- source: grafana/grafana-image-renderer:3.10.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-grafana-grafana-image-renderer:3.10.1
-  type: image
-- source: grafana/grafana-image-renderer:3.10.5
-  target: stgregistry.suse.com/rancher/charts/mirrored-grafana-grafana-image-renderer:3.10.5
-  type: image
-- source: grafana/grafana-image-renderer:3.11.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-grafana-grafana-image-renderer:3.11.1
-  type: image
-- source: grafana/grafana-image-renderer:3.11.6
-  target: stgregistry.suse.com/rancher/charts/mirrored-grafana-grafana-image-renderer:3.11.6
-  type: image
-- source: grafana/grafana-image-renderer:3.12.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-grafana-grafana-image-renderer:3.12.3
-  type: image
-- source: grafana/grafana-image-renderer:3.12.6
-  target: stgregistry.suse.com/rancher/charts/mirrored-grafana-grafana-image-renderer:3.12.6
-  type: image
-- source: grafana/grafana-image-renderer:3.8.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-grafana-grafana-image-renderer:3.8.0
-  type: image
-- source: grafana/grafana-image-renderer:v4.0.15
-  target: stgregistry.suse.com/rancher/charts/mirrored-grafana-grafana-image-renderer:v4.0.15
-  type: image
-- source: grafana/grafana-image-renderer:v4.0.5
-  target: stgregistry.suse.com/rancher/charts/mirrored-grafana-grafana-image-renderer:v4.0.5
-  type: image
 - source: idealista/prom2teams:3.2.1
   target: docker.io/rancher/mirrored-idealista-prom2teams:3.2.1
   type: image
@@ -4091,21 +2489,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-idealista-prom2teams:4.2.1
   type: image
 - source: idealista/prom2teams:3.2.1
-  target: registry.suse.com/rancher/charts/mirrored-idealista-prom2teams:3.2.1
-  type: image
-- source: idealista/prom2teams:3.2.2
-  target: registry.suse.com/rancher/charts/mirrored-idealista-prom2teams:3.2.2
-  type: image
-- source: idealista/prom2teams:3.2.3
-  target: registry.suse.com/rancher/charts/mirrored-idealista-prom2teams:3.2.3
-  type: image
-- source: idealista/prom2teams:4.2.0
-  target: registry.suse.com/rancher/charts/mirrored-idealista-prom2teams:4.2.0
-  type: image
-- source: idealista/prom2teams:4.2.1
-  target: registry.suse.com/rancher/charts/mirrored-idealista-prom2teams:4.2.1
-  type: image
-- source: idealista/prom2teams:3.2.1
   target: stgregistry.suse.com/rancher/mirrored-idealista-prom2teams:3.2.1
   type: image
 - source: idealista/prom2teams:3.2.2
@@ -4120,21 +2503,6 @@ sync:
 - source: idealista/prom2teams:4.2.1
   target: stgregistry.suse.com/rancher/mirrored-idealista-prom2teams:4.2.1
   type: image
-- source: idealista/prom2teams:3.2.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-idealista-prom2teams:3.2.1
-  type: image
-- source: idealista/prom2teams:3.2.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-idealista-prom2teams:3.2.2
-  type: image
-- source: idealista/prom2teams:3.2.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-idealista-prom2teams:3.2.3
-  type: image
-- source: idealista/prom2teams:4.2.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-idealista-prom2teams:4.2.0
-  type: image
-- source: idealista/prom2teams:4.2.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-idealista-prom2teams:4.2.1
-  type: image
 - source: istio/citadel:1.5.9
   target: docker.io/rancher/mirrored-istio-citadel:1.5.9
   type: image
@@ -4142,13 +2510,7 @@ sync:
   target: registry.suse.com/rancher/mirrored-istio-citadel:1.5.9
   type: image
 - source: istio/citadel:1.5.9
-  target: registry.suse.com/rancher/charts/mirrored-istio-citadel:1.5.9
-  type: image
-- source: istio/citadel:1.5.9
   target: stgregistry.suse.com/rancher/mirrored-istio-citadel:1.5.9
-  type: image
-- source: istio/citadel:1.5.9
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-citadel:1.5.9
   type: image
 - source: istio/coredns-plugin:0.2-istio-1.1
   target: docker.io/rancher/istio-coredns-plugin:0.2-istio-1.1
@@ -4157,13 +2519,7 @@ sync:
   target: registry.suse.com/rancher/istio-coredns-plugin:0.2-istio-1.1
   type: image
 - source: istio/coredns-plugin:0.2-istio-1.1
-  target: registry.suse.com/rancher/charts/istio-coredns-plugin:0.2-istio-1.1
-  type: image
-- source: istio/coredns-plugin:0.2-istio-1.1
   target: stgregistry.suse.com/rancher/istio-coredns-plugin:0.2-istio-1.1
-  type: image
-- source: istio/coredns-plugin:0.2-istio-1.1
-  target: stgregistry.suse.com/rancher/charts/istio-coredns-plugin:0.2-istio-1.1
   type: image
 - source: istio/coredns-plugin:0.2-istio-1.1
   target: docker.io/rancher/mirrored-istio-coredns-plugin:0.2-istio-1.1
@@ -4172,13 +2528,7 @@ sync:
   target: registry.suse.com/rancher/mirrored-istio-coredns-plugin:0.2-istio-1.1
   type: image
 - source: istio/coredns-plugin:0.2-istio-1.1
-  target: registry.suse.com/rancher/charts/mirrored-istio-coredns-plugin:0.2-istio-1.1
-  type: image
-- source: istio/coredns-plugin:0.2-istio-1.1
   target: stgregistry.suse.com/rancher/mirrored-istio-coredns-plugin:0.2-istio-1.1
-  type: image
-- source: istio/coredns-plugin:0.2-istio-1.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-coredns-plugin:0.2-istio-1.1
   type: image
 - source: istio/galley:1.5.9
   target: docker.io/rancher/mirrored-istio-galley:1.5.9
@@ -4187,13 +2537,7 @@ sync:
   target: registry.suse.com/rancher/mirrored-istio-galley:1.5.9
   type: image
 - source: istio/galley:1.5.9
-  target: registry.suse.com/rancher/charts/mirrored-istio-galley:1.5.9
-  type: image
-- source: istio/galley:1.5.9
   target: stgregistry.suse.com/rancher/mirrored-istio-galley:1.5.9
-  type: image
-- source: istio/galley:1.5.9
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-galley:1.5.9
   type: image
 - source: istio/install-cni:1.7.0
   target: docker.io/rancher/istio-install-cni:1.7.0
@@ -4232,24 +2576,6 @@ sync:
   target: registry.suse.com/rancher/istio-install-cni:1.8.3
   type: image
 - source: istio/install-cni:1.7.0
-  target: registry.suse.com/rancher/charts/istio-install-cni:1.7.0
-  type: image
-- source: istio/install-cni:1.7.1
-  target: registry.suse.com/rancher/charts/istio-install-cni:1.7.1
-  type: image
-- source: istio/install-cni:1.7.3
-  target: registry.suse.com/rancher/charts/istio-install-cni:1.7.3
-  type: image
-- source: istio/install-cni:1.7.6
-  target: registry.suse.com/rancher/charts/istio-install-cni:1.7.6
-  type: image
-- source: istio/install-cni:1.8.1
-  target: registry.suse.com/rancher/charts/istio-install-cni:1.8.1
-  type: image
-- source: istio/install-cni:1.8.3
-  target: registry.suse.com/rancher/charts/istio-install-cni:1.8.3
-  type: image
-- source: istio/install-cni:1.7.0
   target: stgregistry.suse.com/rancher/istio-install-cni:1.7.0
   type: image
 - source: istio/install-cni:1.7.1
@@ -4266,24 +2592,6 @@ sync:
   type: image
 - source: istio/install-cni:1.8.3
   target: stgregistry.suse.com/rancher/istio-install-cni:1.8.3
-  type: image
-- source: istio/install-cni:1.7.0
-  target: stgregistry.suse.com/rancher/charts/istio-install-cni:1.7.0
-  type: image
-- source: istio/install-cni:1.7.1
-  target: stgregistry.suse.com/rancher/charts/istio-install-cni:1.7.1
-  type: image
-- source: istio/install-cni:1.7.3
-  target: stgregistry.suse.com/rancher/charts/istio-install-cni:1.7.3
-  type: image
-- source: istio/install-cni:1.7.6
-  target: stgregistry.suse.com/rancher/charts/istio-install-cni:1.7.6
-  type: image
-- source: istio/install-cni:1.8.1
-  target: stgregistry.suse.com/rancher/charts/istio-install-cni:1.8.1
-  type: image
-- source: istio/install-cni:1.8.3
-  target: stgregistry.suse.com/rancher/charts/istio-install-cni:1.8.3
   type: image
 - source: istio/install-cni:1.10.0
   target: docker.io/rancher/mirrored-istio-install-cni:1.10.0
@@ -4628,177 +2936,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-istio-install-cni:1.9.8
   type: image
 - source: istio/install-cni:1.10.0
-  target: registry.suse.com/rancher/charts/mirrored-istio-install-cni:1.10.0
-  type: image
-- source: istio/install-cni:1.10.1
-  target: registry.suse.com/rancher/charts/mirrored-istio-install-cni:1.10.1
-  type: image
-- source: istio/install-cni:1.10.2
-  target: registry.suse.com/rancher/charts/mirrored-istio-install-cni:1.10.2
-  type: image
-- source: istio/install-cni:1.10.4
-  target: registry.suse.com/rancher/charts/mirrored-istio-install-cni:1.10.4
-  type: image
-- source: istio/install-cni:1.11.2
-  target: registry.suse.com/rancher/charts/mirrored-istio-install-cni:1.11.2
-  type: image
-- source: istio/install-cni:1.11.4
-  target: registry.suse.com/rancher/charts/mirrored-istio-install-cni:1.11.4
-  type: image
-- source: istio/install-cni:1.11.7
-  target: registry.suse.com/rancher/charts/mirrored-istio-install-cni:1.11.7
-  type: image
-- source: istio/install-cni:1.11.8
-  target: registry.suse.com/rancher/charts/mirrored-istio-install-cni:1.11.8
-  type: image
-- source: istio/install-cni:1.12.6
-  target: registry.suse.com/rancher/charts/mirrored-istio-install-cni:1.12.6
-  type: image
-- source: istio/install-cni:1.13.3
-  target: registry.suse.com/rancher/charts/mirrored-istio-install-cni:1.13.3
-  type: image
-- source: istio/install-cni:1.14.1
-  target: registry.suse.com/rancher/charts/mirrored-istio-install-cni:1.14.1
-  type: image
-- source: istio/install-cni:1.14.1-distroless
-  target: registry.suse.com/rancher/charts/mirrored-istio-install-cni:1.14.1-distroless
-  type: image
-- source: istio/install-cni:1.14.3
-  target: registry.suse.com/rancher/charts/mirrored-istio-install-cni:1.14.3
-  type: image
-- source: istio/install-cni:1.14.3-distroless
-  target: registry.suse.com/rancher/charts/mirrored-istio-install-cni:1.14.3-distroless
-  type: image
-- source: istio/install-cni:1.15.2
-  target: registry.suse.com/rancher/charts/mirrored-istio-install-cni:1.15.2
-  type: image
-- source: istio/install-cni:1.15.2-distroless
-  target: registry.suse.com/rancher/charts/mirrored-istio-install-cni:1.15.2-distroless
-  type: image
-- source: istio/install-cni:1.15.3
-  target: registry.suse.com/rancher/charts/mirrored-istio-install-cni:1.15.3
-  type: image
-- source: istio/install-cni:1.15.3-distroless
-  target: registry.suse.com/rancher/charts/mirrored-istio-install-cni:1.15.3-distroless
-  type: image
-- source: istio/install-cni:1.16.3
-  target: registry.suse.com/rancher/charts/mirrored-istio-install-cni:1.16.3
-  type: image
-- source: istio/install-cni:1.16.3-distroless
-  target: registry.suse.com/rancher/charts/mirrored-istio-install-cni:1.16.3-distroless
-  type: image
-- source: istio/install-cni:1.17.2
-  target: registry.suse.com/rancher/charts/mirrored-istio-install-cni:1.17.2
-  type: image
-- source: istio/install-cni:1.17.2-distroless
-  target: registry.suse.com/rancher/charts/mirrored-istio-install-cni:1.17.2-distroless
-  type: image
-- source: istio/install-cni:1.18.2
-  target: registry.suse.com/rancher/charts/mirrored-istio-install-cni:1.18.2
-  type: image
-- source: istio/install-cni:1.18.2-distroless
-  target: registry.suse.com/rancher/charts/mirrored-istio-install-cni:1.18.2-distroless
-  type: image
-- source: istio/install-cni:1.19.0
-  target: registry.suse.com/rancher/charts/mirrored-istio-install-cni:1.19.0
-  type: image
-- source: istio/install-cni:1.19.0-distroless
-  target: registry.suse.com/rancher/charts/mirrored-istio-install-cni:1.19.0-distroless
-  type: image
-- source: istio/install-cni:1.19.5
-  target: registry.suse.com/rancher/charts/mirrored-istio-install-cni:1.19.5
-  type: image
-- source: istio/install-cni:1.19.5-distroless
-  target: registry.suse.com/rancher/charts/mirrored-istio-install-cni:1.19.5-distroless
-  type: image
-- source: istio/install-cni:1.19.6
-  target: registry.suse.com/rancher/charts/mirrored-istio-install-cni:1.19.6
-  type: image
-- source: istio/install-cni:1.19.6-distroless
-  target: registry.suse.com/rancher/charts/mirrored-istio-install-cni:1.19.6-distroless
-  type: image
-- source: istio/install-cni:1.20.3
-  target: registry.suse.com/rancher/charts/mirrored-istio-install-cni:1.20.3
-  type: image
-- source: istio/install-cni:1.20.3-distroless
-  target: registry.suse.com/rancher/charts/mirrored-istio-install-cni:1.20.3-distroless
-  type: image
-- source: istio/install-cni:1.21.1
-  target: registry.suse.com/rancher/charts/mirrored-istio-install-cni:1.21.1
-  type: image
-- source: istio/install-cni:1.21.1-distroless
-  target: registry.suse.com/rancher/charts/mirrored-istio-install-cni:1.21.1-distroless
-  type: image
-- source: istio/install-cni:1.22.1
-  target: registry.suse.com/rancher/charts/mirrored-istio-install-cni:1.22.1
-  type: image
-- source: istio/install-cni:1.22.1-distroless
-  target: registry.suse.com/rancher/charts/mirrored-istio-install-cni:1.22.1-distroless
-  type: image
-- source: istio/install-cni:1.23.2
-  target: registry.suse.com/rancher/charts/mirrored-istio-install-cni:1.23.2
-  type: image
-- source: istio/install-cni:1.23.2-distroless
-  target: registry.suse.com/rancher/charts/mirrored-istio-install-cni:1.23.2-distroless
-  type: image
-- source: istio/install-cni:1.24.0
-  target: registry.suse.com/rancher/charts/mirrored-istio-install-cni:1.24.0
-  type: image
-- source: istio/install-cni:1.24.0-distroless
-  target: registry.suse.com/rancher/charts/mirrored-istio-install-cni:1.24.0-distroless
-  type: image
-- source: istio/install-cni:1.24.1
-  target: registry.suse.com/rancher/charts/mirrored-istio-install-cni:1.24.1
-  type: image
-- source: istio/install-cni:1.24.1-distroless
-  target: registry.suse.com/rancher/charts/mirrored-istio-install-cni:1.24.1-distroless
-  type: image
-- source: istio/install-cni:1.25.0
-  target: registry.suse.com/rancher/charts/mirrored-istio-install-cni:1.25.0
-  type: image
-- source: istio/install-cni:1.25.0-distroless
-  target: registry.suse.com/rancher/charts/mirrored-istio-install-cni:1.25.0-distroless
-  type: image
-- source: istio/install-cni:1.26.2
-  target: registry.suse.com/rancher/charts/mirrored-istio-install-cni:1.26.2
-  type: image
-- source: istio/install-cni:1.26.2-distroless
-  target: registry.suse.com/rancher/charts/mirrored-istio-install-cni:1.26.2-distroless
-  type: image
-- source: istio/install-cni:1.7.8
-  target: registry.suse.com/rancher/charts/mirrored-istio-install-cni:1.7.8
-  type: image
-- source: istio/install-cni:1.8.3
-  target: registry.suse.com/rancher/charts/mirrored-istio-install-cni:1.8.3
-  type: image
-- source: istio/install-cni:1.8.4
-  target: registry.suse.com/rancher/charts/mirrored-istio-install-cni:1.8.4
-  type: image
-- source: istio/install-cni:1.8.5
-  target: registry.suse.com/rancher/charts/mirrored-istio-install-cni:1.8.5
-  type: image
-- source: istio/install-cni:1.8.6
-  target: registry.suse.com/rancher/charts/mirrored-istio-install-cni:1.8.6
-  type: image
-- source: istio/install-cni:1.9.1
-  target: registry.suse.com/rancher/charts/mirrored-istio-install-cni:1.9.1
-  type: image
-- source: istio/install-cni:1.9.2
-  target: registry.suse.com/rancher/charts/mirrored-istio-install-cni:1.9.2
-  type: image
-- source: istio/install-cni:1.9.3
-  target: registry.suse.com/rancher/charts/mirrored-istio-install-cni:1.9.3
-  type: image
-- source: istio/install-cni:1.9.5
-  target: registry.suse.com/rancher/charts/mirrored-istio-install-cni:1.9.5
-  type: image
-- source: istio/install-cni:1.9.6
-  target: registry.suse.com/rancher/charts/mirrored-istio-install-cni:1.9.6
-  type: image
-- source: istio/install-cni:1.9.8
-  target: registry.suse.com/rancher/charts/mirrored-istio-install-cni:1.9.8
-  type: image
-- source: istio/install-cni:1.10.0
   target: stgregistry.suse.com/rancher/mirrored-istio-install-cni:1.10.0
   type: image
 - source: istio/install-cni:1.10.1
@@ -4969,177 +3106,6 @@ sync:
 - source: istio/install-cni:1.9.8
   target: stgregistry.suse.com/rancher/mirrored-istio-install-cni:1.9.8
   type: image
-- source: istio/install-cni:1.10.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-install-cni:1.10.0
-  type: image
-- source: istio/install-cni:1.10.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-install-cni:1.10.1
-  type: image
-- source: istio/install-cni:1.10.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-install-cni:1.10.2
-  type: image
-- source: istio/install-cni:1.10.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-install-cni:1.10.4
-  type: image
-- source: istio/install-cni:1.11.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-install-cni:1.11.2
-  type: image
-- source: istio/install-cni:1.11.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-install-cni:1.11.4
-  type: image
-- source: istio/install-cni:1.11.7
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-install-cni:1.11.7
-  type: image
-- source: istio/install-cni:1.11.8
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-install-cni:1.11.8
-  type: image
-- source: istio/install-cni:1.12.6
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-install-cni:1.12.6
-  type: image
-- source: istio/install-cni:1.13.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-install-cni:1.13.3
-  type: image
-- source: istio/install-cni:1.14.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-install-cni:1.14.1
-  type: image
-- source: istio/install-cni:1.14.1-distroless
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-install-cni:1.14.1-distroless
-  type: image
-- source: istio/install-cni:1.14.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-install-cni:1.14.3
-  type: image
-- source: istio/install-cni:1.14.3-distroless
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-install-cni:1.14.3-distroless
-  type: image
-- source: istio/install-cni:1.15.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-install-cni:1.15.2
-  type: image
-- source: istio/install-cni:1.15.2-distroless
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-install-cni:1.15.2-distroless
-  type: image
-- source: istio/install-cni:1.15.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-install-cni:1.15.3
-  type: image
-- source: istio/install-cni:1.15.3-distroless
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-install-cni:1.15.3-distroless
-  type: image
-- source: istio/install-cni:1.16.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-install-cni:1.16.3
-  type: image
-- source: istio/install-cni:1.16.3-distroless
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-install-cni:1.16.3-distroless
-  type: image
-- source: istio/install-cni:1.17.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-install-cni:1.17.2
-  type: image
-- source: istio/install-cni:1.17.2-distroless
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-install-cni:1.17.2-distroless
-  type: image
-- source: istio/install-cni:1.18.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-install-cni:1.18.2
-  type: image
-- source: istio/install-cni:1.18.2-distroless
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-install-cni:1.18.2-distroless
-  type: image
-- source: istio/install-cni:1.19.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-install-cni:1.19.0
-  type: image
-- source: istio/install-cni:1.19.0-distroless
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-install-cni:1.19.0-distroless
-  type: image
-- source: istio/install-cni:1.19.5
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-install-cni:1.19.5
-  type: image
-- source: istio/install-cni:1.19.5-distroless
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-install-cni:1.19.5-distroless
-  type: image
-- source: istio/install-cni:1.19.6
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-install-cni:1.19.6
-  type: image
-- source: istio/install-cni:1.19.6-distroless
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-install-cni:1.19.6-distroless
-  type: image
-- source: istio/install-cni:1.20.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-install-cni:1.20.3
-  type: image
-- source: istio/install-cni:1.20.3-distroless
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-install-cni:1.20.3-distroless
-  type: image
-- source: istio/install-cni:1.21.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-install-cni:1.21.1
-  type: image
-- source: istio/install-cni:1.21.1-distroless
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-install-cni:1.21.1-distroless
-  type: image
-- source: istio/install-cni:1.22.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-install-cni:1.22.1
-  type: image
-- source: istio/install-cni:1.22.1-distroless
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-install-cni:1.22.1-distroless
-  type: image
-- source: istio/install-cni:1.23.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-install-cni:1.23.2
-  type: image
-- source: istio/install-cni:1.23.2-distroless
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-install-cni:1.23.2-distroless
-  type: image
-- source: istio/install-cni:1.24.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-install-cni:1.24.0
-  type: image
-- source: istio/install-cni:1.24.0-distroless
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-install-cni:1.24.0-distroless
-  type: image
-- source: istio/install-cni:1.24.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-install-cni:1.24.1
-  type: image
-- source: istio/install-cni:1.24.1-distroless
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-install-cni:1.24.1-distroless
-  type: image
-- source: istio/install-cni:1.25.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-install-cni:1.25.0
-  type: image
-- source: istio/install-cni:1.25.0-distroless
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-install-cni:1.25.0-distroless
-  type: image
-- source: istio/install-cni:1.26.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-install-cni:1.26.2
-  type: image
-- source: istio/install-cni:1.26.2-distroless
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-install-cni:1.26.2-distroless
-  type: image
-- source: istio/install-cni:1.7.8
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-install-cni:1.7.8
-  type: image
-- source: istio/install-cni:1.8.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-install-cni:1.8.3
-  type: image
-- source: istio/install-cni:1.8.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-install-cni:1.8.4
-  type: image
-- source: istio/install-cni:1.8.5
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-install-cni:1.8.5
-  type: image
-- source: istio/install-cni:1.8.6
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-install-cni:1.8.6
-  type: image
-- source: istio/install-cni:1.9.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-install-cni:1.9.1
-  type: image
-- source: istio/install-cni:1.9.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-install-cni:1.9.2
-  type: image
-- source: istio/install-cni:1.9.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-install-cni:1.9.3
-  type: image
-- source: istio/install-cni:1.9.5
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-install-cni:1.9.5
-  type: image
-- source: istio/install-cni:1.9.6
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-install-cni:1.9.6
-  type: image
-- source: istio/install-cni:1.9.8
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-install-cni:1.9.8
-  type: image
 - source: istio/kubectl:1.5.10
   target: docker.io/rancher/istio-kubectl:1.5.10
   type: image
@@ -5147,13 +3113,7 @@ sync:
   target: registry.suse.com/rancher/istio-kubectl:1.5.10
   type: image
 - source: istio/kubectl:1.5.10
-  target: registry.suse.com/rancher/charts/istio-kubectl:1.5.10
-  type: image
-- source: istio/kubectl:1.5.10
   target: stgregistry.suse.com/rancher/istio-kubectl:1.5.10
-  type: image
-- source: istio/kubectl:1.5.10
-  target: stgregistry.suse.com/rancher/charts/istio-kubectl:1.5.10
   type: image
 - source: istio/kubectl:1.5.9
   target: docker.io/rancher/mirrored-istio-kubectl:1.5.9
@@ -5162,13 +3122,7 @@ sync:
   target: registry.suse.com/rancher/mirrored-istio-kubectl:1.5.9
   type: image
 - source: istio/kubectl:1.5.9
-  target: registry.suse.com/rancher/charts/mirrored-istio-kubectl:1.5.9
-  type: image
-- source: istio/kubectl:1.5.9
   target: stgregistry.suse.com/rancher/mirrored-istio-kubectl:1.5.9
-  type: image
-- source: istio/kubectl:1.5.9
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-kubectl:1.5.9
   type: image
 - source: istio/mixer:1.7.0
   target: docker.io/rancher/istio-mixer:1.7.0
@@ -5195,18 +3149,6 @@ sync:
   target: registry.suse.com/rancher/istio-mixer:1.7.6
   type: image
 - source: istio/mixer:1.7.0
-  target: registry.suse.com/rancher/charts/istio-mixer:1.7.0
-  type: image
-- source: istio/mixer:1.7.1
-  target: registry.suse.com/rancher/charts/istio-mixer:1.7.1
-  type: image
-- source: istio/mixer:1.7.3
-  target: registry.suse.com/rancher/charts/istio-mixer:1.7.3
-  type: image
-- source: istio/mixer:1.7.6
-  target: registry.suse.com/rancher/charts/istio-mixer:1.7.6
-  type: image
-- source: istio/mixer:1.7.0
   target: stgregistry.suse.com/rancher/istio-mixer:1.7.0
   type: image
 - source: istio/mixer:1.7.1
@@ -5217,18 +3159,6 @@ sync:
   type: image
 - source: istio/mixer:1.7.6
   target: stgregistry.suse.com/rancher/istio-mixer:1.7.6
-  type: image
-- source: istio/mixer:1.7.0
-  target: stgregistry.suse.com/rancher/charts/istio-mixer:1.7.0
-  type: image
-- source: istio/mixer:1.7.1
-  target: stgregistry.suse.com/rancher/charts/istio-mixer:1.7.1
-  type: image
-- source: istio/mixer:1.7.3
-  target: stgregistry.suse.com/rancher/charts/istio-mixer:1.7.3
-  type: image
-- source: istio/mixer:1.7.6
-  target: stgregistry.suse.com/rancher/charts/istio-mixer:1.7.6
   type: image
 - source: istio/mixer:1.5.9
   target: docker.io/rancher/mirrored-istio-mixer:1.5.9
@@ -5243,22 +3173,10 @@ sync:
   target: registry.suse.com/rancher/mirrored-istio-mixer:1.7.8
   type: image
 - source: istio/mixer:1.5.9
-  target: registry.suse.com/rancher/charts/mirrored-istio-mixer:1.5.9
-  type: image
-- source: istio/mixer:1.7.8
-  target: registry.suse.com/rancher/charts/mirrored-istio-mixer:1.7.8
-  type: image
-- source: istio/mixer:1.5.9
   target: stgregistry.suse.com/rancher/mirrored-istio-mixer:1.5.9
   type: image
 - source: istio/mixer:1.7.8
   target: stgregistry.suse.com/rancher/mirrored-istio-mixer:1.7.8
-  type: image
-- source: istio/mixer:1.5.9
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-mixer:1.5.9
-  type: image
-- source: istio/mixer:1.7.8
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-mixer:1.7.8
   type: image
 - source: istio/node-agent-k8s:1.5.9
   target: docker.io/rancher/mirrored-istio-node-agent-k8s:1.5.9
@@ -5267,13 +3185,7 @@ sync:
   target: registry.suse.com/rancher/mirrored-istio-node-agent-k8s:1.5.9
   type: image
 - source: istio/node-agent-k8s:1.5.9
-  target: registry.suse.com/rancher/charts/mirrored-istio-node-agent-k8s:1.5.9
-  type: image
-- source: istio/node-agent-k8s:1.5.9
   target: stgregistry.suse.com/rancher/mirrored-istio-node-agent-k8s:1.5.9
-  type: image
-- source: istio/node-agent-k8s:1.5.9
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-node-agent-k8s:1.5.9
   type: image
 - source: istio/pilot:1.7.0
   target: docker.io/rancher/istio-pilot:1.7.0
@@ -5312,24 +3224,6 @@ sync:
   target: registry.suse.com/rancher/istio-pilot:1.8.3
   type: image
 - source: istio/pilot:1.7.0
-  target: registry.suse.com/rancher/charts/istio-pilot:1.7.0
-  type: image
-- source: istio/pilot:1.7.1
-  target: registry.suse.com/rancher/charts/istio-pilot:1.7.1
-  type: image
-- source: istio/pilot:1.7.3
-  target: registry.suse.com/rancher/charts/istio-pilot:1.7.3
-  type: image
-- source: istio/pilot:1.7.6
-  target: registry.suse.com/rancher/charts/istio-pilot:1.7.6
-  type: image
-- source: istio/pilot:1.8.1
-  target: registry.suse.com/rancher/charts/istio-pilot:1.8.1
-  type: image
-- source: istio/pilot:1.8.3
-  target: registry.suse.com/rancher/charts/istio-pilot:1.8.3
-  type: image
-- source: istio/pilot:1.7.0
   target: stgregistry.suse.com/rancher/istio-pilot:1.7.0
   type: image
 - source: istio/pilot:1.7.1
@@ -5346,24 +3240,6 @@ sync:
   type: image
 - source: istio/pilot:1.8.3
   target: stgregistry.suse.com/rancher/istio-pilot:1.8.3
-  type: image
-- source: istio/pilot:1.7.0
-  target: stgregistry.suse.com/rancher/charts/istio-pilot:1.7.0
-  type: image
-- source: istio/pilot:1.7.1
-  target: stgregistry.suse.com/rancher/charts/istio-pilot:1.7.1
-  type: image
-- source: istio/pilot:1.7.3
-  target: stgregistry.suse.com/rancher/charts/istio-pilot:1.7.3
-  type: image
-- source: istio/pilot:1.7.6
-  target: stgregistry.suse.com/rancher/charts/istio-pilot:1.7.6
-  type: image
-- source: istio/pilot:1.8.1
-  target: stgregistry.suse.com/rancher/charts/istio-pilot:1.8.1
-  type: image
-- source: istio/pilot:1.8.3
-  target: stgregistry.suse.com/rancher/charts/istio-pilot:1.8.3
   type: image
 - source: istio/pilot:1.10.0
   target: docker.io/rancher/mirrored-istio-pilot:1.10.0
@@ -5714,180 +3590,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-istio-pilot:1.9.8
   type: image
 - source: istio/pilot:1.10.0
-  target: registry.suse.com/rancher/charts/mirrored-istio-pilot:1.10.0
-  type: image
-- source: istio/pilot:1.10.1
-  target: registry.suse.com/rancher/charts/mirrored-istio-pilot:1.10.1
-  type: image
-- source: istio/pilot:1.10.2
-  target: registry.suse.com/rancher/charts/mirrored-istio-pilot:1.10.2
-  type: image
-- source: istio/pilot:1.10.4
-  target: registry.suse.com/rancher/charts/mirrored-istio-pilot:1.10.4
-  type: image
-- source: istio/pilot:1.11.2
-  target: registry.suse.com/rancher/charts/mirrored-istio-pilot:1.11.2
-  type: image
-- source: istio/pilot:1.11.4
-  target: registry.suse.com/rancher/charts/mirrored-istio-pilot:1.11.4
-  type: image
-- source: istio/pilot:1.11.7
-  target: registry.suse.com/rancher/charts/mirrored-istio-pilot:1.11.7
-  type: image
-- source: istio/pilot:1.11.8
-  target: registry.suse.com/rancher/charts/mirrored-istio-pilot:1.11.8
-  type: image
-- source: istio/pilot:1.12.6
-  target: registry.suse.com/rancher/charts/mirrored-istio-pilot:1.12.6
-  type: image
-- source: istio/pilot:1.13.3
-  target: registry.suse.com/rancher/charts/mirrored-istio-pilot:1.13.3
-  type: image
-- source: istio/pilot:1.14.1
-  target: registry.suse.com/rancher/charts/mirrored-istio-pilot:1.14.1
-  type: image
-- source: istio/pilot:1.14.1-distroless
-  target: registry.suse.com/rancher/charts/mirrored-istio-pilot:1.14.1-distroless
-  type: image
-- source: istio/pilot:1.14.3
-  target: registry.suse.com/rancher/charts/mirrored-istio-pilot:1.14.3
-  type: image
-- source: istio/pilot:1.14.3-distroless
-  target: registry.suse.com/rancher/charts/mirrored-istio-pilot:1.14.3-distroless
-  type: image
-- source: istio/pilot:1.15.2
-  target: registry.suse.com/rancher/charts/mirrored-istio-pilot:1.15.2
-  type: image
-- source: istio/pilot:1.15.2-distroless
-  target: registry.suse.com/rancher/charts/mirrored-istio-pilot:1.15.2-distroless
-  type: image
-- source: istio/pilot:1.15.3
-  target: registry.suse.com/rancher/charts/mirrored-istio-pilot:1.15.3
-  type: image
-- source: istio/pilot:1.15.3-distroless
-  target: registry.suse.com/rancher/charts/mirrored-istio-pilot:1.15.3-distroless
-  type: image
-- source: istio/pilot:1.16.3
-  target: registry.suse.com/rancher/charts/mirrored-istio-pilot:1.16.3
-  type: image
-- source: istio/pilot:1.16.3-distroless
-  target: registry.suse.com/rancher/charts/mirrored-istio-pilot:1.16.3-distroless
-  type: image
-- source: istio/pilot:1.17.2
-  target: registry.suse.com/rancher/charts/mirrored-istio-pilot:1.17.2
-  type: image
-- source: istio/pilot:1.17.2-distroless
-  target: registry.suse.com/rancher/charts/mirrored-istio-pilot:1.17.2-distroless
-  type: image
-- source: istio/pilot:1.18.2
-  target: registry.suse.com/rancher/charts/mirrored-istio-pilot:1.18.2
-  type: image
-- source: istio/pilot:1.18.2-distroless
-  target: registry.suse.com/rancher/charts/mirrored-istio-pilot:1.18.2-distroless
-  type: image
-- source: istio/pilot:1.19.0
-  target: registry.suse.com/rancher/charts/mirrored-istio-pilot:1.19.0
-  type: image
-- source: istio/pilot:1.19.0-distroless
-  target: registry.suse.com/rancher/charts/mirrored-istio-pilot:1.19.0-distroless
-  type: image
-- source: istio/pilot:1.19.5
-  target: registry.suse.com/rancher/charts/mirrored-istio-pilot:1.19.5
-  type: image
-- source: istio/pilot:1.19.5-distroless
-  target: registry.suse.com/rancher/charts/mirrored-istio-pilot:1.19.5-distroless
-  type: image
-- source: istio/pilot:1.19.6
-  target: registry.suse.com/rancher/charts/mirrored-istio-pilot:1.19.6
-  type: image
-- source: istio/pilot:1.19.6-distroless
-  target: registry.suse.com/rancher/charts/mirrored-istio-pilot:1.19.6-distroless
-  type: image
-- source: istio/pilot:1.20.3
-  target: registry.suse.com/rancher/charts/mirrored-istio-pilot:1.20.3
-  type: image
-- source: istio/pilot:1.20.3-distroless
-  target: registry.suse.com/rancher/charts/mirrored-istio-pilot:1.20.3-distroless
-  type: image
-- source: istio/pilot:1.21.1
-  target: registry.suse.com/rancher/charts/mirrored-istio-pilot:1.21.1
-  type: image
-- source: istio/pilot:1.21.1-distroless
-  target: registry.suse.com/rancher/charts/mirrored-istio-pilot:1.21.1-distroless
-  type: image
-- source: istio/pilot:1.22.1
-  target: registry.suse.com/rancher/charts/mirrored-istio-pilot:1.22.1
-  type: image
-- source: istio/pilot:1.22.1-distroless
-  target: registry.suse.com/rancher/charts/mirrored-istio-pilot:1.22.1-distroless
-  type: image
-- source: istio/pilot:1.23.2
-  target: registry.suse.com/rancher/charts/mirrored-istio-pilot:1.23.2
-  type: image
-- source: istio/pilot:1.23.2-distroless
-  target: registry.suse.com/rancher/charts/mirrored-istio-pilot:1.23.2-distroless
-  type: image
-- source: istio/pilot:1.24.0
-  target: registry.suse.com/rancher/charts/mirrored-istio-pilot:1.24.0
-  type: image
-- source: istio/pilot:1.24.0-distroless
-  target: registry.suse.com/rancher/charts/mirrored-istio-pilot:1.24.0-distroless
-  type: image
-- source: istio/pilot:1.24.1
-  target: registry.suse.com/rancher/charts/mirrored-istio-pilot:1.24.1
-  type: image
-- source: istio/pilot:1.24.1-distroless
-  target: registry.suse.com/rancher/charts/mirrored-istio-pilot:1.24.1-distroless
-  type: image
-- source: istio/pilot:1.25.0
-  target: registry.suse.com/rancher/charts/mirrored-istio-pilot:1.25.0
-  type: image
-- source: istio/pilot:1.25.0-distroless
-  target: registry.suse.com/rancher/charts/mirrored-istio-pilot:1.25.0-distroless
-  type: image
-- source: istio/pilot:1.26.2
-  target: registry.suse.com/rancher/charts/mirrored-istio-pilot:1.26.2
-  type: image
-- source: istio/pilot:1.26.2-distroless
-  target: registry.suse.com/rancher/charts/mirrored-istio-pilot:1.26.2-distroless
-  type: image
-- source: istio/pilot:1.5.9
-  target: registry.suse.com/rancher/charts/mirrored-istio-pilot:1.5.9
-  type: image
-- source: istio/pilot:1.7.8
-  target: registry.suse.com/rancher/charts/mirrored-istio-pilot:1.7.8
-  type: image
-- source: istio/pilot:1.8.3
-  target: registry.suse.com/rancher/charts/mirrored-istio-pilot:1.8.3
-  type: image
-- source: istio/pilot:1.8.4
-  target: registry.suse.com/rancher/charts/mirrored-istio-pilot:1.8.4
-  type: image
-- source: istio/pilot:1.8.5
-  target: registry.suse.com/rancher/charts/mirrored-istio-pilot:1.8.5
-  type: image
-- source: istio/pilot:1.8.6
-  target: registry.suse.com/rancher/charts/mirrored-istio-pilot:1.8.6
-  type: image
-- source: istio/pilot:1.9.1
-  target: registry.suse.com/rancher/charts/mirrored-istio-pilot:1.9.1
-  type: image
-- source: istio/pilot:1.9.2
-  target: registry.suse.com/rancher/charts/mirrored-istio-pilot:1.9.2
-  type: image
-- source: istio/pilot:1.9.3
-  target: registry.suse.com/rancher/charts/mirrored-istio-pilot:1.9.3
-  type: image
-- source: istio/pilot:1.9.5
-  target: registry.suse.com/rancher/charts/mirrored-istio-pilot:1.9.5
-  type: image
-- source: istio/pilot:1.9.6
-  target: registry.suse.com/rancher/charts/mirrored-istio-pilot:1.9.6
-  type: image
-- source: istio/pilot:1.9.8
-  target: registry.suse.com/rancher/charts/mirrored-istio-pilot:1.9.8
-  type: image
-- source: istio/pilot:1.10.0
   target: stgregistry.suse.com/rancher/mirrored-istio-pilot:1.10.0
   type: image
 - source: istio/pilot:1.10.1
@@ -6061,180 +3763,6 @@ sync:
 - source: istio/pilot:1.9.8
   target: stgregistry.suse.com/rancher/mirrored-istio-pilot:1.9.8
   type: image
-- source: istio/pilot:1.10.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-pilot:1.10.0
-  type: image
-- source: istio/pilot:1.10.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-pilot:1.10.1
-  type: image
-- source: istio/pilot:1.10.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-pilot:1.10.2
-  type: image
-- source: istio/pilot:1.10.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-pilot:1.10.4
-  type: image
-- source: istio/pilot:1.11.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-pilot:1.11.2
-  type: image
-- source: istio/pilot:1.11.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-pilot:1.11.4
-  type: image
-- source: istio/pilot:1.11.7
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-pilot:1.11.7
-  type: image
-- source: istio/pilot:1.11.8
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-pilot:1.11.8
-  type: image
-- source: istio/pilot:1.12.6
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-pilot:1.12.6
-  type: image
-- source: istio/pilot:1.13.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-pilot:1.13.3
-  type: image
-- source: istio/pilot:1.14.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-pilot:1.14.1
-  type: image
-- source: istio/pilot:1.14.1-distroless
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-pilot:1.14.1-distroless
-  type: image
-- source: istio/pilot:1.14.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-pilot:1.14.3
-  type: image
-- source: istio/pilot:1.14.3-distroless
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-pilot:1.14.3-distroless
-  type: image
-- source: istio/pilot:1.15.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-pilot:1.15.2
-  type: image
-- source: istio/pilot:1.15.2-distroless
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-pilot:1.15.2-distroless
-  type: image
-- source: istio/pilot:1.15.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-pilot:1.15.3
-  type: image
-- source: istio/pilot:1.15.3-distroless
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-pilot:1.15.3-distroless
-  type: image
-- source: istio/pilot:1.16.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-pilot:1.16.3
-  type: image
-- source: istio/pilot:1.16.3-distroless
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-pilot:1.16.3-distroless
-  type: image
-- source: istio/pilot:1.17.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-pilot:1.17.2
-  type: image
-- source: istio/pilot:1.17.2-distroless
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-pilot:1.17.2-distroless
-  type: image
-- source: istio/pilot:1.18.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-pilot:1.18.2
-  type: image
-- source: istio/pilot:1.18.2-distroless
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-pilot:1.18.2-distroless
-  type: image
-- source: istio/pilot:1.19.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-pilot:1.19.0
-  type: image
-- source: istio/pilot:1.19.0-distroless
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-pilot:1.19.0-distroless
-  type: image
-- source: istio/pilot:1.19.5
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-pilot:1.19.5
-  type: image
-- source: istio/pilot:1.19.5-distroless
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-pilot:1.19.5-distroless
-  type: image
-- source: istio/pilot:1.19.6
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-pilot:1.19.6
-  type: image
-- source: istio/pilot:1.19.6-distroless
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-pilot:1.19.6-distroless
-  type: image
-- source: istio/pilot:1.20.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-pilot:1.20.3
-  type: image
-- source: istio/pilot:1.20.3-distroless
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-pilot:1.20.3-distroless
-  type: image
-- source: istio/pilot:1.21.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-pilot:1.21.1
-  type: image
-- source: istio/pilot:1.21.1-distroless
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-pilot:1.21.1-distroless
-  type: image
-- source: istio/pilot:1.22.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-pilot:1.22.1
-  type: image
-- source: istio/pilot:1.22.1-distroless
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-pilot:1.22.1-distroless
-  type: image
-- source: istio/pilot:1.23.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-pilot:1.23.2
-  type: image
-- source: istio/pilot:1.23.2-distroless
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-pilot:1.23.2-distroless
-  type: image
-- source: istio/pilot:1.24.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-pilot:1.24.0
-  type: image
-- source: istio/pilot:1.24.0-distroless
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-pilot:1.24.0-distroless
-  type: image
-- source: istio/pilot:1.24.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-pilot:1.24.1
-  type: image
-- source: istio/pilot:1.24.1-distroless
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-pilot:1.24.1-distroless
-  type: image
-- source: istio/pilot:1.25.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-pilot:1.25.0
-  type: image
-- source: istio/pilot:1.25.0-distroless
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-pilot:1.25.0-distroless
-  type: image
-- source: istio/pilot:1.26.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-pilot:1.26.2
-  type: image
-- source: istio/pilot:1.26.2-distroless
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-pilot:1.26.2-distroless
-  type: image
-- source: istio/pilot:1.5.9
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-pilot:1.5.9
-  type: image
-- source: istio/pilot:1.7.8
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-pilot:1.7.8
-  type: image
-- source: istio/pilot:1.8.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-pilot:1.8.3
-  type: image
-- source: istio/pilot:1.8.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-pilot:1.8.4
-  type: image
-- source: istio/pilot:1.8.5
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-pilot:1.8.5
-  type: image
-- source: istio/pilot:1.8.6
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-pilot:1.8.6
-  type: image
-- source: istio/pilot:1.9.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-pilot:1.9.1
-  type: image
-- source: istio/pilot:1.9.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-pilot:1.9.2
-  type: image
-- source: istio/pilot:1.9.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-pilot:1.9.3
-  type: image
-- source: istio/pilot:1.9.5
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-pilot:1.9.5
-  type: image
-- source: istio/pilot:1.9.6
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-pilot:1.9.6
-  type: image
-- source: istio/pilot:1.9.8
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-pilot:1.9.8
-  type: image
 - source: istio/proxyv2:1.7.0
   target: docker.io/rancher/istio-proxyv2:1.7.0
   type: image
@@ -6272,24 +3800,6 @@ sync:
   target: registry.suse.com/rancher/istio-proxyv2:1.8.3
   type: image
 - source: istio/proxyv2:1.7.0
-  target: registry.suse.com/rancher/charts/istio-proxyv2:1.7.0
-  type: image
-- source: istio/proxyv2:1.7.1
-  target: registry.suse.com/rancher/charts/istio-proxyv2:1.7.1
-  type: image
-- source: istio/proxyv2:1.7.3
-  target: registry.suse.com/rancher/charts/istio-proxyv2:1.7.3
-  type: image
-- source: istio/proxyv2:1.7.6
-  target: registry.suse.com/rancher/charts/istio-proxyv2:1.7.6
-  type: image
-- source: istio/proxyv2:1.8.1
-  target: registry.suse.com/rancher/charts/istio-proxyv2:1.8.1
-  type: image
-- source: istio/proxyv2:1.8.3
-  target: registry.suse.com/rancher/charts/istio-proxyv2:1.8.3
-  type: image
-- source: istio/proxyv2:1.7.0
   target: stgregistry.suse.com/rancher/istio-proxyv2:1.7.0
   type: image
 - source: istio/proxyv2:1.7.1
@@ -6306,24 +3816,6 @@ sync:
   type: image
 - source: istio/proxyv2:1.8.3
   target: stgregistry.suse.com/rancher/istio-proxyv2:1.8.3
-  type: image
-- source: istio/proxyv2:1.7.0
-  target: stgregistry.suse.com/rancher/charts/istio-proxyv2:1.7.0
-  type: image
-- source: istio/proxyv2:1.7.1
-  target: stgregistry.suse.com/rancher/charts/istio-proxyv2:1.7.1
-  type: image
-- source: istio/proxyv2:1.7.3
-  target: stgregistry.suse.com/rancher/charts/istio-proxyv2:1.7.3
-  type: image
-- source: istio/proxyv2:1.7.6
-  target: stgregistry.suse.com/rancher/charts/istio-proxyv2:1.7.6
-  type: image
-- source: istio/proxyv2:1.8.1
-  target: stgregistry.suse.com/rancher/charts/istio-proxyv2:1.8.1
-  type: image
-- source: istio/proxyv2:1.8.3
-  target: stgregistry.suse.com/rancher/charts/istio-proxyv2:1.8.3
   type: image
 - source: istio/proxyv2:1.10.0
   target: docker.io/rancher/mirrored-istio-proxyv2:1.10.0
@@ -6674,180 +4166,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-istio-proxyv2:1.9.8
   type: image
 - source: istio/proxyv2:1.10.0
-  target: registry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.10.0
-  type: image
-- source: istio/proxyv2:1.10.1
-  target: registry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.10.1
-  type: image
-- source: istio/proxyv2:1.10.2
-  target: registry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.10.2
-  type: image
-- source: istio/proxyv2:1.10.4
-  target: registry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.10.4
-  type: image
-- source: istio/proxyv2:1.11.2
-  target: registry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.11.2
-  type: image
-- source: istio/proxyv2:1.11.4
-  target: registry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.11.4
-  type: image
-- source: istio/proxyv2:1.11.7
-  target: registry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.11.7
-  type: image
-- source: istio/proxyv2:1.11.8
-  target: registry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.11.8
-  type: image
-- source: istio/proxyv2:1.12.6
-  target: registry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.12.6
-  type: image
-- source: istio/proxyv2:1.13.3
-  target: registry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.13.3
-  type: image
-- source: istio/proxyv2:1.14.1
-  target: registry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.14.1
-  type: image
-- source: istio/proxyv2:1.14.1-distroless
-  target: registry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.14.1-distroless
-  type: image
-- source: istio/proxyv2:1.14.3
-  target: registry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.14.3
-  type: image
-- source: istio/proxyv2:1.14.3-distroless
-  target: registry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.14.3-distroless
-  type: image
-- source: istio/proxyv2:1.15.2
-  target: registry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.15.2
-  type: image
-- source: istio/proxyv2:1.15.2-distroless
-  target: registry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.15.2-distroless
-  type: image
-- source: istio/proxyv2:1.15.3
-  target: registry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.15.3
-  type: image
-- source: istio/proxyv2:1.15.3-distroless
-  target: registry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.15.3-distroless
-  type: image
-- source: istio/proxyv2:1.16.3
-  target: registry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.16.3
-  type: image
-- source: istio/proxyv2:1.16.3-distroless
-  target: registry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.16.3-distroless
-  type: image
-- source: istio/proxyv2:1.17.2
-  target: registry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.17.2
-  type: image
-- source: istio/proxyv2:1.17.2-distroless
-  target: registry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.17.2-distroless
-  type: image
-- source: istio/proxyv2:1.18.2
-  target: registry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.18.2
-  type: image
-- source: istio/proxyv2:1.18.2-distroless
-  target: registry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.18.2-distroless
-  type: image
-- source: istio/proxyv2:1.19.0
-  target: registry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.19.0
-  type: image
-- source: istio/proxyv2:1.19.0-distroless
-  target: registry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.19.0-distroless
-  type: image
-- source: istio/proxyv2:1.19.5
-  target: registry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.19.5
-  type: image
-- source: istio/proxyv2:1.19.5-distroless
-  target: registry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.19.5-distroless
-  type: image
-- source: istio/proxyv2:1.19.6
-  target: registry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.19.6
-  type: image
-- source: istio/proxyv2:1.19.6-distroless
-  target: registry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.19.6-distroless
-  type: image
-- source: istio/proxyv2:1.20.3
-  target: registry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.20.3
-  type: image
-- source: istio/proxyv2:1.20.3-distroless
-  target: registry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.20.3-distroless
-  type: image
-- source: istio/proxyv2:1.21.1
-  target: registry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.21.1
-  type: image
-- source: istio/proxyv2:1.21.1-distroless
-  target: registry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.21.1-distroless
-  type: image
-- source: istio/proxyv2:1.22.1
-  target: registry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.22.1
-  type: image
-- source: istio/proxyv2:1.22.1-distroless
-  target: registry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.22.1-distroless
-  type: image
-- source: istio/proxyv2:1.23.2
-  target: registry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.23.2
-  type: image
-- source: istio/proxyv2:1.23.2-distroless
-  target: registry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.23.2-distroless
-  type: image
-- source: istio/proxyv2:1.24.0
-  target: registry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.24.0
-  type: image
-- source: istio/proxyv2:1.24.0-distroless
-  target: registry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.24.0-distroless
-  type: image
-- source: istio/proxyv2:1.24.1
-  target: registry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.24.1
-  type: image
-- source: istio/proxyv2:1.24.1-distroless
-  target: registry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.24.1-distroless
-  type: image
-- source: istio/proxyv2:1.25.0
-  target: registry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.25.0
-  type: image
-- source: istio/proxyv2:1.25.0-distroless
-  target: registry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.25.0-distroless
-  type: image
-- source: istio/proxyv2:1.26.2
-  target: registry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.26.2
-  type: image
-- source: istio/proxyv2:1.26.2-distroless
-  target: registry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.26.2-distroless
-  type: image
-- source: istio/proxyv2:1.5.9
-  target: registry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.5.9
-  type: image
-- source: istio/proxyv2:1.7.8
-  target: registry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.7.8
-  type: image
-- source: istio/proxyv2:1.8.3
-  target: registry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.8.3
-  type: image
-- source: istio/proxyv2:1.8.4
-  target: registry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.8.4
-  type: image
-- source: istio/proxyv2:1.8.5
-  target: registry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.8.5
-  type: image
-- source: istio/proxyv2:1.8.6
-  target: registry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.8.6
-  type: image
-- source: istio/proxyv2:1.9.1
-  target: registry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.9.1
-  type: image
-- source: istio/proxyv2:1.9.2
-  target: registry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.9.2
-  type: image
-- source: istio/proxyv2:1.9.3
-  target: registry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.9.3
-  type: image
-- source: istio/proxyv2:1.9.5
-  target: registry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.9.5
-  type: image
-- source: istio/proxyv2:1.9.6
-  target: registry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.9.6
-  type: image
-- source: istio/proxyv2:1.9.8
-  target: registry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.9.8
-  type: image
-- source: istio/proxyv2:1.10.0
   target: stgregistry.suse.com/rancher/mirrored-istio-proxyv2:1.10.0
   type: image
 - source: istio/proxyv2:1.10.1
@@ -7021,180 +4339,6 @@ sync:
 - source: istio/proxyv2:1.9.8
   target: stgregistry.suse.com/rancher/mirrored-istio-proxyv2:1.9.8
   type: image
-- source: istio/proxyv2:1.10.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.10.0
-  type: image
-- source: istio/proxyv2:1.10.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.10.1
-  type: image
-- source: istio/proxyv2:1.10.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.10.2
-  type: image
-- source: istio/proxyv2:1.10.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.10.4
-  type: image
-- source: istio/proxyv2:1.11.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.11.2
-  type: image
-- source: istio/proxyv2:1.11.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.11.4
-  type: image
-- source: istio/proxyv2:1.11.7
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.11.7
-  type: image
-- source: istio/proxyv2:1.11.8
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.11.8
-  type: image
-- source: istio/proxyv2:1.12.6
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.12.6
-  type: image
-- source: istio/proxyv2:1.13.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.13.3
-  type: image
-- source: istio/proxyv2:1.14.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.14.1
-  type: image
-- source: istio/proxyv2:1.14.1-distroless
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.14.1-distroless
-  type: image
-- source: istio/proxyv2:1.14.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.14.3
-  type: image
-- source: istio/proxyv2:1.14.3-distroless
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.14.3-distroless
-  type: image
-- source: istio/proxyv2:1.15.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.15.2
-  type: image
-- source: istio/proxyv2:1.15.2-distroless
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.15.2-distroless
-  type: image
-- source: istio/proxyv2:1.15.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.15.3
-  type: image
-- source: istio/proxyv2:1.15.3-distroless
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.15.3-distroless
-  type: image
-- source: istio/proxyv2:1.16.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.16.3
-  type: image
-- source: istio/proxyv2:1.16.3-distroless
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.16.3-distroless
-  type: image
-- source: istio/proxyv2:1.17.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.17.2
-  type: image
-- source: istio/proxyv2:1.17.2-distroless
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.17.2-distroless
-  type: image
-- source: istio/proxyv2:1.18.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.18.2
-  type: image
-- source: istio/proxyv2:1.18.2-distroless
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.18.2-distroless
-  type: image
-- source: istio/proxyv2:1.19.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.19.0
-  type: image
-- source: istio/proxyv2:1.19.0-distroless
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.19.0-distroless
-  type: image
-- source: istio/proxyv2:1.19.5
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.19.5
-  type: image
-- source: istio/proxyv2:1.19.5-distroless
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.19.5-distroless
-  type: image
-- source: istio/proxyv2:1.19.6
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.19.6
-  type: image
-- source: istio/proxyv2:1.19.6-distroless
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.19.6-distroless
-  type: image
-- source: istio/proxyv2:1.20.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.20.3
-  type: image
-- source: istio/proxyv2:1.20.3-distroless
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.20.3-distroless
-  type: image
-- source: istio/proxyv2:1.21.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.21.1
-  type: image
-- source: istio/proxyv2:1.21.1-distroless
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.21.1-distroless
-  type: image
-- source: istio/proxyv2:1.22.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.22.1
-  type: image
-- source: istio/proxyv2:1.22.1-distroless
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.22.1-distroless
-  type: image
-- source: istio/proxyv2:1.23.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.23.2
-  type: image
-- source: istio/proxyv2:1.23.2-distroless
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.23.2-distroless
-  type: image
-- source: istio/proxyv2:1.24.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.24.0
-  type: image
-- source: istio/proxyv2:1.24.0-distroless
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.24.0-distroless
-  type: image
-- source: istio/proxyv2:1.24.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.24.1
-  type: image
-- source: istio/proxyv2:1.24.1-distroless
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.24.1-distroless
-  type: image
-- source: istio/proxyv2:1.25.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.25.0
-  type: image
-- source: istio/proxyv2:1.25.0-distroless
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.25.0-distroless
-  type: image
-- source: istio/proxyv2:1.26.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.26.2
-  type: image
-- source: istio/proxyv2:1.26.2-distroless
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.26.2-distroless
-  type: image
-- source: istio/proxyv2:1.5.9
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.5.9
-  type: image
-- source: istio/proxyv2:1.7.8
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.7.8
-  type: image
-- source: istio/proxyv2:1.8.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.8.3
-  type: image
-- source: istio/proxyv2:1.8.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.8.4
-  type: image
-- source: istio/proxyv2:1.8.5
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.8.5
-  type: image
-- source: istio/proxyv2:1.8.6
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.8.6
-  type: image
-- source: istio/proxyv2:1.9.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.9.1
-  type: image
-- source: istio/proxyv2:1.9.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.9.2
-  type: image
-- source: istio/proxyv2:1.9.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.9.3
-  type: image
-- source: istio/proxyv2:1.9.5
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.9.5
-  type: image
-- source: istio/proxyv2:1.9.6
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.9.6
-  type: image
-- source: istio/proxyv2:1.9.8
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-proxyv2:1.9.8
-  type: image
 - source: istio/sidecar_injector:1.5.9
   target: docker.io/rancher/mirrored-istio-sidecar_injector:1.5.9
   type: image
@@ -7202,13 +4346,7 @@ sync:
   target: registry.suse.com/rancher/mirrored-istio-sidecar_injector:1.5.9
   type: image
 - source: istio/sidecar_injector:1.5.9
-  target: registry.suse.com/rancher/charts/mirrored-istio-sidecar_injector:1.5.9
-  type: image
-- source: istio/sidecar_injector:1.5.9
   target: stgregistry.suse.com/rancher/mirrored-istio-sidecar_injector:1.5.9
-  type: image
-- source: istio/sidecar_injector:1.5.9
-  target: stgregistry.suse.com/rancher/charts/mirrored-istio-sidecar_injector:1.5.9
   type: image
 - source: jaegertracing/all-in-one:1.20.0
   target: docker.io/rancher/jaegertracing-all-in-one:1.20.0
@@ -7217,13 +4355,7 @@ sync:
   target: registry.suse.com/rancher/jaegertracing-all-in-one:1.20.0
   type: image
 - source: jaegertracing/all-in-one:1.20.0
-  target: registry.suse.com/rancher/charts/jaegertracing-all-in-one:1.20.0
-  type: image
-- source: jaegertracing/all-in-one:1.20.0
   target: stgregistry.suse.com/rancher/jaegertracing-all-in-one:1.20.0
-  type: image
-- source: jaegertracing/all-in-one:1.20.0
-  target: stgregistry.suse.com/rancher/charts/jaegertracing-all-in-one:1.20.0
   type: image
 - source: jaegertracing/all-in-one:1.14
   target: docker.io/rancher/mirrored-jaegertracing-all-in-one:1.14
@@ -7364,75 +4496,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-jaegertracing-all-in-one:1.71.0
   type: image
 - source: jaegertracing/all-in-one:1.14
-  target: registry.suse.com/rancher/charts/mirrored-jaegertracing-all-in-one:1.14
-  type: image
-- source: jaegertracing/all-in-one:1.20.0
-  target: registry.suse.com/rancher/charts/mirrored-jaegertracing-all-in-one:1.20.0
-  type: image
-- source: jaegertracing/all-in-one:1.26.0
-  target: registry.suse.com/rancher/charts/mirrored-jaegertracing-all-in-one:1.26.0
-  type: image
-- source: jaegertracing/all-in-one:1.27.0
-  target: registry.suse.com/rancher/charts/mirrored-jaegertracing-all-in-one:1.27.0
-  type: image
-- source: jaegertracing/all-in-one:1.31.0
-  target: registry.suse.com/rancher/charts/mirrored-jaegertracing-all-in-one:1.31.0
-  type: image
-- source: jaegertracing/all-in-one:1.32.0
-  target: registry.suse.com/rancher/charts/mirrored-jaegertracing-all-in-one:1.32.0
-  type: image
-- source: jaegertracing/all-in-one:1.33.0
-  target: registry.suse.com/rancher/charts/mirrored-jaegertracing-all-in-one:1.33.0
-  type: image
-- source: jaegertracing/all-in-one:1.35.1
-  target: registry.suse.com/rancher/charts/mirrored-jaegertracing-all-in-one:1.35.1
-  type: image
-- source: jaegertracing/all-in-one:1.37.0
-  target: registry.suse.com/rancher/charts/mirrored-jaegertracing-all-in-one:1.37.0
-  type: image
-- source: jaegertracing/all-in-one:1.38.1
-  target: registry.suse.com/rancher/charts/mirrored-jaegertracing-all-in-one:1.38.1
-  type: image
-- source: jaegertracing/all-in-one:1.39.0
-  target: registry.suse.com/rancher/charts/mirrored-jaegertracing-all-in-one:1.39.0
-  type: image
-- source: jaegertracing/all-in-one:1.42.0
-  target: registry.suse.com/rancher/charts/mirrored-jaegertracing-all-in-one:1.42.0
-  type: image
-- source: jaegertracing/all-in-one:1.43.0
-  target: registry.suse.com/rancher/charts/mirrored-jaegertracing-all-in-one:1.43.0
-  type: image
-- source: jaegertracing/all-in-one:1.47.0
-  target: registry.suse.com/rancher/charts/mirrored-jaegertracing-all-in-one:1.47.0
-  type: image
-- source: jaegertracing/all-in-one:1.49.0
-  target: registry.suse.com/rancher/charts/mirrored-jaegertracing-all-in-one:1.49.0
-  type: image
-- source: jaegertracing/all-in-one:1.52.0
-  target: registry.suse.com/rancher/charts/mirrored-jaegertracing-all-in-one:1.52.0
-  type: image
-- source: jaegertracing/all-in-one:1.53.0
-  target: registry.suse.com/rancher/charts/mirrored-jaegertracing-all-in-one:1.53.0
-  type: image
-- source: jaegertracing/all-in-one:1.56.0
-  target: registry.suse.com/rancher/charts/mirrored-jaegertracing-all-in-one:1.56.0
-  type: image
-- source: jaegertracing/all-in-one:1.57.0
-  target: registry.suse.com/rancher/charts/mirrored-jaegertracing-all-in-one:1.57.0
-  type: image
-- source: jaegertracing/all-in-one:1.60.0
-  target: registry.suse.com/rancher/charts/mirrored-jaegertracing-all-in-one:1.60.0
-  type: image
-- source: jaegertracing/all-in-one:1.63.0
-  target: registry.suse.com/rancher/charts/mirrored-jaegertracing-all-in-one:1.63.0
-  type: image
-- source: jaegertracing/all-in-one:1.67.0
-  target: registry.suse.com/rancher/charts/mirrored-jaegertracing-all-in-one:1.67.0
-  type: image
-- source: jaegertracing/all-in-one:1.71.0
-  target: registry.suse.com/rancher/charts/mirrored-jaegertracing-all-in-one:1.71.0
-  type: image
-- source: jaegertracing/all-in-one:1.14
   target: stgregistry.suse.com/rancher/mirrored-jaegertracing-all-in-one:1.14
   type: image
 - source: jaegertracing/all-in-one:1.20.0
@@ -7501,75 +4564,6 @@ sync:
 - source: jaegertracing/all-in-one:1.71.0
   target: stgregistry.suse.com/rancher/mirrored-jaegertracing-all-in-one:1.71.0
   type: image
-- source: jaegertracing/all-in-one:1.14
-  target: stgregistry.suse.com/rancher/charts/mirrored-jaegertracing-all-in-one:1.14
-  type: image
-- source: jaegertracing/all-in-one:1.20.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-jaegertracing-all-in-one:1.20.0
-  type: image
-- source: jaegertracing/all-in-one:1.26.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-jaegertracing-all-in-one:1.26.0
-  type: image
-- source: jaegertracing/all-in-one:1.27.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-jaegertracing-all-in-one:1.27.0
-  type: image
-- source: jaegertracing/all-in-one:1.31.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-jaegertracing-all-in-one:1.31.0
-  type: image
-- source: jaegertracing/all-in-one:1.32.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-jaegertracing-all-in-one:1.32.0
-  type: image
-- source: jaegertracing/all-in-one:1.33.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-jaegertracing-all-in-one:1.33.0
-  type: image
-- source: jaegertracing/all-in-one:1.35.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-jaegertracing-all-in-one:1.35.1
-  type: image
-- source: jaegertracing/all-in-one:1.37.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-jaegertracing-all-in-one:1.37.0
-  type: image
-- source: jaegertracing/all-in-one:1.38.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-jaegertracing-all-in-one:1.38.1
-  type: image
-- source: jaegertracing/all-in-one:1.39.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-jaegertracing-all-in-one:1.39.0
-  type: image
-- source: jaegertracing/all-in-one:1.42.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-jaegertracing-all-in-one:1.42.0
-  type: image
-- source: jaegertracing/all-in-one:1.43.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-jaegertracing-all-in-one:1.43.0
-  type: image
-- source: jaegertracing/all-in-one:1.47.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-jaegertracing-all-in-one:1.47.0
-  type: image
-- source: jaegertracing/all-in-one:1.49.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-jaegertracing-all-in-one:1.49.0
-  type: image
-- source: jaegertracing/all-in-one:1.52.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-jaegertracing-all-in-one:1.52.0
-  type: image
-- source: jaegertracing/all-in-one:1.53.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-jaegertracing-all-in-one:1.53.0
-  type: image
-- source: jaegertracing/all-in-one:1.56.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-jaegertracing-all-in-one:1.56.0
-  type: image
-- source: jaegertracing/all-in-one:1.57.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-jaegertracing-all-in-one:1.57.0
-  type: image
-- source: jaegertracing/all-in-one:1.60.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-jaegertracing-all-in-one:1.60.0
-  type: image
-- source: jaegertracing/all-in-one:1.63.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-jaegertracing-all-in-one:1.63.0
-  type: image
-- source: jaegertracing/all-in-one:1.67.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-jaegertracing-all-in-one:1.67.0
-  type: image
-- source: jaegertracing/all-in-one:1.71.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-jaegertracing-all-in-one:1.71.0
-  type: image
 - source: jenkins/jnlp-slave:3.35-4
   target: docker.io/rancher/mirrored-jenkins-jnlp-slave:3.35-4
   type: image
@@ -7583,22 +4577,10 @@ sync:
   target: registry.suse.com/rancher/mirrored-jenkins-jnlp-slave:4.7-1
   type: image
 - source: jenkins/jnlp-slave:3.35-4
-  target: registry.suse.com/rancher/charts/mirrored-jenkins-jnlp-slave:3.35-4
-  type: image
-- source: jenkins/jnlp-slave:4.7-1
-  target: registry.suse.com/rancher/charts/mirrored-jenkins-jnlp-slave:4.7-1
-  type: image
-- source: jenkins/jnlp-slave:3.35-4
   target: stgregistry.suse.com/rancher/mirrored-jenkins-jnlp-slave:3.35-4
   type: image
 - source: jenkins/jnlp-slave:4.7-1
   target: stgregistry.suse.com/rancher/mirrored-jenkins-jnlp-slave:4.7-1
-  type: image
-- source: jenkins/jnlp-slave:3.35-4
-  target: stgregistry.suse.com/rancher/charts/mirrored-jenkins-jnlp-slave:3.35-4
-  type: image
-- source: jenkins/jnlp-slave:4.7-1
-  target: stgregistry.suse.com/rancher/charts/mirrored-jenkins-jnlp-slave:4.7-1
   type: image
 - source: jettech/kube-webhook-certgen:v1.2.1
   target: docker.io/rancher/jettech-kube-webhook-certgen:v1.2.1
@@ -7613,22 +4595,10 @@ sync:
   target: registry.suse.com/rancher/jettech-kube-webhook-certgen:v1.5.0
   type: image
 - source: jettech/kube-webhook-certgen:v1.2.1
-  target: registry.suse.com/rancher/charts/jettech-kube-webhook-certgen:v1.2.1
-  type: image
-- source: jettech/kube-webhook-certgen:v1.5.0
-  target: registry.suse.com/rancher/charts/jettech-kube-webhook-certgen:v1.5.0
-  type: image
-- source: jettech/kube-webhook-certgen:v1.2.1
   target: stgregistry.suse.com/rancher/jettech-kube-webhook-certgen:v1.2.1
   type: image
 - source: jettech/kube-webhook-certgen:v1.5.0
   target: stgregistry.suse.com/rancher/jettech-kube-webhook-certgen:v1.5.0
-  type: image
-- source: jettech/kube-webhook-certgen:v1.2.1
-  target: stgregistry.suse.com/rancher/charts/jettech-kube-webhook-certgen:v1.2.1
-  type: image
-- source: jettech/kube-webhook-certgen:v1.5.0
-  target: stgregistry.suse.com/rancher/charts/jettech-kube-webhook-certgen:v1.5.0
   type: image
 - source: jettech/kube-webhook-certgen:v1.2.1
   target: docker.io/rancher/mirrored-jettech-kube-webhook-certgen:v1.2.1
@@ -7655,18 +4625,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-jettech-kube-webhook-certgen:v1.5.2
   type: image
 - source: jettech/kube-webhook-certgen:v1.2.1
-  target: registry.suse.com/rancher/charts/mirrored-jettech-kube-webhook-certgen:v1.2.1
-  type: image
-- source: jettech/kube-webhook-certgen:v1.5.0
-  target: registry.suse.com/rancher/charts/mirrored-jettech-kube-webhook-certgen:v1.5.0
-  type: image
-- source: jettech/kube-webhook-certgen:v1.5.1
-  target: registry.suse.com/rancher/charts/mirrored-jettech-kube-webhook-certgen:v1.5.1
-  type: image
-- source: jettech/kube-webhook-certgen:v1.5.2
-  target: registry.suse.com/rancher/charts/mirrored-jettech-kube-webhook-certgen:v1.5.2
-  type: image
-- source: jettech/kube-webhook-certgen:v1.2.1
   target: stgregistry.suse.com/rancher/mirrored-jettech-kube-webhook-certgen:v1.2.1
   type: image
 - source: jettech/kube-webhook-certgen:v1.5.0
@@ -7677,18 +4635,6 @@ sync:
   type: image
 - source: jettech/kube-webhook-certgen:v1.5.2
   target: stgregistry.suse.com/rancher/mirrored-jettech-kube-webhook-certgen:v1.5.2
-  type: image
-- source: jettech/kube-webhook-certgen:v1.2.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-jettech-kube-webhook-certgen:v1.2.1
-  type: image
-- source: jettech/kube-webhook-certgen:v1.5.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-jettech-kube-webhook-certgen:v1.5.0
-  type: image
-- source: jettech/kube-webhook-certgen:v1.5.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-jettech-kube-webhook-certgen:v1.5.1
-  type: image
-- source: jettech/kube-webhook-certgen:v1.5.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-jettech-kube-webhook-certgen:v1.5.2
   type: image
 - source: jimmidyson/configmap-reload:v0.3.0
   target: docker.io/rancher/jimmidyson-configmap-reload:v0.3.0
@@ -7703,22 +4649,10 @@ sync:
   target: registry.suse.com/rancher/jimmidyson-configmap-reload:v0.4.0
   type: image
 - source: jimmidyson/configmap-reload:v0.3.0
-  target: registry.suse.com/rancher/charts/jimmidyson-configmap-reload:v0.3.0
-  type: image
-- source: jimmidyson/configmap-reload:v0.4.0
-  target: registry.suse.com/rancher/charts/jimmidyson-configmap-reload:v0.4.0
-  type: image
-- source: jimmidyson/configmap-reload:v0.3.0
   target: stgregistry.suse.com/rancher/jimmidyson-configmap-reload:v0.3.0
   type: image
 - source: jimmidyson/configmap-reload:v0.4.0
   target: stgregistry.suse.com/rancher/jimmidyson-configmap-reload:v0.4.0
-  type: image
-- source: jimmidyson/configmap-reload:v0.3.0
-  target: stgregistry.suse.com/rancher/charts/jimmidyson-configmap-reload:v0.3.0
-  type: image
-- source: jimmidyson/configmap-reload:v0.4.0
-  target: stgregistry.suse.com/rancher/charts/jimmidyson-configmap-reload:v0.4.0
   type: image
 - source: jimmidyson/configmap-reload:v0.3.0
   target: docker.io/rancher/mirrored-jimmidyson-configmap-reload:v0.3.0
@@ -7739,15 +4673,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-jimmidyson-configmap-reload:v0.8.0
   type: image
 - source: jimmidyson/configmap-reload:v0.3.0
-  target: registry.suse.com/rancher/charts/mirrored-jimmidyson-configmap-reload:v0.3.0
-  type: image
-- source: jimmidyson/configmap-reload:v0.4.0
-  target: registry.suse.com/rancher/charts/mirrored-jimmidyson-configmap-reload:v0.4.0
-  type: image
-- source: jimmidyson/configmap-reload:v0.8.0
-  target: registry.suse.com/rancher/charts/mirrored-jimmidyson-configmap-reload:v0.8.0
-  type: image
-- source: jimmidyson/configmap-reload:v0.3.0
   target: stgregistry.suse.com/rancher/mirrored-jimmidyson-configmap-reload:v0.3.0
   type: image
 - source: jimmidyson/configmap-reload:v0.4.0
@@ -7755,15 +4680,6 @@ sync:
   type: image
 - source: jimmidyson/configmap-reload:v0.8.0
   target: stgregistry.suse.com/rancher/mirrored-jimmidyson-configmap-reload:v0.8.0
-  type: image
-- source: jimmidyson/configmap-reload:v0.3.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-jimmidyson-configmap-reload:v0.3.0
-  type: image
-- source: jimmidyson/configmap-reload:v0.4.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-jimmidyson-configmap-reload:v0.4.0
-  type: image
-- source: jimmidyson/configmap-reload:v0.8.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-jimmidyson-configmap-reload:v0.8.0
   type: image
 - source: kiwigrid/k8s-sidecar:0.1.151
   target: docker.io/rancher/kiwigrid-k8s-sidecar:0.1.151
@@ -7778,22 +4694,10 @@ sync:
   target: registry.suse.com/rancher/kiwigrid-k8s-sidecar:1.1.0
   type: image
 - source: kiwigrid/k8s-sidecar:0.1.151
-  target: registry.suse.com/rancher/charts/kiwigrid-k8s-sidecar:0.1.151
-  type: image
-- source: kiwigrid/k8s-sidecar:1.1.0
-  target: registry.suse.com/rancher/charts/kiwigrid-k8s-sidecar:1.1.0
-  type: image
-- source: kiwigrid/k8s-sidecar:0.1.151
   target: stgregistry.suse.com/rancher/kiwigrid-k8s-sidecar:0.1.151
   type: image
 - source: kiwigrid/k8s-sidecar:1.1.0
   target: stgregistry.suse.com/rancher/kiwigrid-k8s-sidecar:1.1.0
-  type: image
-- source: kiwigrid/k8s-sidecar:0.1.151
-  target: stgregistry.suse.com/rancher/charts/kiwigrid-k8s-sidecar:0.1.151
-  type: image
-- source: kiwigrid/k8s-sidecar:1.1.0
-  target: stgregistry.suse.com/rancher/charts/kiwigrid-k8s-sidecar:1.1.0
   type: image
 - source: kiwigrid/k8s-sidecar:0.1.151
   target: docker.io/rancher/mirrored-kiwigrid-k8s-sidecar:0.1.151
@@ -7808,22 +4712,10 @@ sync:
   target: registry.suse.com/rancher/mirrored-kiwigrid-k8s-sidecar:1.27.4
   type: image
 - source: kiwigrid/k8s-sidecar:0.1.151
-  target: registry.suse.com/rancher/charts/mirrored-kiwigrid-k8s-sidecar:0.1.151
-  type: image
-- source: kiwigrid/k8s-sidecar:1.27.4
-  target: registry.suse.com/rancher/charts/mirrored-kiwigrid-k8s-sidecar:1.27.4
-  type: image
-- source: kiwigrid/k8s-sidecar:0.1.151
   target: stgregistry.suse.com/rancher/mirrored-kiwigrid-k8s-sidecar:0.1.151
   type: image
 - source: kiwigrid/k8s-sidecar:1.27.4
   target: stgregistry.suse.com/rancher/mirrored-kiwigrid-k8s-sidecar:1.27.4
-  type: image
-- source: kiwigrid/k8s-sidecar:0.1.151
-  target: stgregistry.suse.com/rancher/charts/mirrored-kiwigrid-k8s-sidecar:0.1.151
-  type: image
-- source: kiwigrid/k8s-sidecar:1.27.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-kiwigrid-k8s-sidecar:1.27.4
   type: image
 - source: library/busybox:1.31.1
   target: docker.io/rancher/library-busybox:1.31.1
@@ -7838,22 +4730,10 @@ sync:
   target: registry.suse.com/rancher/library-busybox:1.32.1
   type: image
 - source: library/busybox:1.31.1
-  target: registry.suse.com/rancher/charts/library-busybox:1.31.1
-  type: image
-- source: library/busybox:1.32.1
-  target: registry.suse.com/rancher/charts/library-busybox:1.32.1
-  type: image
-- source: library/busybox:1.31.1
   target: stgregistry.suse.com/rancher/library-busybox:1.31.1
   type: image
 - source: library/busybox:1.32.1
   target: stgregistry.suse.com/rancher/library-busybox:1.32.1
-  type: image
-- source: library/busybox:1.31.1
-  target: stgregistry.suse.com/rancher/charts/library-busybox:1.31.1
-  type: image
-- source: library/busybox:1.32.1
-  target: stgregistry.suse.com/rancher/charts/library-busybox:1.32.1
   type: image
 - source: library/busybox:1.31.1
   target: docker.io/rancher/mirrored-library-busybox:1.31.1
@@ -7886,21 +4766,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-library-busybox:1.37.0
   type: image
 - source: library/busybox:1.31.1
-  target: registry.suse.com/rancher/charts/mirrored-library-busybox:1.31.1
-  type: image
-- source: library/busybox:1.32.1
-  target: registry.suse.com/rancher/charts/mirrored-library-busybox:1.32.1
-  type: image
-- source: library/busybox:1.34.1
-  target: registry.suse.com/rancher/charts/mirrored-library-busybox:1.34.1
-  type: image
-- source: library/busybox:1.36.1
-  target: registry.suse.com/rancher/charts/mirrored-library-busybox:1.36.1
-  type: image
-- source: library/busybox:1.37.0
-  target: registry.suse.com/rancher/charts/mirrored-library-busybox:1.37.0
-  type: image
-- source: library/busybox:1.31.1
   target: stgregistry.suse.com/rancher/mirrored-library-busybox:1.31.1
   type: image
 - source: library/busybox:1.32.1
@@ -7915,21 +4780,6 @@ sync:
 - source: library/busybox:1.37.0
   target: stgregistry.suse.com/rancher/mirrored-library-busybox:1.37.0
   type: image
-- source: library/busybox:1.31.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-library-busybox:1.31.1
-  type: image
-- source: library/busybox:1.32.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-library-busybox:1.32.1
-  type: image
-- source: library/busybox:1.34.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-library-busybox:1.34.1
-  type: image
-- source: library/busybox:1.36.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-library-busybox:1.36.1
-  type: image
-- source: library/busybox:1.37.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-library-busybox:1.37.0
-  type: image
 - source: library/nginx:1.19.2-alpine
   target: docker.io/rancher/library-nginx:1.19.2-alpine
   type: image
@@ -7937,13 +4787,7 @@ sync:
   target: registry.suse.com/rancher/library-nginx:1.19.2-alpine
   type: image
 - source: library/nginx:1.19.2-alpine
-  target: registry.suse.com/rancher/charts/library-nginx:1.19.2-alpine
-  type: image
-- source: library/nginx:1.19.2-alpine
   target: stgregistry.suse.com/rancher/library-nginx:1.19.2-alpine
-  type: image
-- source: library/nginx:1.19.2-alpine
-  target: stgregistry.suse.com/rancher/charts/library-nginx:1.19.2-alpine
   type: image
 - source: library/nginx:1.19.2-alpine
   target: docker.io/rancher/mirrored-library-nginx:1.19.2-alpine
@@ -8006,36 +4850,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-library-nginx:1.29.1-alpine
   type: image
 - source: library/nginx:1.19.2-alpine
-  target: registry.suse.com/rancher/charts/mirrored-library-nginx:1.19.2-alpine
-  type: image
-- source: library/nginx:1.19.9-alpine
-  target: registry.suse.com/rancher/charts/mirrored-library-nginx:1.19.9-alpine
-  type: image
-- source: library/nginx:1.21.0-alpine
-  target: registry.suse.com/rancher/charts/mirrored-library-nginx:1.21.0-alpine
-  type: image
-- source: library/nginx:1.21.1-alpine
-  target: registry.suse.com/rancher/charts/mirrored-library-nginx:1.21.1-alpine
-  type: image
-- source: library/nginx:1.21.6-alpine
-  target: registry.suse.com/rancher/charts/mirrored-library-nginx:1.21.6-alpine
-  type: image
-- source: library/nginx:1.23.0-alpine
-  target: registry.suse.com/rancher/charts/mirrored-library-nginx:1.23.0-alpine
-  type: image
-- source: library/nginx:1.23.2-alpine
-  target: registry.suse.com/rancher/charts/mirrored-library-nginx:1.23.2-alpine
-  type: image
-- source: library/nginx:1.24.0-alpine
-  target: registry.suse.com/rancher/charts/mirrored-library-nginx:1.24.0-alpine
-  type: image
-- source: library/nginx:1.27.2-alpine
-  target: registry.suse.com/rancher/charts/mirrored-library-nginx:1.27.2-alpine
-  type: image
-- source: library/nginx:1.29.1-alpine
-  target: registry.suse.com/rancher/charts/mirrored-library-nginx:1.29.1-alpine
-  type: image
-- source: library/nginx:1.19.2-alpine
   target: stgregistry.suse.com/rancher/mirrored-library-nginx:1.19.2-alpine
   type: image
 - source: library/nginx:1.19.9-alpine
@@ -8065,36 +4879,6 @@ sync:
 - source: library/nginx:1.29.1-alpine
   target: stgregistry.suse.com/rancher/mirrored-library-nginx:1.29.1-alpine
   type: image
-- source: library/nginx:1.19.2-alpine
-  target: stgregistry.suse.com/rancher/charts/mirrored-library-nginx:1.19.2-alpine
-  type: image
-- source: library/nginx:1.19.9-alpine
-  target: stgregistry.suse.com/rancher/charts/mirrored-library-nginx:1.19.9-alpine
-  type: image
-- source: library/nginx:1.21.0-alpine
-  target: stgregistry.suse.com/rancher/charts/mirrored-library-nginx:1.21.0-alpine
-  type: image
-- source: library/nginx:1.21.1-alpine
-  target: stgregistry.suse.com/rancher/charts/mirrored-library-nginx:1.21.1-alpine
-  type: image
-- source: library/nginx:1.21.6-alpine
-  target: stgregistry.suse.com/rancher/charts/mirrored-library-nginx:1.21.6-alpine
-  type: image
-- source: library/nginx:1.23.0-alpine
-  target: stgregistry.suse.com/rancher/charts/mirrored-library-nginx:1.23.0-alpine
-  type: image
-- source: library/nginx:1.23.2-alpine
-  target: stgregistry.suse.com/rancher/charts/mirrored-library-nginx:1.23.2-alpine
-  type: image
-- source: library/nginx:1.24.0-alpine
-  target: stgregistry.suse.com/rancher/charts/mirrored-library-nginx:1.24.0-alpine
-  type: image
-- source: library/nginx:1.27.2-alpine
-  target: stgregistry.suse.com/rancher/charts/mirrored-library-nginx:1.27.2-alpine
-  type: image
-- source: library/nginx:1.29.1-alpine
-  target: stgregistry.suse.com/rancher/charts/mirrored-library-nginx:1.29.1-alpine
-  type: image
 - source: library/redis:7.2.9
   target: docker.io/rancher/mirrored-library-redis:7.2.9
   type: image
@@ -8102,13 +4886,7 @@ sync:
   target: registry.suse.com/rancher/mirrored-library-redis:7.2.9
   type: image
 - source: library/redis:7.2.9
-  target: registry.suse.com/rancher/charts/mirrored-library-redis:7.2.9
-  type: image
-- source: library/redis:7.2.9
   target: stgregistry.suse.com/rancher/mirrored-library-redis:7.2.9
-  type: image
-- source: library/redis:7.2.9
-  target: stgregistry.suse.com/rancher/charts/mirrored-library-redis:7.2.9
   type: image
 - source: library/registry:2.7.1
   target: docker.io/rancher/mirrored-library-registry:2.7.1
@@ -8123,22 +4901,10 @@ sync:
   target: registry.suse.com/rancher/mirrored-library-registry:2.8.1
   type: image
 - source: library/registry:2.7.1
-  target: registry.suse.com/rancher/charts/mirrored-library-registry:2.7.1
-  type: image
-- source: library/registry:2.8.1
-  target: registry.suse.com/rancher/charts/mirrored-library-registry:2.8.1
-  type: image
-- source: library/registry:2.7.1
   target: stgregistry.suse.com/rancher/mirrored-library-registry:2.7.1
   type: image
 - source: library/registry:2.8.1
   target: stgregistry.suse.com/rancher/mirrored-library-registry:2.8.1
-  type: image
-- source: library/registry:2.7.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-library-registry:2.7.1
-  type: image
-- source: library/registry:2.8.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-library-registry:2.8.1
   type: image
 - source: library/traefik:2.4.2
   target: docker.io/rancher/library-traefik:2.4.2
@@ -8159,15 +4925,6 @@ sync:
   target: registry.suse.com/rancher/library-traefik:2.4.9
   type: image
 - source: library/traefik:2.4.2
-  target: registry.suse.com/rancher/charts/library-traefik:2.4.2
-  type: image
-- source: library/traefik:2.4.8
-  target: registry.suse.com/rancher/charts/library-traefik:2.4.8
-  type: image
-- source: library/traefik:2.4.9
-  target: registry.suse.com/rancher/charts/library-traefik:2.4.9
-  type: image
-- source: library/traefik:2.4.2
   target: stgregistry.suse.com/rancher/library-traefik:2.4.2
   type: image
 - source: library/traefik:2.4.8
@@ -8175,15 +4932,6 @@ sync:
   type: image
 - source: library/traefik:2.4.9
   target: stgregistry.suse.com/rancher/library-traefik:2.4.9
-  type: image
-- source: library/traefik:2.4.2
-  target: stgregistry.suse.com/rancher/charts/library-traefik:2.4.2
-  type: image
-- source: library/traefik:2.4.8
-  target: stgregistry.suse.com/rancher/charts/library-traefik:2.4.8
-  type: image
-- source: library/traefik:2.4.9
-  target: stgregistry.suse.com/rancher/charts/library-traefik:2.4.9
   type: image
 - source: library/traefik:2.10.5
   target: docker.io/rancher/mirrored-library-traefik:2.10.5
@@ -8354,90 +5102,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-library-traefik:3.5.3
   type: image
 - source: library/traefik:2.10.5
-  target: registry.suse.com/rancher/charts/mirrored-library-traefik:2.10.5
-  type: image
-- source: library/traefik:2.10.7
-  target: registry.suse.com/rancher/charts/mirrored-library-traefik:2.10.7
-  type: image
-- source: library/traefik:2.11.10
-  target: registry.suse.com/rancher/charts/mirrored-library-traefik:2.11.10
-  type: image
-- source: library/traefik:2.11.11
-  target: registry.suse.com/rancher/charts/mirrored-library-traefik:2.11.11
-  type: image
-- source: library/traefik:2.11.16
-  target: registry.suse.com/rancher/charts/mirrored-library-traefik:2.11.16
-  type: image
-- source: library/traefik:2.11.17
-  target: registry.suse.com/rancher/charts/mirrored-library-traefik:2.11.17
-  type: image
-- source: library/traefik:2.11.18
-  target: registry.suse.com/rancher/charts/mirrored-library-traefik:2.11.18
-  type: image
-- source: library/traefik:2.11.20
-  target: registry.suse.com/rancher/charts/mirrored-library-traefik:2.11.20
-  type: image
-- source: library/traefik:2.11.22
-  target: registry.suse.com/rancher/charts/mirrored-library-traefik:2.11.22
-  type: image
-- source: library/traefik:2.11.24
-  target: registry.suse.com/rancher/charts/mirrored-library-traefik:2.11.24
-  type: image
-- source: library/traefik:2.11.29
-  target: registry.suse.com/rancher/charts/mirrored-library-traefik:2.11.29
-  type: image
-- source: library/traefik:2.11.8
-  target: registry.suse.com/rancher/charts/mirrored-library-traefik:2.11.8
-  type: image
-- source: library/traefik:2.4.8
-  target: registry.suse.com/rancher/charts/mirrored-library-traefik:2.4.8
-  type: image
-- source: library/traefik:2.5.0
-  target: registry.suse.com/rancher/charts/mirrored-library-traefik:2.5.0
-  type: image
-- source: library/traefik:2.5.6
-  target: registry.suse.com/rancher/charts/mirrored-library-traefik:2.5.6
-  type: image
-- source: library/traefik:2.6.0
-  target: registry.suse.com/rancher/charts/mirrored-library-traefik:2.6.0
-  type: image
-- source: library/traefik:2.6.1
-  target: registry.suse.com/rancher/charts/mirrored-library-traefik:2.6.1
-  type: image
-- source: library/traefik:2.6.2
-  target: registry.suse.com/rancher/charts/mirrored-library-traefik:2.6.2
-  type: image
-- source: library/traefik:2.8.7
-  target: registry.suse.com/rancher/charts/mirrored-library-traefik:2.8.7
-  type: image
-- source: library/traefik:2.9.1
-  target: registry.suse.com/rancher/charts/mirrored-library-traefik:2.9.1
-  type: image
-- source: library/traefik:2.9.10
-  target: registry.suse.com/rancher/charts/mirrored-library-traefik:2.9.10
-  type: image
-- source: library/traefik:2.9.4
-  target: registry.suse.com/rancher/charts/mirrored-library-traefik:2.9.4
-  type: image
-- source: library/traefik:3.3.2
-  target: registry.suse.com/rancher/charts/mirrored-library-traefik:3.3.2
-  type: image
-- source: library/traefik:3.3.3
-  target: registry.suse.com/rancher/charts/mirrored-library-traefik:3.3.3
-  type: image
-- source: library/traefik:3.3.5
-  target: registry.suse.com/rancher/charts/mirrored-library-traefik:3.3.5
-  type: image
-- source: library/traefik:3.3.6
-  target: registry.suse.com/rancher/charts/mirrored-library-traefik:3.3.6
-  type: image
-- source: library/traefik:3.5.1
-  target: registry.suse.com/rancher/charts/mirrored-library-traefik:3.5.1
-  type: image
-- source: library/traefik:3.5.3
-  target: registry.suse.com/rancher/charts/mirrored-library-traefik:3.5.3
-  type: image
-- source: library/traefik:2.10.5
   target: stgregistry.suse.com/rancher/mirrored-library-traefik:2.10.5
   type: image
 - source: library/traefik:2.10.7
@@ -8521,90 +5185,6 @@ sync:
 - source: library/traefik:3.5.3
   target: stgregistry.suse.com/rancher/mirrored-library-traefik:3.5.3
   type: image
-- source: library/traefik:2.10.5
-  target: stgregistry.suse.com/rancher/charts/mirrored-library-traefik:2.10.5
-  type: image
-- source: library/traefik:2.10.7
-  target: stgregistry.suse.com/rancher/charts/mirrored-library-traefik:2.10.7
-  type: image
-- source: library/traefik:2.11.10
-  target: stgregistry.suse.com/rancher/charts/mirrored-library-traefik:2.11.10
-  type: image
-- source: library/traefik:2.11.11
-  target: stgregistry.suse.com/rancher/charts/mirrored-library-traefik:2.11.11
-  type: image
-- source: library/traefik:2.11.16
-  target: stgregistry.suse.com/rancher/charts/mirrored-library-traefik:2.11.16
-  type: image
-- source: library/traefik:2.11.17
-  target: stgregistry.suse.com/rancher/charts/mirrored-library-traefik:2.11.17
-  type: image
-- source: library/traefik:2.11.18
-  target: stgregistry.suse.com/rancher/charts/mirrored-library-traefik:2.11.18
-  type: image
-- source: library/traefik:2.11.20
-  target: stgregistry.suse.com/rancher/charts/mirrored-library-traefik:2.11.20
-  type: image
-- source: library/traefik:2.11.22
-  target: stgregistry.suse.com/rancher/charts/mirrored-library-traefik:2.11.22
-  type: image
-- source: library/traefik:2.11.24
-  target: stgregistry.suse.com/rancher/charts/mirrored-library-traefik:2.11.24
-  type: image
-- source: library/traefik:2.11.29
-  target: stgregistry.suse.com/rancher/charts/mirrored-library-traefik:2.11.29
-  type: image
-- source: library/traefik:2.11.8
-  target: stgregistry.suse.com/rancher/charts/mirrored-library-traefik:2.11.8
-  type: image
-- source: library/traefik:2.4.8
-  target: stgregistry.suse.com/rancher/charts/mirrored-library-traefik:2.4.8
-  type: image
-- source: library/traefik:2.5.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-library-traefik:2.5.0
-  type: image
-- source: library/traefik:2.5.6
-  target: stgregistry.suse.com/rancher/charts/mirrored-library-traefik:2.5.6
-  type: image
-- source: library/traefik:2.6.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-library-traefik:2.6.0
-  type: image
-- source: library/traefik:2.6.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-library-traefik:2.6.1
-  type: image
-- source: library/traefik:2.6.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-library-traefik:2.6.2
-  type: image
-- source: library/traefik:2.8.7
-  target: stgregistry.suse.com/rancher/charts/mirrored-library-traefik:2.8.7
-  type: image
-- source: library/traefik:2.9.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-library-traefik:2.9.1
-  type: image
-- source: library/traefik:2.9.10
-  target: stgregistry.suse.com/rancher/charts/mirrored-library-traefik:2.9.10
-  type: image
-- source: library/traefik:2.9.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-library-traefik:2.9.4
-  type: image
-- source: library/traefik:3.3.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-library-traefik:3.3.2
-  type: image
-- source: library/traefik:3.3.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-library-traefik:3.3.3
-  type: image
-- source: library/traefik:3.3.5
-  target: stgregistry.suse.com/rancher/charts/mirrored-library-traefik:3.3.5
-  type: image
-- source: library/traefik:3.3.6
-  target: stgregistry.suse.com/rancher/charts/mirrored-library-traefik:3.3.6
-  type: image
-- source: library/traefik:3.5.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-library-traefik:3.5.1
-  type: image
-- source: library/traefik:3.5.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-library-traefik:3.5.3
-  type: image
 - source: longhornio/backing-image-manager:v1_20210422
   target: docker.io/rancher/longhornio-backing-image-manager:v1_20210422
   type: image
@@ -8642,24 +5222,6 @@ sync:
   target: registry.suse.com/rancher/longhornio-backing-image-manager:v3_20220808
   type: image
 - source: longhornio/backing-image-manager:v1_20210422
-  target: registry.suse.com/rancher/charts/longhornio-backing-image-manager:v1_20210422
-  type: image
-- source: longhornio/backing-image-manager:v1_20210422_patch1
-  target: registry.suse.com/rancher/charts/longhornio-backing-image-manager:v1_20210422_patch1
-  type: image
-- source: longhornio/backing-image-manager:v2_20210820
-  target: registry.suse.com/rancher/charts/longhornio-backing-image-manager:v2_20210820
-  type: image
-- source: longhornio/backing-image-manager:v2_20210820_patch1
-  target: registry.suse.com/rancher/charts/longhornio-backing-image-manager:v2_20210820_patch1
-  type: image
-- source: longhornio/backing-image-manager:v3_20220609
-  target: registry.suse.com/rancher/charts/longhornio-backing-image-manager:v3_20220609
-  type: image
-- source: longhornio/backing-image-manager:v3_20220808
-  target: registry.suse.com/rancher/charts/longhornio-backing-image-manager:v3_20220808
-  type: image
-- source: longhornio/backing-image-manager:v1_20210422
   target: stgregistry.suse.com/rancher/longhornio-backing-image-manager:v1_20210422
   type: image
 - source: longhornio/backing-image-manager:v1_20210422_patch1
@@ -8676,24 +5238,6 @@ sync:
   type: image
 - source: longhornio/backing-image-manager:v3_20220808
   target: stgregistry.suse.com/rancher/longhornio-backing-image-manager:v3_20220808
-  type: image
-- source: longhornio/backing-image-manager:v1_20210422
-  target: stgregistry.suse.com/rancher/charts/longhornio-backing-image-manager:v1_20210422
-  type: image
-- source: longhornio/backing-image-manager:v1_20210422_patch1
-  target: stgregistry.suse.com/rancher/charts/longhornio-backing-image-manager:v1_20210422_patch1
-  type: image
-- source: longhornio/backing-image-manager:v2_20210820
-  target: stgregistry.suse.com/rancher/charts/longhornio-backing-image-manager:v2_20210820
-  type: image
-- source: longhornio/backing-image-manager:v2_20210820_patch1
-  target: stgregistry.suse.com/rancher/charts/longhornio-backing-image-manager:v2_20210820_patch1
-  type: image
-- source: longhornio/backing-image-manager:v3_20220609
-  target: stgregistry.suse.com/rancher/charts/longhornio-backing-image-manager:v3_20220609
-  type: image
-- source: longhornio/backing-image-manager:v3_20220808
-  target: stgregistry.suse.com/rancher/charts/longhornio-backing-image-manager:v3_20220808
   type: image
 - source: longhornio/backing-image-manager:v1.4.0
   target: docker.io/rancher/mirrored-longhornio-backing-image-manager:v1.4.0
@@ -8894,105 +5438,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-longhornio-backing-image-manager:v3_20230320
   type: image
 - source: longhornio/backing-image-manager:v1.4.0
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v1.4.0
-  type: image
-- source: longhornio/backing-image-manager:v1.4.1
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v1.4.1
-  type: image
-- source: longhornio/backing-image-manager:v1.4.2
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v1.4.2
-  type: image
-- source: longhornio/backing-image-manager:v1.4.3
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v1.4.3
-  type: image
-- source: longhornio/backing-image-manager:v1.4.4
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v1.4.4
-  type: image
-- source: longhornio/backing-image-manager:v1.5.0
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v1.5.0
-  type: image
-- source: longhornio/backing-image-manager:v1.5.1
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v1.5.1
-  type: image
-- source: longhornio/backing-image-manager:v1.5.2
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v1.5.2
-  type: image
-- source: longhornio/backing-image-manager:v1.5.3
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v1.5.3
-  type: image
-- source: longhornio/backing-image-manager:v1.5.4
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v1.5.4
-  type: image
-- source: longhornio/backing-image-manager:v1.5.5
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v1.5.5
-  type: image
-- source: longhornio/backing-image-manager:v1.6.0
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v1.6.0
-  type: image
-- source: longhornio/backing-image-manager:v1.6.1
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v1.6.1
-  type: image
-- source: longhornio/backing-image-manager:v1.6.2
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v1.6.2
-  type: image
-- source: longhornio/backing-image-manager:v1.6.3
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v1.6.3
-  type: image
-- source: longhornio/backing-image-manager:v1.6.4
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v1.6.4
-  type: image
-- source: longhornio/backing-image-manager:v1.7.0
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v1.7.0
-  type: image
-- source: longhornio/backing-image-manager:v1.7.1
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v1.7.1
-  type: image
-- source: longhornio/backing-image-manager:v1.7.2
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v1.7.2
-  type: image
-- source: longhornio/backing-image-manager:v1.7.3
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v1.7.3
-  type: image
-- source: longhornio/backing-image-manager:v1.8.1
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v1.8.1
-  type: image
-- source: longhornio/backing-image-manager:v1.8.2
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v1.8.2
-  type: image
-- source: longhornio/backing-image-manager:v1.9.1
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v1.9.1
-  type: image
-- source: longhornio/backing-image-manager:v1.9.2
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v1.9.2
-  type: image
-- source: longhornio/backing-image-manager:v1_20210422
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v1_20210422
-  type: image
-- source: longhornio/backing-image-manager:v1_20210422_patch1
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v1_20210422_patch1
-  type: image
-- source: longhornio/backing-image-manager:v2_20210820
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v2_20210820
-  type: image
-- source: longhornio/backing-image-manager:v2_20210820_patch1
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v2_20210820_patch1
-  type: image
-- source: longhornio/backing-image-manager:v2_20221027
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v2_20221027
-  type: image
-- source: longhornio/backing-image-manager:v3_20220609
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v3_20220609
-  type: image
-- source: longhornio/backing-image-manager:v3_20220808
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v3_20220808
-  type: image
-- source: longhornio/backing-image-manager:v3_20221003
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v3_20221003
-  type: image
-- source: longhornio/backing-image-manager:v3_20230320
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v3_20230320
-  type: image
-- source: longhornio/backing-image-manager:v1.4.0
   target: stgregistry.suse.com/rancher/mirrored-longhornio-backing-image-manager:v1.4.0
   type: image
 - source: longhornio/backing-image-manager:v1.4.1
@@ -9091,105 +5536,6 @@ sync:
 - source: longhornio/backing-image-manager:v3_20230320
   target: stgregistry.suse.com/rancher/mirrored-longhornio-backing-image-manager:v3_20230320
   type: image
-- source: longhornio/backing-image-manager:v1.4.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v1.4.0
-  type: image
-- source: longhornio/backing-image-manager:v1.4.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v1.4.1
-  type: image
-- source: longhornio/backing-image-manager:v1.4.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v1.4.2
-  type: image
-- source: longhornio/backing-image-manager:v1.4.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v1.4.3
-  type: image
-- source: longhornio/backing-image-manager:v1.4.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v1.4.4
-  type: image
-- source: longhornio/backing-image-manager:v1.5.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v1.5.0
-  type: image
-- source: longhornio/backing-image-manager:v1.5.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v1.5.1
-  type: image
-- source: longhornio/backing-image-manager:v1.5.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v1.5.2
-  type: image
-- source: longhornio/backing-image-manager:v1.5.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v1.5.3
-  type: image
-- source: longhornio/backing-image-manager:v1.5.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v1.5.4
-  type: image
-- source: longhornio/backing-image-manager:v1.5.5
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v1.5.5
-  type: image
-- source: longhornio/backing-image-manager:v1.6.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v1.6.0
-  type: image
-- source: longhornio/backing-image-manager:v1.6.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v1.6.1
-  type: image
-- source: longhornio/backing-image-manager:v1.6.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v1.6.2
-  type: image
-- source: longhornio/backing-image-manager:v1.6.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v1.6.3
-  type: image
-- source: longhornio/backing-image-manager:v1.6.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v1.6.4
-  type: image
-- source: longhornio/backing-image-manager:v1.7.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v1.7.0
-  type: image
-- source: longhornio/backing-image-manager:v1.7.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v1.7.1
-  type: image
-- source: longhornio/backing-image-manager:v1.7.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v1.7.2
-  type: image
-- source: longhornio/backing-image-manager:v1.7.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v1.7.3
-  type: image
-- source: longhornio/backing-image-manager:v1.8.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v1.8.1
-  type: image
-- source: longhornio/backing-image-manager:v1.8.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v1.8.2
-  type: image
-- source: longhornio/backing-image-manager:v1.9.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v1.9.1
-  type: image
-- source: longhornio/backing-image-manager:v1.9.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v1.9.2
-  type: image
-- source: longhornio/backing-image-manager:v1_20210422
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v1_20210422
-  type: image
-- source: longhornio/backing-image-manager:v1_20210422_patch1
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v1_20210422_patch1
-  type: image
-- source: longhornio/backing-image-manager:v2_20210820
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v2_20210820
-  type: image
-- source: longhornio/backing-image-manager:v2_20210820_patch1
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v2_20210820_patch1
-  type: image
-- source: longhornio/backing-image-manager:v2_20221027
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v2_20221027
-  type: image
-- source: longhornio/backing-image-manager:v3_20220609
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v3_20220609
-  type: image
-- source: longhornio/backing-image-manager:v3_20220808
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v3_20220808
-  type: image
-- source: longhornio/backing-image-manager:v3_20221003
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v3_20221003
-  type: image
-- source: longhornio/backing-image-manager:v3_20230320
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-backing-image-manager:v3_20230320
-  type: image
 - source: longhornio/csi-attacher:v2.0.0
   target: docker.io/rancher/longhornio-csi-attacher:v2.0.0
   type: image
@@ -9221,21 +5567,6 @@ sync:
   target: registry.suse.com/rancher/longhornio-csi-attacher:v3.4.0
   type: image
 - source: longhornio/csi-attacher:v2.0.0
-  target: registry.suse.com/rancher/charts/longhornio-csi-attacher:v2.0.0
-  type: image
-- source: longhornio/csi-attacher:v2.2.1-lh1
-  target: registry.suse.com/rancher/charts/longhornio-csi-attacher:v2.2.1-lh1
-  type: image
-- source: longhornio/csi-attacher:v2.2.1-lh2
-  target: registry.suse.com/rancher/charts/longhornio-csi-attacher:v2.2.1-lh2
-  type: image
-- source: longhornio/csi-attacher:v3.2.1
-  target: registry.suse.com/rancher/charts/longhornio-csi-attacher:v3.2.1
-  type: image
-- source: longhornio/csi-attacher:v3.4.0
-  target: registry.suse.com/rancher/charts/longhornio-csi-attacher:v3.4.0
-  type: image
-- source: longhornio/csi-attacher:v2.0.0
   target: stgregistry.suse.com/rancher/longhornio-csi-attacher:v2.0.0
   type: image
 - source: longhornio/csi-attacher:v2.2.1-lh1
@@ -9249,21 +5580,6 @@ sync:
   type: image
 - source: longhornio/csi-attacher:v3.4.0
   target: stgregistry.suse.com/rancher/longhornio-csi-attacher:v3.4.0
-  type: image
-- source: longhornio/csi-attacher:v2.0.0
-  target: stgregistry.suse.com/rancher/charts/longhornio-csi-attacher:v2.0.0
-  type: image
-- source: longhornio/csi-attacher:v2.2.1-lh1
-  target: stgregistry.suse.com/rancher/charts/longhornio-csi-attacher:v2.2.1-lh1
-  type: image
-- source: longhornio/csi-attacher:v2.2.1-lh2
-  target: stgregistry.suse.com/rancher/charts/longhornio-csi-attacher:v2.2.1-lh2
-  type: image
-- source: longhornio/csi-attacher:v3.2.1
-  target: stgregistry.suse.com/rancher/charts/longhornio-csi-attacher:v3.2.1
-  type: image
-- source: longhornio/csi-attacher:v3.4.0
-  target: stgregistry.suse.com/rancher/charts/longhornio-csi-attacher:v3.4.0
   type: image
 - source: longhornio/csi-attacher:v2.2.1-lh1
   target: docker.io/rancher/mirrored-longhornio-csi-attacher:v2.2.1-lh1
@@ -9350,48 +5666,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-longhornio-csi-attacher:v4.9.0-20250709
   type: image
 - source: longhornio/csi-attacher:v2.2.1-lh1
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-attacher:v2.2.1-lh1
-  type: image
-- source: longhornio/csi-attacher:v2.2.1-lh2
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-attacher:v2.2.1-lh2
-  type: image
-- source: longhornio/csi-attacher:v3.2.1
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-attacher:v3.2.1
-  type: image
-- source: longhornio/csi-attacher:v3.4.0
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-attacher:v3.4.0
-  type: image
-- source: longhornio/csi-attacher:v4.2.0
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-attacher:v4.2.0
-  type: image
-- source: longhornio/csi-attacher:v4.4.2
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-attacher:v4.4.2
-  type: image
-- source: longhornio/csi-attacher:v4.5.1
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-attacher:v4.5.1
-  type: image
-- source: longhornio/csi-attacher:v4.6.1
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-attacher:v4.6.1
-  type: image
-- source: longhornio/csi-attacher:v4.7.0
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-attacher:v4.7.0
-  type: image
-- source: longhornio/csi-attacher:v4.7.0-20241219
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-attacher:v4.7.0-20241219
-  type: image
-- source: longhornio/csi-attacher:v4.8.0
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-attacher:v4.8.0
-  type: image
-- source: longhornio/csi-attacher:v4.8.1
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-attacher:v4.8.1
-  type: image
-- source: longhornio/csi-attacher:v4.9.0
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-attacher:v4.9.0
-  type: image
-- source: longhornio/csi-attacher:v4.9.0-20250709
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-attacher:v4.9.0-20250709
-  type: image
-- source: longhornio/csi-attacher:v2.2.1-lh1
   target: stgregistry.suse.com/rancher/mirrored-longhornio-csi-attacher:v2.2.1-lh1
   type: image
 - source: longhornio/csi-attacher:v2.2.1-lh2
@@ -9433,48 +5707,6 @@ sync:
 - source: longhornio/csi-attacher:v4.9.0-20250709
   target: stgregistry.suse.com/rancher/mirrored-longhornio-csi-attacher:v4.9.0-20250709
   type: image
-- source: longhornio/csi-attacher:v2.2.1-lh1
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-attacher:v2.2.1-lh1
-  type: image
-- source: longhornio/csi-attacher:v2.2.1-lh2
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-attacher:v2.2.1-lh2
-  type: image
-- source: longhornio/csi-attacher:v3.2.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-attacher:v3.2.1
-  type: image
-- source: longhornio/csi-attacher:v3.4.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-attacher:v3.4.0
-  type: image
-- source: longhornio/csi-attacher:v4.2.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-attacher:v4.2.0
-  type: image
-- source: longhornio/csi-attacher:v4.4.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-attacher:v4.4.2
-  type: image
-- source: longhornio/csi-attacher:v4.5.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-attacher:v4.5.1
-  type: image
-- source: longhornio/csi-attacher:v4.6.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-attacher:v4.6.1
-  type: image
-- source: longhornio/csi-attacher:v4.7.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-attacher:v4.7.0
-  type: image
-- source: longhornio/csi-attacher:v4.7.0-20241219
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-attacher:v4.7.0-20241219
-  type: image
-- source: longhornio/csi-attacher:v4.8.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-attacher:v4.8.0
-  type: image
-- source: longhornio/csi-attacher:v4.8.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-attacher:v4.8.1
-  type: image
-- source: longhornio/csi-attacher:v4.9.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-attacher:v4.9.0
-  type: image
-- source: longhornio/csi-attacher:v4.9.0-20250709
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-attacher:v4.9.0-20250709
-  type: image
 - source: longhornio/csi-node-driver-registrar:v1.2.0
   target: docker.io/rancher/longhornio-csi-node-driver-registrar:v1.2.0
   type: image
@@ -9500,18 +5732,6 @@ sync:
   target: registry.suse.com/rancher/longhornio-csi-node-driver-registrar:v2.5.0
   type: image
 - source: longhornio/csi-node-driver-registrar:v1.2.0
-  target: registry.suse.com/rancher/charts/longhornio-csi-node-driver-registrar:v1.2.0
-  type: image
-- source: longhornio/csi-node-driver-registrar:v1.2.0-lh1
-  target: registry.suse.com/rancher/charts/longhornio-csi-node-driver-registrar:v1.2.0-lh1
-  type: image
-- source: longhornio/csi-node-driver-registrar:v2.3.0
-  target: registry.suse.com/rancher/charts/longhornio-csi-node-driver-registrar:v2.3.0
-  type: image
-- source: longhornio/csi-node-driver-registrar:v2.5.0
-  target: registry.suse.com/rancher/charts/longhornio-csi-node-driver-registrar:v2.5.0
-  type: image
-- source: longhornio/csi-node-driver-registrar:v1.2.0
   target: stgregistry.suse.com/rancher/longhornio-csi-node-driver-registrar:v1.2.0
   type: image
 - source: longhornio/csi-node-driver-registrar:v1.2.0-lh1
@@ -9522,18 +5742,6 @@ sync:
   type: image
 - source: longhornio/csi-node-driver-registrar:v2.5.0
   target: stgregistry.suse.com/rancher/longhornio-csi-node-driver-registrar:v2.5.0
-  type: image
-- source: longhornio/csi-node-driver-registrar:v1.2.0
-  target: stgregistry.suse.com/rancher/charts/longhornio-csi-node-driver-registrar:v1.2.0
-  type: image
-- source: longhornio/csi-node-driver-registrar:v1.2.0-lh1
-  target: stgregistry.suse.com/rancher/charts/longhornio-csi-node-driver-registrar:v1.2.0-lh1
-  type: image
-- source: longhornio/csi-node-driver-registrar:v2.3.0
-  target: stgregistry.suse.com/rancher/charts/longhornio-csi-node-driver-registrar:v2.3.0
-  type: image
-- source: longhornio/csi-node-driver-registrar:v2.5.0
-  target: stgregistry.suse.com/rancher/charts/longhornio-csi-node-driver-registrar:v2.5.0
   type: image
 - source: longhornio/csi-node-driver-registrar:v1.2.0-lh1
   target: docker.io/rancher/mirrored-longhornio-csi-node-driver-registrar:v1.2.0-lh1
@@ -9602,39 +5810,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-longhornio-csi-node-driver-registrar:v2.9.2
   type: image
 - source: longhornio/csi-node-driver-registrar:v1.2.0-lh1
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-node-driver-registrar:v1.2.0-lh1
-  type: image
-- source: longhornio/csi-node-driver-registrar:v2.11.1
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-node-driver-registrar:v2.11.1
-  type: image
-- source: longhornio/csi-node-driver-registrar:v2.12.0
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-node-driver-registrar:v2.12.0
-  type: image
-- source: longhornio/csi-node-driver-registrar:v2.12.0-20241219
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-node-driver-registrar:v2.12.0-20241219
-  type: image
-- source: longhornio/csi-node-driver-registrar:v2.13.0
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-node-driver-registrar:v2.13.0
-  type: image
-- source: longhornio/csi-node-driver-registrar:v2.14.0
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-node-driver-registrar:v2.14.0
-  type: image
-- source: longhornio/csi-node-driver-registrar:v2.14.0-20250709
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-node-driver-registrar:v2.14.0-20250709
-  type: image
-- source: longhornio/csi-node-driver-registrar:v2.3.0
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-node-driver-registrar:v2.3.0
-  type: image
-- source: longhornio/csi-node-driver-registrar:v2.5.0
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-node-driver-registrar:v2.5.0
-  type: image
-- source: longhornio/csi-node-driver-registrar:v2.7.0
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-node-driver-registrar:v2.7.0
-  type: image
-- source: longhornio/csi-node-driver-registrar:v2.9.2
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-node-driver-registrar:v2.9.2
-  type: image
-- source: longhornio/csi-node-driver-registrar:v1.2.0-lh1
   target: stgregistry.suse.com/rancher/mirrored-longhornio-csi-node-driver-registrar:v1.2.0-lh1
   type: image
 - source: longhornio/csi-node-driver-registrar:v2.11.1
@@ -9667,39 +5842,6 @@ sync:
 - source: longhornio/csi-node-driver-registrar:v2.9.2
   target: stgregistry.suse.com/rancher/mirrored-longhornio-csi-node-driver-registrar:v2.9.2
   type: image
-- source: longhornio/csi-node-driver-registrar:v1.2.0-lh1
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-node-driver-registrar:v1.2.0-lh1
-  type: image
-- source: longhornio/csi-node-driver-registrar:v2.11.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-node-driver-registrar:v2.11.1
-  type: image
-- source: longhornio/csi-node-driver-registrar:v2.12.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-node-driver-registrar:v2.12.0
-  type: image
-- source: longhornio/csi-node-driver-registrar:v2.12.0-20241219
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-node-driver-registrar:v2.12.0-20241219
-  type: image
-- source: longhornio/csi-node-driver-registrar:v2.13.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-node-driver-registrar:v2.13.0
-  type: image
-- source: longhornio/csi-node-driver-registrar:v2.14.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-node-driver-registrar:v2.14.0
-  type: image
-- source: longhornio/csi-node-driver-registrar:v2.14.0-20250709
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-node-driver-registrar:v2.14.0-20250709
-  type: image
-- source: longhornio/csi-node-driver-registrar:v2.3.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-node-driver-registrar:v2.3.0
-  type: image
-- source: longhornio/csi-node-driver-registrar:v2.5.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-node-driver-registrar:v2.5.0
-  type: image
-- source: longhornio/csi-node-driver-registrar:v2.7.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-node-driver-registrar:v2.7.0
-  type: image
-- source: longhornio/csi-node-driver-registrar:v2.9.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-node-driver-registrar:v2.9.2
-  type: image
 - source: longhornio/csi-provisioner:v1.4.0
   target: docker.io/rancher/longhornio-csi-provisioner:v1.4.0
   type: image
@@ -9725,18 +5867,6 @@ sync:
   target: registry.suse.com/rancher/longhornio-csi-provisioner:v2.1.2
   type: image
 - source: longhornio/csi-provisioner:v1.4.0
-  target: registry.suse.com/rancher/charts/longhornio-csi-provisioner:v1.4.0
-  type: image
-- source: longhornio/csi-provisioner:v1.6.0-lh1
-  target: registry.suse.com/rancher/charts/longhornio-csi-provisioner:v1.6.0-lh1
-  type: image
-- source: longhornio/csi-provisioner:v1.6.0-lh2
-  target: registry.suse.com/rancher/charts/longhornio-csi-provisioner:v1.6.0-lh2
-  type: image
-- source: longhornio/csi-provisioner:v2.1.2
-  target: registry.suse.com/rancher/charts/longhornio-csi-provisioner:v2.1.2
-  type: image
-- source: longhornio/csi-provisioner:v1.4.0
   target: stgregistry.suse.com/rancher/longhornio-csi-provisioner:v1.4.0
   type: image
 - source: longhornio/csi-provisioner:v1.6.0-lh1
@@ -9747,18 +5877,6 @@ sync:
   type: image
 - source: longhornio/csi-provisioner:v2.1.2
   target: stgregistry.suse.com/rancher/longhornio-csi-provisioner:v2.1.2
-  type: image
-- source: longhornio/csi-provisioner:v1.4.0
-  target: stgregistry.suse.com/rancher/charts/longhornio-csi-provisioner:v1.4.0
-  type: image
-- source: longhornio/csi-provisioner:v1.6.0-lh1
-  target: stgregistry.suse.com/rancher/charts/longhornio-csi-provisioner:v1.6.0-lh1
-  type: image
-- source: longhornio/csi-provisioner:v1.6.0-lh2
-  target: stgregistry.suse.com/rancher/charts/longhornio-csi-provisioner:v1.6.0-lh2
-  type: image
-- source: longhornio/csi-provisioner:v2.1.2
-  target: stgregistry.suse.com/rancher/charts/longhornio-csi-provisioner:v2.1.2
   type: image
 - source: longhornio/csi-provisioner:v1.6.0-lh1
   target: docker.io/rancher/mirrored-longhornio-csi-provisioner:v1.6.0-lh1
@@ -9845,48 +5963,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-longhornio-csi-provisioner:v5.3.0-20250709
   type: image
 - source: longhornio/csi-provisioner:v1.6.0-lh1
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-provisioner:v1.6.0-lh1
-  type: image
-- source: longhornio/csi-provisioner:v1.6.0-lh2
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-provisioner:v1.6.0-lh2
-  type: image
-- source: longhornio/csi-provisioner:v2.1.2
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-provisioner:v2.1.2
-  type: image
-- source: longhornio/csi-provisioner:v3.4.1
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-provisioner:v3.4.1
-  type: image
-- source: longhornio/csi-provisioner:v3.6.2
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-provisioner:v3.6.2
-  type: image
-- source: longhornio/csi-provisioner:v3.6.4
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-provisioner:v3.6.4
-  type: image
-- source: longhornio/csi-provisioner:v3.6.4-20241219
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-provisioner:v3.6.4-20241219
-  type: image
-- source: longhornio/csi-provisioner:v4.0.1
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-provisioner:v4.0.1
-  type: image
-- source: longhornio/csi-provisioner:v4.0.1-20241007
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-provisioner:v4.0.1-20241007
-  type: image
-- source: longhornio/csi-provisioner:v4.0.1-20250204
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-provisioner:v4.0.1-20250204
-  type: image
-- source: longhornio/csi-provisioner:v5.1.0-20241220
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-provisioner:v5.1.0-20241220
-  type: image
-- source: longhornio/csi-provisioner:v5.2.0
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-provisioner:v5.2.0
-  type: image
-- source: longhornio/csi-provisioner:v5.3.0
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-provisioner:v5.3.0
-  type: image
-- source: longhornio/csi-provisioner:v5.3.0-20250709
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-provisioner:v5.3.0-20250709
-  type: image
-- source: longhornio/csi-provisioner:v1.6.0-lh1
   target: stgregistry.suse.com/rancher/mirrored-longhornio-csi-provisioner:v1.6.0-lh1
   type: image
 - source: longhornio/csi-provisioner:v1.6.0-lh2
@@ -9928,48 +6004,6 @@ sync:
 - source: longhornio/csi-provisioner:v5.3.0-20250709
   target: stgregistry.suse.com/rancher/mirrored-longhornio-csi-provisioner:v5.3.0-20250709
   type: image
-- source: longhornio/csi-provisioner:v1.6.0-lh1
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-provisioner:v1.6.0-lh1
-  type: image
-- source: longhornio/csi-provisioner:v1.6.0-lh2
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-provisioner:v1.6.0-lh2
-  type: image
-- source: longhornio/csi-provisioner:v2.1.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-provisioner:v2.1.2
-  type: image
-- source: longhornio/csi-provisioner:v3.4.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-provisioner:v3.4.1
-  type: image
-- source: longhornio/csi-provisioner:v3.6.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-provisioner:v3.6.2
-  type: image
-- source: longhornio/csi-provisioner:v3.6.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-provisioner:v3.6.4
-  type: image
-- source: longhornio/csi-provisioner:v3.6.4-20241219
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-provisioner:v3.6.4-20241219
-  type: image
-- source: longhornio/csi-provisioner:v4.0.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-provisioner:v4.0.1
-  type: image
-- source: longhornio/csi-provisioner:v4.0.1-20241007
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-provisioner:v4.0.1-20241007
-  type: image
-- source: longhornio/csi-provisioner:v4.0.1-20250204
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-provisioner:v4.0.1-20250204
-  type: image
-- source: longhornio/csi-provisioner:v5.1.0-20241220
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-provisioner:v5.1.0-20241220
-  type: image
-- source: longhornio/csi-provisioner:v5.2.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-provisioner:v5.2.0
-  type: image
-- source: longhornio/csi-provisioner:v5.3.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-provisioner:v5.3.0
-  type: image
-- source: longhornio/csi-provisioner:v5.3.0-20250709
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-provisioner:v5.3.0-20250709
-  type: image
 - source: longhornio/csi-resizer:v0.3.0
   target: docker.io/rancher/longhornio-csi-resizer:v0.3.0
   type: image
@@ -9995,18 +6029,6 @@ sync:
   target: registry.suse.com/rancher/longhornio-csi-resizer:v1.2.0
   type: image
 - source: longhornio/csi-resizer:v0.3.0
-  target: registry.suse.com/rancher/charts/longhornio-csi-resizer:v0.3.0
-  type: image
-- source: longhornio/csi-resizer:v0.5.1-lh1
-  target: registry.suse.com/rancher/charts/longhornio-csi-resizer:v0.5.1-lh1
-  type: image
-- source: longhornio/csi-resizer:v0.5.1-lh2
-  target: registry.suse.com/rancher/charts/longhornio-csi-resizer:v0.5.1-lh2
-  type: image
-- source: longhornio/csi-resizer:v1.2.0
-  target: registry.suse.com/rancher/charts/longhornio-csi-resizer:v1.2.0
-  type: image
-- source: longhornio/csi-resizer:v0.3.0
   target: stgregistry.suse.com/rancher/longhornio-csi-resizer:v0.3.0
   type: image
 - source: longhornio/csi-resizer:v0.5.1-lh1
@@ -10017,18 +6039,6 @@ sync:
   type: image
 - source: longhornio/csi-resizer:v1.2.0
   target: stgregistry.suse.com/rancher/longhornio-csi-resizer:v1.2.0
-  type: image
-- source: longhornio/csi-resizer:v0.3.0
-  target: stgregistry.suse.com/rancher/charts/longhornio-csi-resizer:v0.3.0
-  type: image
-- source: longhornio/csi-resizer:v0.5.1-lh1
-  target: stgregistry.suse.com/rancher/charts/longhornio-csi-resizer:v0.5.1-lh1
-  type: image
-- source: longhornio/csi-resizer:v0.5.1-lh2
-  target: stgregistry.suse.com/rancher/charts/longhornio-csi-resizer:v0.5.1-lh2
-  type: image
-- source: longhornio/csi-resizer:v1.2.0
-  target: stgregistry.suse.com/rancher/charts/longhornio-csi-resizer:v1.2.0
   type: image
 - source: longhornio/csi-resizer:v0.5.1-lh1
   target: docker.io/rancher/mirrored-longhornio-csi-resizer:v0.5.1-lh1
@@ -10109,45 +6119,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-longhornio-csi-resizer:v1.9.2
   type: image
 - source: longhornio/csi-resizer:v0.5.1-lh1
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-resizer:v0.5.1-lh1
-  type: image
-- source: longhornio/csi-resizer:v0.5.1-lh2
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-resizer:v0.5.1-lh2
-  type: image
-- source: longhornio/csi-resizer:v1.10.1
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-resizer:v1.10.1
-  type: image
-- source: longhornio/csi-resizer:v1.11.1
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-resizer:v1.11.1
-  type: image
-- source: longhornio/csi-resizer:v1.12.0
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-resizer:v1.12.0
-  type: image
-- source: longhornio/csi-resizer:v1.12.0-20241219
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-resizer:v1.12.0-20241219
-  type: image
-- source: longhornio/csi-resizer:v1.13.1
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-resizer:v1.13.1
-  type: image
-- source: longhornio/csi-resizer:v1.13.2
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-resizer:v1.13.2
-  type: image
-- source: longhornio/csi-resizer:v1.14.0-20250709
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-resizer:v1.14.0-20250709
-  type: image
-- source: longhornio/csi-resizer:v1.2.0
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-resizer:v1.2.0
-  type: image
-- source: longhornio/csi-resizer:v1.3.0
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-resizer:v1.3.0
-  type: image
-- source: longhornio/csi-resizer:v1.7.0
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-resizer:v1.7.0
-  type: image
-- source: longhornio/csi-resizer:v1.9.2
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-resizer:v1.9.2
-  type: image
-- source: longhornio/csi-resizer:v0.5.1-lh1
   target: stgregistry.suse.com/rancher/mirrored-longhornio-csi-resizer:v0.5.1-lh1
   type: image
 - source: longhornio/csi-resizer:v0.5.1-lh2
@@ -10186,45 +6157,6 @@ sync:
 - source: longhornio/csi-resizer:v1.9.2
   target: stgregistry.suse.com/rancher/mirrored-longhornio-csi-resizer:v1.9.2
   type: image
-- source: longhornio/csi-resizer:v0.5.1-lh1
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-resizer:v0.5.1-lh1
-  type: image
-- source: longhornio/csi-resizer:v0.5.1-lh2
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-resizer:v0.5.1-lh2
-  type: image
-- source: longhornio/csi-resizer:v1.10.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-resizer:v1.10.1
-  type: image
-- source: longhornio/csi-resizer:v1.11.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-resizer:v1.11.1
-  type: image
-- source: longhornio/csi-resizer:v1.12.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-resizer:v1.12.0
-  type: image
-- source: longhornio/csi-resizer:v1.12.0-20241219
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-resizer:v1.12.0-20241219
-  type: image
-- source: longhornio/csi-resizer:v1.13.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-resizer:v1.13.1
-  type: image
-- source: longhornio/csi-resizer:v1.13.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-resizer:v1.13.2
-  type: image
-- source: longhornio/csi-resizer:v1.14.0-20250709
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-resizer:v1.14.0-20250709
-  type: image
-- source: longhornio/csi-resizer:v1.2.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-resizer:v1.2.0
-  type: image
-- source: longhornio/csi-resizer:v1.3.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-resizer:v1.3.0
-  type: image
-- source: longhornio/csi-resizer:v1.7.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-resizer:v1.7.0
-  type: image
-- source: longhornio/csi-resizer:v1.9.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-resizer:v1.9.2
-  type: image
 - source: longhornio/csi-snapshotter:v2.1.1-lh1
   target: docker.io/rancher/longhornio-csi-snapshotter:v2.1.1-lh1
   type: image
@@ -10244,15 +6176,6 @@ sync:
   target: registry.suse.com/rancher/longhornio-csi-snapshotter:v3.0.3
   type: image
 - source: longhornio/csi-snapshotter:v2.1.1-lh1
-  target: registry.suse.com/rancher/charts/longhornio-csi-snapshotter:v2.1.1-lh1
-  type: image
-- source: longhornio/csi-snapshotter:v2.1.1-lh2
-  target: registry.suse.com/rancher/charts/longhornio-csi-snapshotter:v2.1.1-lh2
-  type: image
-- source: longhornio/csi-snapshotter:v3.0.3
-  target: registry.suse.com/rancher/charts/longhornio-csi-snapshotter:v3.0.3
-  type: image
-- source: longhornio/csi-snapshotter:v2.1.1-lh1
   target: stgregistry.suse.com/rancher/longhornio-csi-snapshotter:v2.1.1-lh1
   type: image
 - source: longhornio/csi-snapshotter:v2.1.1-lh2
@@ -10260,15 +6183,6 @@ sync:
   type: image
 - source: longhornio/csi-snapshotter:v3.0.3
   target: stgregistry.suse.com/rancher/longhornio-csi-snapshotter:v3.0.3
-  type: image
-- source: longhornio/csi-snapshotter:v2.1.1-lh1
-  target: stgregistry.suse.com/rancher/charts/longhornio-csi-snapshotter:v2.1.1-lh1
-  type: image
-- source: longhornio/csi-snapshotter:v2.1.1-lh2
-  target: stgregistry.suse.com/rancher/charts/longhornio-csi-snapshotter:v2.1.1-lh2
-  type: image
-- source: longhornio/csi-snapshotter:v3.0.3
-  target: stgregistry.suse.com/rancher/charts/longhornio-csi-snapshotter:v3.0.3
   type: image
 - source: longhornio/csi-snapshotter:v2.1.1-lh1
   target: docker.io/rancher/mirrored-longhornio-csi-snapshotter:v2.1.1-lh1
@@ -10349,45 +6263,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-longhornio-csi-snapshotter:v8.3.0-20250709
   type: image
 - source: longhornio/csi-snapshotter:v2.1.1-lh1
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-snapshotter:v2.1.1-lh1
-  type: image
-- source: longhornio/csi-snapshotter:v2.1.1-lh2
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-snapshotter:v2.1.1-lh2
-  type: image
-- source: longhornio/csi-snapshotter:v3.0.3
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-snapshotter:v3.0.3
-  type: image
-- source: longhornio/csi-snapshotter:v5.0.1
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-snapshotter:v5.0.1
-  type: image
-- source: longhornio/csi-snapshotter:v6.2.1
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-snapshotter:v6.2.1
-  type: image
-- source: longhornio/csi-snapshotter:v6.3.2
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-snapshotter:v6.3.2
-  type: image
-- source: longhornio/csi-snapshotter:v6.3.4
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-snapshotter:v6.3.4
-  type: image
-- source: longhornio/csi-snapshotter:v6.3.4-20241219
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-snapshotter:v6.3.4-20241219
-  type: image
-- source: longhornio/csi-snapshotter:v7.0.2
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-snapshotter:v7.0.2
-  type: image
-- source: longhornio/csi-snapshotter:v7.0.2-20241007
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-snapshotter:v7.0.2-20241007
-  type: image
-- source: longhornio/csi-snapshotter:v7.0.2-20250204
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-snapshotter:v7.0.2-20250204
-  type: image
-- source: longhornio/csi-snapshotter:v8.2.0
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-snapshotter:v8.2.0
-  type: image
-- source: longhornio/csi-snapshotter:v8.3.0-20250709
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-csi-snapshotter:v8.3.0-20250709
-  type: image
-- source: longhornio/csi-snapshotter:v2.1.1-lh1
   target: stgregistry.suse.com/rancher/mirrored-longhornio-csi-snapshotter:v2.1.1-lh1
   type: image
 - source: longhornio/csi-snapshotter:v2.1.1-lh2
@@ -10425,45 +6300,6 @@ sync:
   type: image
 - source: longhornio/csi-snapshotter:v8.3.0-20250709
   target: stgregistry.suse.com/rancher/mirrored-longhornio-csi-snapshotter:v8.3.0-20250709
-  type: image
-- source: longhornio/csi-snapshotter:v2.1.1-lh1
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-snapshotter:v2.1.1-lh1
-  type: image
-- source: longhornio/csi-snapshotter:v2.1.1-lh2
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-snapshotter:v2.1.1-lh2
-  type: image
-- source: longhornio/csi-snapshotter:v3.0.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-snapshotter:v3.0.3
-  type: image
-- source: longhornio/csi-snapshotter:v5.0.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-snapshotter:v5.0.1
-  type: image
-- source: longhornio/csi-snapshotter:v6.2.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-snapshotter:v6.2.1
-  type: image
-- source: longhornio/csi-snapshotter:v6.3.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-snapshotter:v6.3.2
-  type: image
-- source: longhornio/csi-snapshotter:v6.3.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-snapshotter:v6.3.4
-  type: image
-- source: longhornio/csi-snapshotter:v6.3.4-20241219
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-snapshotter:v6.3.4-20241219
-  type: image
-- source: longhornio/csi-snapshotter:v7.0.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-snapshotter:v7.0.2
-  type: image
-- source: longhornio/csi-snapshotter:v7.0.2-20241007
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-snapshotter:v7.0.2-20241007
-  type: image
-- source: longhornio/csi-snapshotter:v7.0.2-20250204
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-snapshotter:v7.0.2-20250204
-  type: image
-- source: longhornio/csi-snapshotter:v8.2.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-snapshotter:v8.2.0
-  type: image
-- source: longhornio/csi-snapshotter:v8.3.0-20250709
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-csi-snapshotter:v8.3.0-20250709
   type: image
 - source: longhornio/livenessprobe:v2.11.0
   target: docker.io/rancher/mirrored-longhornio-livenessprobe:v2.11.0
@@ -10526,36 +6362,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-longhornio-livenessprobe:v2.9.0
   type: image
 - source: longhornio/livenessprobe:v2.11.0
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-livenessprobe:v2.11.0
-  type: image
-- source: longhornio/livenessprobe:v2.12.0
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-livenessprobe:v2.12.0
-  type: image
-- source: longhornio/livenessprobe:v2.13.1
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-livenessprobe:v2.13.1
-  type: image
-- source: longhornio/livenessprobe:v2.14.0
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-livenessprobe:v2.14.0
-  type: image
-- source: longhornio/livenessprobe:v2.14.0-20241219
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-livenessprobe:v2.14.0-20241219
-  type: image
-- source: longhornio/livenessprobe:v2.15.0
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-livenessprobe:v2.15.0
-  type: image
-- source: longhornio/livenessprobe:v2.16.0
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-livenessprobe:v2.16.0
-  type: image
-- source: longhornio/livenessprobe:v2.16.0-20250709
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-livenessprobe:v2.16.0-20250709
-  type: image
-- source: longhornio/livenessprobe:v2.8.0
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-livenessprobe:v2.8.0
-  type: image
-- source: longhornio/livenessprobe:v2.9.0
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-livenessprobe:v2.9.0
-  type: image
-- source: longhornio/livenessprobe:v2.11.0
   target: stgregistry.suse.com/rancher/mirrored-longhornio-livenessprobe:v2.11.0
   type: image
 - source: longhornio/livenessprobe:v2.12.0
@@ -10584,36 +6390,6 @@ sync:
   type: image
 - source: longhornio/livenessprobe:v2.9.0
   target: stgregistry.suse.com/rancher/mirrored-longhornio-livenessprobe:v2.9.0
-  type: image
-- source: longhornio/livenessprobe:v2.11.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-livenessprobe:v2.11.0
-  type: image
-- source: longhornio/livenessprobe:v2.12.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-livenessprobe:v2.12.0
-  type: image
-- source: longhornio/livenessprobe:v2.13.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-livenessprobe:v2.13.1
-  type: image
-- source: longhornio/livenessprobe:v2.14.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-livenessprobe:v2.14.0
-  type: image
-- source: longhornio/livenessprobe:v2.14.0-20241219
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-livenessprobe:v2.14.0-20241219
-  type: image
-- source: longhornio/livenessprobe:v2.15.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-livenessprobe:v2.15.0
-  type: image
-- source: longhornio/livenessprobe:v2.16.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-livenessprobe:v2.16.0
-  type: image
-- source: longhornio/livenessprobe:v2.16.0-20250709
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-livenessprobe:v2.16.0-20250709
-  type: image
-- source: longhornio/livenessprobe:v2.8.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-livenessprobe:v2.8.0
-  type: image
-- source: longhornio/livenessprobe:v2.9.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-livenessprobe:v2.9.0
   type: image
 - source: longhornio/longhorn-cli:v1.7.0
   target: docker.io/rancher/mirrored-longhornio-longhorn-cli:v1.7.0
@@ -10664,30 +6440,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-longhornio-longhorn-cli:v1.9.2
   type: image
 - source: longhornio/longhorn-cli:v1.7.0
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-cli:v1.7.0
-  type: image
-- source: longhornio/longhorn-cli:v1.7.1
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-cli:v1.7.1
-  type: image
-- source: longhornio/longhorn-cli:v1.7.2
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-cli:v1.7.2
-  type: image
-- source: longhornio/longhorn-cli:v1.7.3
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-cli:v1.7.3
-  type: image
-- source: longhornio/longhorn-cli:v1.8.1
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-cli:v1.8.1
-  type: image
-- source: longhornio/longhorn-cli:v1.8.2
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-cli:v1.8.2
-  type: image
-- source: longhornio/longhorn-cli:v1.9.1
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-cli:v1.9.1
-  type: image
-- source: longhornio/longhorn-cli:v1.9.2
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-cli:v1.9.2
-  type: image
-- source: longhornio/longhorn-cli:v1.7.0
   target: stgregistry.suse.com/rancher/mirrored-longhornio-longhorn-cli:v1.7.0
   type: image
 - source: longhornio/longhorn-cli:v1.7.1
@@ -10710,30 +6462,6 @@ sync:
   type: image
 - source: longhornio/longhorn-cli:v1.9.2
   target: stgregistry.suse.com/rancher/mirrored-longhornio-longhorn-cli:v1.9.2
-  type: image
-- source: longhornio/longhorn-cli:v1.7.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-cli:v1.7.0
-  type: image
-- source: longhornio/longhorn-cli:v1.7.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-cli:v1.7.1
-  type: image
-- source: longhornio/longhorn-cli:v1.7.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-cli:v1.7.2
-  type: image
-- source: longhornio/longhorn-cli:v1.7.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-cli:v1.7.3
-  type: image
-- source: longhornio/longhorn-cli:v1.8.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-cli:v1.8.1
-  type: image
-- source: longhornio/longhorn-cli:v1.8.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-cli:v1.8.2
-  type: image
-- source: longhornio/longhorn-cli:v1.9.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-cli:v1.9.1
-  type: image
-- source: longhornio/longhorn-cli:v1.9.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-cli:v1.9.2
   type: image
 - source: longhornio/longhorn-engine:v1.0.2
   target: docker.io/rancher/longhornio-longhorn-engine:v1.0.2
@@ -10814,45 +6542,6 @@ sync:
   target: registry.suse.com/rancher/longhornio-longhorn-engine:v1.3.1
   type: image
 - source: longhornio/longhorn-engine:v1.0.2
-  target: registry.suse.com/rancher/charts/longhornio-longhorn-engine:v1.0.2
-  type: image
-- source: longhornio/longhorn-engine:v1.1.0
-  target: registry.suse.com/rancher/charts/longhornio-longhorn-engine:v1.1.0
-  type: image
-- source: longhornio/longhorn-engine:v1.1.1
-  target: registry.suse.com/rancher/charts/longhornio-longhorn-engine:v1.1.1
-  type: image
-- source: longhornio/longhorn-engine:v1.1.2
-  target: registry.suse.com/rancher/charts/longhornio-longhorn-engine:v1.1.2
-  type: image
-- source: longhornio/longhorn-engine:v1.1.3
-  target: registry.suse.com/rancher/charts/longhornio-longhorn-engine:v1.1.3
-  type: image
-- source: longhornio/longhorn-engine:v1.2.0
-  target: registry.suse.com/rancher/charts/longhornio-longhorn-engine:v1.2.0
-  type: image
-- source: longhornio/longhorn-engine:v1.2.1
-  target: registry.suse.com/rancher/charts/longhornio-longhorn-engine:v1.2.1
-  type: image
-- source: longhornio/longhorn-engine:v1.2.2
-  target: registry.suse.com/rancher/charts/longhornio-longhorn-engine:v1.2.2
-  type: image
-- source: longhornio/longhorn-engine:v1.2.3
-  target: registry.suse.com/rancher/charts/longhornio-longhorn-engine:v1.2.3
-  type: image
-- source: longhornio/longhorn-engine:v1.2.4
-  target: registry.suse.com/rancher/charts/longhornio-longhorn-engine:v1.2.4
-  type: image
-- source: longhornio/longhorn-engine:v1.2.5
-  target: registry.suse.com/rancher/charts/longhornio-longhorn-engine:v1.2.5
-  type: image
-- source: longhornio/longhorn-engine:v1.3.0
-  target: registry.suse.com/rancher/charts/longhornio-longhorn-engine:v1.3.0
-  type: image
-- source: longhornio/longhorn-engine:v1.3.1
-  target: registry.suse.com/rancher/charts/longhornio-longhorn-engine:v1.3.1
-  type: image
-- source: longhornio/longhorn-engine:v1.0.2
   target: stgregistry.suse.com/rancher/longhornio-longhorn-engine:v1.0.2
   type: image
 - source: longhornio/longhorn-engine:v1.1.0
@@ -10890,45 +6579,6 @@ sync:
   type: image
 - source: longhornio/longhorn-engine:v1.3.1
   target: stgregistry.suse.com/rancher/longhornio-longhorn-engine:v1.3.1
-  type: image
-- source: longhornio/longhorn-engine:v1.0.2
-  target: stgregistry.suse.com/rancher/charts/longhornio-longhorn-engine:v1.0.2
-  type: image
-- source: longhornio/longhorn-engine:v1.1.0
-  target: stgregistry.suse.com/rancher/charts/longhornio-longhorn-engine:v1.1.0
-  type: image
-- source: longhornio/longhorn-engine:v1.1.1
-  target: stgregistry.suse.com/rancher/charts/longhornio-longhorn-engine:v1.1.1
-  type: image
-- source: longhornio/longhorn-engine:v1.1.2
-  target: stgregistry.suse.com/rancher/charts/longhornio-longhorn-engine:v1.1.2
-  type: image
-- source: longhornio/longhorn-engine:v1.1.3
-  target: stgregistry.suse.com/rancher/charts/longhornio-longhorn-engine:v1.1.3
-  type: image
-- source: longhornio/longhorn-engine:v1.2.0
-  target: stgregistry.suse.com/rancher/charts/longhornio-longhorn-engine:v1.2.0
-  type: image
-- source: longhornio/longhorn-engine:v1.2.1
-  target: stgregistry.suse.com/rancher/charts/longhornio-longhorn-engine:v1.2.1
-  type: image
-- source: longhornio/longhorn-engine:v1.2.2
-  target: stgregistry.suse.com/rancher/charts/longhornio-longhorn-engine:v1.2.2
-  type: image
-- source: longhornio/longhorn-engine:v1.2.3
-  target: stgregistry.suse.com/rancher/charts/longhornio-longhorn-engine:v1.2.3
-  type: image
-- source: longhornio/longhorn-engine:v1.2.4
-  target: stgregistry.suse.com/rancher/charts/longhornio-longhorn-engine:v1.2.4
-  type: image
-- source: longhornio/longhorn-engine:v1.2.5
-  target: stgregistry.suse.com/rancher/charts/longhornio-longhorn-engine:v1.2.5
-  type: image
-- source: longhornio/longhorn-engine:v1.3.0
-  target: stgregistry.suse.com/rancher/charts/longhornio-longhorn-engine:v1.3.0
-  type: image
-- source: longhornio/longhorn-engine:v1.3.1
-  target: stgregistry.suse.com/rancher/charts/longhornio-longhorn-engine:v1.3.1
   type: image
 - source: longhornio/longhorn-engine:v1.1.0
   target: docker.io/rancher/mirrored-longhornio-longhorn-engine:v1.1.0
@@ -11165,123 +6815,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-longhornio-longhorn-engine:v1.9.2
   type: image
 - source: longhornio/longhorn-engine:v1.1.0
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.1.0
-  type: image
-- source: longhornio/longhorn-engine:v1.1.1
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.1.1
-  type: image
-- source: longhornio/longhorn-engine:v1.1.2
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.1.2
-  type: image
-- source: longhornio/longhorn-engine:v1.1.3
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.1.3
-  type: image
-- source: longhornio/longhorn-engine:v1.2.0
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.2.0
-  type: image
-- source: longhornio/longhorn-engine:v1.2.1
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.2.1
-  type: image
-- source: longhornio/longhorn-engine:v1.2.2
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.2.2
-  type: image
-- source: longhornio/longhorn-engine:v1.2.3
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.2.3
-  type: image
-- source: longhornio/longhorn-engine:v1.2.4
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.2.4
-  type: image
-- source: longhornio/longhorn-engine:v1.2.5
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.2.5
-  type: image
-- source: longhornio/longhorn-engine:v1.2.6
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.2.6
-  type: image
-- source: longhornio/longhorn-engine:v1.3.0
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.3.0
-  type: image
-- source: longhornio/longhorn-engine:v1.3.1
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.3.1
-  type: image
-- source: longhornio/longhorn-engine:v1.3.2
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.3.2
-  type: image
-- source: longhornio/longhorn-engine:v1.3.3
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.3.3
-  type: image
-- source: longhornio/longhorn-engine:v1.4.0
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.4.0
-  type: image
-- source: longhornio/longhorn-engine:v1.4.1
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.4.1
-  type: image
-- source: longhornio/longhorn-engine:v1.4.2
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.4.2
-  type: image
-- source: longhornio/longhorn-engine:v1.4.3
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.4.3
-  type: image
-- source: longhornio/longhorn-engine:v1.4.4
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.4.4
-  type: image
-- source: longhornio/longhorn-engine:v1.5.0
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.5.0
-  type: image
-- source: longhornio/longhorn-engine:v1.5.1
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.5.1
-  type: image
-- source: longhornio/longhorn-engine:v1.5.2
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.5.2
-  type: image
-- source: longhornio/longhorn-engine:v1.5.3
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.5.3
-  type: image
-- source: longhornio/longhorn-engine:v1.5.4
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.5.4
-  type: image
-- source: longhornio/longhorn-engine:v1.5.5
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.5.5
-  type: image
-- source: longhornio/longhorn-engine:v1.6.0
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.6.0
-  type: image
-- source: longhornio/longhorn-engine:v1.6.1
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.6.1
-  type: image
-- source: longhornio/longhorn-engine:v1.6.2
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.6.2
-  type: image
-- source: longhornio/longhorn-engine:v1.6.3
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.6.3
-  type: image
-- source: longhornio/longhorn-engine:v1.6.4
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.6.4
-  type: image
-- source: longhornio/longhorn-engine:v1.7.0
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.7.0
-  type: image
-- source: longhornio/longhorn-engine:v1.7.1
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.7.1
-  type: image
-- source: longhornio/longhorn-engine:v1.7.2
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.7.2
-  type: image
-- source: longhornio/longhorn-engine:v1.7.3
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.7.3
-  type: image
-- source: longhornio/longhorn-engine:v1.8.1
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.8.1
-  type: image
-- source: longhornio/longhorn-engine:v1.8.2
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.8.2
-  type: image
-- source: longhornio/longhorn-engine:v1.9.1
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.9.1
-  type: image
-- source: longhornio/longhorn-engine:v1.9.2
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.9.2
-  type: image
-- source: longhornio/longhorn-engine:v1.1.0
   target: stgregistry.suse.com/rancher/mirrored-longhornio-longhorn-engine:v1.1.0
   type: image
 - source: longhornio/longhorn-engine:v1.1.1
@@ -11398,123 +6931,6 @@ sync:
 - source: longhornio/longhorn-engine:v1.9.2
   target: stgregistry.suse.com/rancher/mirrored-longhornio-longhorn-engine:v1.9.2
   type: image
-- source: longhornio/longhorn-engine:v1.1.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.1.0
-  type: image
-- source: longhornio/longhorn-engine:v1.1.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.1.1
-  type: image
-- source: longhornio/longhorn-engine:v1.1.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.1.2
-  type: image
-- source: longhornio/longhorn-engine:v1.1.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.1.3
-  type: image
-- source: longhornio/longhorn-engine:v1.2.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.2.0
-  type: image
-- source: longhornio/longhorn-engine:v1.2.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.2.1
-  type: image
-- source: longhornio/longhorn-engine:v1.2.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.2.2
-  type: image
-- source: longhornio/longhorn-engine:v1.2.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.2.3
-  type: image
-- source: longhornio/longhorn-engine:v1.2.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.2.4
-  type: image
-- source: longhornio/longhorn-engine:v1.2.5
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.2.5
-  type: image
-- source: longhornio/longhorn-engine:v1.2.6
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.2.6
-  type: image
-- source: longhornio/longhorn-engine:v1.3.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.3.0
-  type: image
-- source: longhornio/longhorn-engine:v1.3.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.3.1
-  type: image
-- source: longhornio/longhorn-engine:v1.3.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.3.2
-  type: image
-- source: longhornio/longhorn-engine:v1.3.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.3.3
-  type: image
-- source: longhornio/longhorn-engine:v1.4.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.4.0
-  type: image
-- source: longhornio/longhorn-engine:v1.4.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.4.1
-  type: image
-- source: longhornio/longhorn-engine:v1.4.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.4.2
-  type: image
-- source: longhornio/longhorn-engine:v1.4.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.4.3
-  type: image
-- source: longhornio/longhorn-engine:v1.4.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.4.4
-  type: image
-- source: longhornio/longhorn-engine:v1.5.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.5.0
-  type: image
-- source: longhornio/longhorn-engine:v1.5.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.5.1
-  type: image
-- source: longhornio/longhorn-engine:v1.5.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.5.2
-  type: image
-- source: longhornio/longhorn-engine:v1.5.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.5.3
-  type: image
-- source: longhornio/longhorn-engine:v1.5.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.5.4
-  type: image
-- source: longhornio/longhorn-engine:v1.5.5
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.5.5
-  type: image
-- source: longhornio/longhorn-engine:v1.6.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.6.0
-  type: image
-- source: longhornio/longhorn-engine:v1.6.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.6.1
-  type: image
-- source: longhornio/longhorn-engine:v1.6.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.6.2
-  type: image
-- source: longhornio/longhorn-engine:v1.6.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.6.3
-  type: image
-- source: longhornio/longhorn-engine:v1.6.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.6.4
-  type: image
-- source: longhornio/longhorn-engine:v1.7.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.7.0
-  type: image
-- source: longhornio/longhorn-engine:v1.7.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.7.1
-  type: image
-- source: longhornio/longhorn-engine:v1.7.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.7.2
-  type: image
-- source: longhornio/longhorn-engine:v1.7.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.7.3
-  type: image
-- source: longhornio/longhorn-engine:v1.8.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.8.1
-  type: image
-- source: longhornio/longhorn-engine:v1.8.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.8.2
-  type: image
-- source: longhornio/longhorn-engine:v1.9.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.9.1
-  type: image
-- source: longhornio/longhorn-engine:v1.9.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-engine:v1.9.2
-  type: image
 - source: longhornio/longhorn-instance-manager:v1_20200514
   target: docker.io/rancher/longhornio-longhorn-instance-manager:v1_20200514
   type: image
@@ -11570,33 +6986,6 @@ sync:
   target: registry.suse.com/rancher/longhornio-longhorn-instance-manager:v1_20220808
   type: image
 - source: longhornio/longhorn-instance-manager:v1_20200514
-  target: registry.suse.com/rancher/charts/longhornio-longhorn-instance-manager:v1_20200514
-  type: image
-- source: longhornio/longhorn-instance-manager:v1_20201216
-  target: registry.suse.com/rancher/charts/longhornio-longhorn-instance-manager:v1_20201216
-  type: image
-- source: longhornio/longhorn-instance-manager:v1_20210621
-  target: registry.suse.com/rancher/charts/longhornio-longhorn-instance-manager:v1_20210621
-  type: image
-- source: longhornio/longhorn-instance-manager:v1_20210731
-  target: registry.suse.com/rancher/charts/longhornio-longhorn-instance-manager:v1_20210731
-  type: image
-- source: longhornio/longhorn-instance-manager:v1_20211210
-  target: registry.suse.com/rancher/charts/longhornio-longhorn-instance-manager:v1_20211210
-  type: image
-- source: longhornio/longhorn-instance-manager:v1_20220303
-  target: registry.suse.com/rancher/charts/longhornio-longhorn-instance-manager:v1_20220303
-  type: image
-- source: longhornio/longhorn-instance-manager:v1_20220303_patch1
-  target: registry.suse.com/rancher/charts/longhornio-longhorn-instance-manager:v1_20220303_patch1
-  type: image
-- source: longhornio/longhorn-instance-manager:v1_20220611
-  target: registry.suse.com/rancher/charts/longhornio-longhorn-instance-manager:v1_20220611
-  type: image
-- source: longhornio/longhorn-instance-manager:v1_20220808
-  target: registry.suse.com/rancher/charts/longhornio-longhorn-instance-manager:v1_20220808
-  type: image
-- source: longhornio/longhorn-instance-manager:v1_20200514
   target: stgregistry.suse.com/rancher/longhornio-longhorn-instance-manager:v1_20200514
   type: image
 - source: longhornio/longhorn-instance-manager:v1_20201216
@@ -11622,33 +7011,6 @@ sync:
   type: image
 - source: longhornio/longhorn-instance-manager:v1_20220808
   target: stgregistry.suse.com/rancher/longhornio-longhorn-instance-manager:v1_20220808
-  type: image
-- source: longhornio/longhorn-instance-manager:v1_20200514
-  target: stgregistry.suse.com/rancher/charts/longhornio-longhorn-instance-manager:v1_20200514
-  type: image
-- source: longhornio/longhorn-instance-manager:v1_20201216
-  target: stgregistry.suse.com/rancher/charts/longhornio-longhorn-instance-manager:v1_20201216
-  type: image
-- source: longhornio/longhorn-instance-manager:v1_20210621
-  target: stgregistry.suse.com/rancher/charts/longhornio-longhorn-instance-manager:v1_20210621
-  type: image
-- source: longhornio/longhorn-instance-manager:v1_20210731
-  target: stgregistry.suse.com/rancher/charts/longhornio-longhorn-instance-manager:v1_20210731
-  type: image
-- source: longhornio/longhorn-instance-manager:v1_20211210
-  target: stgregistry.suse.com/rancher/charts/longhornio-longhorn-instance-manager:v1_20211210
-  type: image
-- source: longhornio/longhorn-instance-manager:v1_20220303
-  target: stgregistry.suse.com/rancher/charts/longhornio-longhorn-instance-manager:v1_20220303
-  type: image
-- source: longhornio/longhorn-instance-manager:v1_20220303_patch1
-  target: stgregistry.suse.com/rancher/charts/longhornio-longhorn-instance-manager:v1_20220303_patch1
-  type: image
-- source: longhornio/longhorn-instance-manager:v1_20220611
-  target: stgregistry.suse.com/rancher/charts/longhornio-longhorn-instance-manager:v1_20220611
-  type: image
-- source: longhornio/longhorn-instance-manager:v1_20220808
-  target: stgregistry.suse.com/rancher/charts/longhornio-longhorn-instance-manager:v1_20220808
   type: image
 - source: longhornio/longhorn-instance-manager:v1.4.0
   target: docker.io/rancher/mirrored-longhornio-longhorn-instance-manager:v1.4.0
@@ -11861,111 +7223,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-longhornio-longhorn-instance-manager:v1_20230407
   type: image
 - source: longhornio/longhorn-instance-manager:v1.4.0
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1.4.0
-  type: image
-- source: longhornio/longhorn-instance-manager:v1.4.1
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1.4.1
-  type: image
-- source: longhornio/longhorn-instance-manager:v1.4.2
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1.4.2
-  type: image
-- source: longhornio/longhorn-instance-manager:v1.4.3
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1.4.3
-  type: image
-- source: longhornio/longhorn-instance-manager:v1.4.4
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1.4.4
-  type: image
-- source: longhornio/longhorn-instance-manager:v1.5.0
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1.5.0
-  type: image
-- source: longhornio/longhorn-instance-manager:v1.5.1
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1.5.1
-  type: image
-- source: longhornio/longhorn-instance-manager:v1.5.2
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1.5.2
-  type: image
-- source: longhornio/longhorn-instance-manager:v1.5.3
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1.5.3
-  type: image
-- source: longhornio/longhorn-instance-manager:v1.5.4
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1.5.4
-  type: image
-- source: longhornio/longhorn-instance-manager:v1.5.5
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1.5.5
-  type: image
-- source: longhornio/longhorn-instance-manager:v1.6.0
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1.6.0
-  type: image
-- source: longhornio/longhorn-instance-manager:v1.6.1
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1.6.1
-  type: image
-- source: longhornio/longhorn-instance-manager:v1.6.2
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1.6.2
-  type: image
-- source: longhornio/longhorn-instance-manager:v1.6.3
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1.6.3
-  type: image
-- source: longhornio/longhorn-instance-manager:v1.6.4
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1.6.4
-  type: image
-- source: longhornio/longhorn-instance-manager:v1.7.0
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1.7.0
-  type: image
-- source: longhornio/longhorn-instance-manager:v1.7.1
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1.7.1
-  type: image
-- source: longhornio/longhorn-instance-manager:v1.7.2
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1.7.2
-  type: image
-- source: longhornio/longhorn-instance-manager:v1.7.3
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1.7.3
-  type: image
-- source: longhornio/longhorn-instance-manager:v1.8.1
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1.8.1
-  type: image
-- source: longhornio/longhorn-instance-manager:v1.8.2
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1.8.2
-  type: image
-- source: longhornio/longhorn-instance-manager:v1.9.1
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1.9.1
-  type: image
-- source: longhornio/longhorn-instance-manager:v1.9.2
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1.9.2
-  type: image
-- source: longhornio/longhorn-instance-manager:v1_20201216
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1_20201216
-  type: image
-- source: longhornio/longhorn-instance-manager:v1_20210621
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1_20210621
-  type: image
-- source: longhornio/longhorn-instance-manager:v1_20210731
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1_20210731
-  type: image
-- source: longhornio/longhorn-instance-manager:v1_20211210
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1_20211210
-  type: image
-- source: longhornio/longhorn-instance-manager:v1_20220303
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1_20220303
-  type: image
-- source: longhornio/longhorn-instance-manager:v1_20220303_patch1
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1_20220303_patch1
-  type: image
-- source: longhornio/longhorn-instance-manager:v1_20220303_patch2
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1_20220303_patch2
-  type: image
-- source: longhornio/longhorn-instance-manager:v1_20220611
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1_20220611
-  type: image
-- source: longhornio/longhorn-instance-manager:v1_20220808
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1_20220808
-  type: image
-- source: longhornio/longhorn-instance-manager:v1_20221003
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1_20221003
-  type: image
-- source: longhornio/longhorn-instance-manager:v1_20230407
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1_20230407
-  type: image
-- source: longhornio/longhorn-instance-manager:v1.4.0
   target: stgregistry.suse.com/rancher/mirrored-longhornio-longhorn-instance-manager:v1.4.0
   type: image
 - source: longhornio/longhorn-instance-manager:v1.4.1
@@ -12070,111 +7327,6 @@ sync:
 - source: longhornio/longhorn-instance-manager:v1_20230407
   target: stgregistry.suse.com/rancher/mirrored-longhornio-longhorn-instance-manager:v1_20230407
   type: image
-- source: longhornio/longhorn-instance-manager:v1.4.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1.4.0
-  type: image
-- source: longhornio/longhorn-instance-manager:v1.4.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1.4.1
-  type: image
-- source: longhornio/longhorn-instance-manager:v1.4.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1.4.2
-  type: image
-- source: longhornio/longhorn-instance-manager:v1.4.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1.4.3
-  type: image
-- source: longhornio/longhorn-instance-manager:v1.4.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1.4.4
-  type: image
-- source: longhornio/longhorn-instance-manager:v1.5.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1.5.0
-  type: image
-- source: longhornio/longhorn-instance-manager:v1.5.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1.5.1
-  type: image
-- source: longhornio/longhorn-instance-manager:v1.5.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1.5.2
-  type: image
-- source: longhornio/longhorn-instance-manager:v1.5.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1.5.3
-  type: image
-- source: longhornio/longhorn-instance-manager:v1.5.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1.5.4
-  type: image
-- source: longhornio/longhorn-instance-manager:v1.5.5
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1.5.5
-  type: image
-- source: longhornio/longhorn-instance-manager:v1.6.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1.6.0
-  type: image
-- source: longhornio/longhorn-instance-manager:v1.6.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1.6.1
-  type: image
-- source: longhornio/longhorn-instance-manager:v1.6.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1.6.2
-  type: image
-- source: longhornio/longhorn-instance-manager:v1.6.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1.6.3
-  type: image
-- source: longhornio/longhorn-instance-manager:v1.6.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1.6.4
-  type: image
-- source: longhornio/longhorn-instance-manager:v1.7.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1.7.0
-  type: image
-- source: longhornio/longhorn-instance-manager:v1.7.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1.7.1
-  type: image
-- source: longhornio/longhorn-instance-manager:v1.7.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1.7.2
-  type: image
-- source: longhornio/longhorn-instance-manager:v1.7.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1.7.3
-  type: image
-- source: longhornio/longhorn-instance-manager:v1.8.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1.8.1
-  type: image
-- source: longhornio/longhorn-instance-manager:v1.8.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1.8.2
-  type: image
-- source: longhornio/longhorn-instance-manager:v1.9.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1.9.1
-  type: image
-- source: longhornio/longhorn-instance-manager:v1.9.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1.9.2
-  type: image
-- source: longhornio/longhorn-instance-manager:v1_20201216
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1_20201216
-  type: image
-- source: longhornio/longhorn-instance-manager:v1_20210621
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1_20210621
-  type: image
-- source: longhornio/longhorn-instance-manager:v1_20210731
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1_20210731
-  type: image
-- source: longhornio/longhorn-instance-manager:v1_20211210
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1_20211210
-  type: image
-- source: longhornio/longhorn-instance-manager:v1_20220303
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1_20220303
-  type: image
-- source: longhornio/longhorn-instance-manager:v1_20220303_patch1
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1_20220303_patch1
-  type: image
-- source: longhornio/longhorn-instance-manager:v1_20220303_patch2
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1_20220303_patch2
-  type: image
-- source: longhornio/longhorn-instance-manager:v1_20220611
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1_20220611
-  type: image
-- source: longhornio/longhorn-instance-manager:v1_20220808
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1_20220808
-  type: image
-- source: longhornio/longhorn-instance-manager:v1_20221003
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1_20221003
-  type: image
-- source: longhornio/longhorn-instance-manager:v1_20230407
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-instance-manager:v1_20230407
-  type: image
 - source: longhornio/longhorn-manager:v1.0.2
   target: docker.io/rancher/longhornio-longhorn-manager:v1.0.2
   type: image
@@ -12254,45 +7406,6 @@ sync:
   target: registry.suse.com/rancher/longhornio-longhorn-manager:v1.3.1
   type: image
 - source: longhornio/longhorn-manager:v1.0.2
-  target: registry.suse.com/rancher/charts/longhornio-longhorn-manager:v1.0.2
-  type: image
-- source: longhornio/longhorn-manager:v1.1.0
-  target: registry.suse.com/rancher/charts/longhornio-longhorn-manager:v1.1.0
-  type: image
-- source: longhornio/longhorn-manager:v1.1.1
-  target: registry.suse.com/rancher/charts/longhornio-longhorn-manager:v1.1.1
-  type: image
-- source: longhornio/longhorn-manager:v1.1.2
-  target: registry.suse.com/rancher/charts/longhornio-longhorn-manager:v1.1.2
-  type: image
-- source: longhornio/longhorn-manager:v1.1.3
-  target: registry.suse.com/rancher/charts/longhornio-longhorn-manager:v1.1.3
-  type: image
-- source: longhornio/longhorn-manager:v1.2.0
-  target: registry.suse.com/rancher/charts/longhornio-longhorn-manager:v1.2.0
-  type: image
-- source: longhornio/longhorn-manager:v1.2.1
-  target: registry.suse.com/rancher/charts/longhornio-longhorn-manager:v1.2.1
-  type: image
-- source: longhornio/longhorn-manager:v1.2.2
-  target: registry.suse.com/rancher/charts/longhornio-longhorn-manager:v1.2.2
-  type: image
-- source: longhornio/longhorn-manager:v1.2.3
-  target: registry.suse.com/rancher/charts/longhornio-longhorn-manager:v1.2.3
-  type: image
-- source: longhornio/longhorn-manager:v1.2.4
-  target: registry.suse.com/rancher/charts/longhornio-longhorn-manager:v1.2.4
-  type: image
-- source: longhornio/longhorn-manager:v1.2.5
-  target: registry.suse.com/rancher/charts/longhornio-longhorn-manager:v1.2.5
-  type: image
-- source: longhornio/longhorn-manager:v1.3.0
-  target: registry.suse.com/rancher/charts/longhornio-longhorn-manager:v1.3.0
-  type: image
-- source: longhornio/longhorn-manager:v1.3.1
-  target: registry.suse.com/rancher/charts/longhornio-longhorn-manager:v1.3.1
-  type: image
-- source: longhornio/longhorn-manager:v1.0.2
   target: stgregistry.suse.com/rancher/longhornio-longhorn-manager:v1.0.2
   type: image
 - source: longhornio/longhorn-manager:v1.1.0
@@ -12330,45 +7443,6 @@ sync:
   type: image
 - source: longhornio/longhorn-manager:v1.3.1
   target: stgregistry.suse.com/rancher/longhornio-longhorn-manager:v1.3.1
-  type: image
-- source: longhornio/longhorn-manager:v1.0.2
-  target: stgregistry.suse.com/rancher/charts/longhornio-longhorn-manager:v1.0.2
-  type: image
-- source: longhornio/longhorn-manager:v1.1.0
-  target: stgregistry.suse.com/rancher/charts/longhornio-longhorn-manager:v1.1.0
-  type: image
-- source: longhornio/longhorn-manager:v1.1.1
-  target: stgregistry.suse.com/rancher/charts/longhornio-longhorn-manager:v1.1.1
-  type: image
-- source: longhornio/longhorn-manager:v1.1.2
-  target: stgregistry.suse.com/rancher/charts/longhornio-longhorn-manager:v1.1.2
-  type: image
-- source: longhornio/longhorn-manager:v1.1.3
-  target: stgregistry.suse.com/rancher/charts/longhornio-longhorn-manager:v1.1.3
-  type: image
-- source: longhornio/longhorn-manager:v1.2.0
-  target: stgregistry.suse.com/rancher/charts/longhornio-longhorn-manager:v1.2.0
-  type: image
-- source: longhornio/longhorn-manager:v1.2.1
-  target: stgregistry.suse.com/rancher/charts/longhornio-longhorn-manager:v1.2.1
-  type: image
-- source: longhornio/longhorn-manager:v1.2.2
-  target: stgregistry.suse.com/rancher/charts/longhornio-longhorn-manager:v1.2.2
-  type: image
-- source: longhornio/longhorn-manager:v1.2.3
-  target: stgregistry.suse.com/rancher/charts/longhornio-longhorn-manager:v1.2.3
-  type: image
-- source: longhornio/longhorn-manager:v1.2.4
-  target: stgregistry.suse.com/rancher/charts/longhornio-longhorn-manager:v1.2.4
-  type: image
-- source: longhornio/longhorn-manager:v1.2.5
-  target: stgregistry.suse.com/rancher/charts/longhornio-longhorn-manager:v1.2.5
-  type: image
-- source: longhornio/longhorn-manager:v1.3.0
-  target: stgregistry.suse.com/rancher/charts/longhornio-longhorn-manager:v1.3.0
-  type: image
-- source: longhornio/longhorn-manager:v1.3.1
-  target: stgregistry.suse.com/rancher/charts/longhornio-longhorn-manager:v1.3.1
   type: image
 - source: longhornio/longhorn-manager:v1.1.0
   target: docker.io/rancher/mirrored-longhornio-longhorn-manager:v1.1.0
@@ -12605,123 +7679,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-longhornio-longhorn-manager:v1.9.2
   type: image
 - source: longhornio/longhorn-manager:v1.1.0
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.1.0
-  type: image
-- source: longhornio/longhorn-manager:v1.1.1
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.1.1
-  type: image
-- source: longhornio/longhorn-manager:v1.1.2
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.1.2
-  type: image
-- source: longhornio/longhorn-manager:v1.1.3
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.1.3
-  type: image
-- source: longhornio/longhorn-manager:v1.2.0
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.2.0
-  type: image
-- source: longhornio/longhorn-manager:v1.2.1
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.2.1
-  type: image
-- source: longhornio/longhorn-manager:v1.2.2
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.2.2
-  type: image
-- source: longhornio/longhorn-manager:v1.2.3
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.2.3
-  type: image
-- source: longhornio/longhorn-manager:v1.2.4
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.2.4
-  type: image
-- source: longhornio/longhorn-manager:v1.2.5
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.2.5
-  type: image
-- source: longhornio/longhorn-manager:v1.2.6
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.2.6
-  type: image
-- source: longhornio/longhorn-manager:v1.3.0
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.3.0
-  type: image
-- source: longhornio/longhorn-manager:v1.3.1
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.3.1
-  type: image
-- source: longhornio/longhorn-manager:v1.3.2
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.3.2
-  type: image
-- source: longhornio/longhorn-manager:v1.3.3
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.3.3
-  type: image
-- source: longhornio/longhorn-manager:v1.4.0
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.4.0
-  type: image
-- source: longhornio/longhorn-manager:v1.4.1
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.4.1
-  type: image
-- source: longhornio/longhorn-manager:v1.4.2
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.4.2
-  type: image
-- source: longhornio/longhorn-manager:v1.4.3
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.4.3
-  type: image
-- source: longhornio/longhorn-manager:v1.4.4
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.4.4
-  type: image
-- source: longhornio/longhorn-manager:v1.5.0
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.5.0
-  type: image
-- source: longhornio/longhorn-manager:v1.5.1
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.5.1
-  type: image
-- source: longhornio/longhorn-manager:v1.5.2
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.5.2
-  type: image
-- source: longhornio/longhorn-manager:v1.5.3
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.5.3
-  type: image
-- source: longhornio/longhorn-manager:v1.5.4
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.5.4
-  type: image
-- source: longhornio/longhorn-manager:v1.5.5
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.5.5
-  type: image
-- source: longhornio/longhorn-manager:v1.6.0
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.6.0
-  type: image
-- source: longhornio/longhorn-manager:v1.6.1
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.6.1
-  type: image
-- source: longhornio/longhorn-manager:v1.6.2
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.6.2
-  type: image
-- source: longhornio/longhorn-manager:v1.6.3
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.6.3
-  type: image
-- source: longhornio/longhorn-manager:v1.6.4
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.6.4
-  type: image
-- source: longhornio/longhorn-manager:v1.7.0
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.7.0
-  type: image
-- source: longhornio/longhorn-manager:v1.7.1
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.7.1
-  type: image
-- source: longhornio/longhorn-manager:v1.7.2
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.7.2
-  type: image
-- source: longhornio/longhorn-manager:v1.7.3
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.7.3
-  type: image
-- source: longhornio/longhorn-manager:v1.8.1
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.8.1
-  type: image
-- source: longhornio/longhorn-manager:v1.8.2
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.8.2
-  type: image
-- source: longhornio/longhorn-manager:v1.9.1
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.9.1
-  type: image
-- source: longhornio/longhorn-manager:v1.9.2
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.9.2
-  type: image
-- source: longhornio/longhorn-manager:v1.1.0
   target: stgregistry.suse.com/rancher/mirrored-longhornio-longhorn-manager:v1.1.0
   type: image
 - source: longhornio/longhorn-manager:v1.1.1
@@ -12838,123 +7795,6 @@ sync:
 - source: longhornio/longhorn-manager:v1.9.2
   target: stgregistry.suse.com/rancher/mirrored-longhornio-longhorn-manager:v1.9.2
   type: image
-- source: longhornio/longhorn-manager:v1.1.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.1.0
-  type: image
-- source: longhornio/longhorn-manager:v1.1.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.1.1
-  type: image
-- source: longhornio/longhorn-manager:v1.1.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.1.2
-  type: image
-- source: longhornio/longhorn-manager:v1.1.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.1.3
-  type: image
-- source: longhornio/longhorn-manager:v1.2.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.2.0
-  type: image
-- source: longhornio/longhorn-manager:v1.2.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.2.1
-  type: image
-- source: longhornio/longhorn-manager:v1.2.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.2.2
-  type: image
-- source: longhornio/longhorn-manager:v1.2.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.2.3
-  type: image
-- source: longhornio/longhorn-manager:v1.2.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.2.4
-  type: image
-- source: longhornio/longhorn-manager:v1.2.5
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.2.5
-  type: image
-- source: longhornio/longhorn-manager:v1.2.6
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.2.6
-  type: image
-- source: longhornio/longhorn-manager:v1.3.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.3.0
-  type: image
-- source: longhornio/longhorn-manager:v1.3.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.3.1
-  type: image
-- source: longhornio/longhorn-manager:v1.3.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.3.2
-  type: image
-- source: longhornio/longhorn-manager:v1.3.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.3.3
-  type: image
-- source: longhornio/longhorn-manager:v1.4.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.4.0
-  type: image
-- source: longhornio/longhorn-manager:v1.4.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.4.1
-  type: image
-- source: longhornio/longhorn-manager:v1.4.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.4.2
-  type: image
-- source: longhornio/longhorn-manager:v1.4.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.4.3
-  type: image
-- source: longhornio/longhorn-manager:v1.4.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.4.4
-  type: image
-- source: longhornio/longhorn-manager:v1.5.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.5.0
-  type: image
-- source: longhornio/longhorn-manager:v1.5.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.5.1
-  type: image
-- source: longhornio/longhorn-manager:v1.5.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.5.2
-  type: image
-- source: longhornio/longhorn-manager:v1.5.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.5.3
-  type: image
-- source: longhornio/longhorn-manager:v1.5.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.5.4
-  type: image
-- source: longhornio/longhorn-manager:v1.5.5
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.5.5
-  type: image
-- source: longhornio/longhorn-manager:v1.6.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.6.0
-  type: image
-- source: longhornio/longhorn-manager:v1.6.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.6.1
-  type: image
-- source: longhornio/longhorn-manager:v1.6.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.6.2
-  type: image
-- source: longhornio/longhorn-manager:v1.6.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.6.3
-  type: image
-- source: longhornio/longhorn-manager:v1.6.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.6.4
-  type: image
-- source: longhornio/longhorn-manager:v1.7.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.7.0
-  type: image
-- source: longhornio/longhorn-manager:v1.7.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.7.1
-  type: image
-- source: longhornio/longhorn-manager:v1.7.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.7.2
-  type: image
-- source: longhornio/longhorn-manager:v1.7.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.7.3
-  type: image
-- source: longhornio/longhorn-manager:v1.8.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.8.1
-  type: image
-- source: longhornio/longhorn-manager:v1.8.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.8.2
-  type: image
-- source: longhornio/longhorn-manager:v1.9.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.9.1
-  type: image
-- source: longhornio/longhorn-manager:v1.9.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-manager:v1.9.2
-  type: image
 - source: longhornio/longhorn-share-manager:v1_20201204
   target: docker.io/rancher/longhornio-longhorn-share-manager:v1_20201204
   type: image
@@ -13010,33 +7850,6 @@ sync:
   target: registry.suse.com/rancher/longhornio-longhorn-share-manager:v1_20220808
   type: image
 - source: longhornio/longhorn-share-manager:v1_20201204
-  target: registry.suse.com/rancher/charts/longhornio-longhorn-share-manager:v1_20201204
-  type: image
-- source: longhornio/longhorn-share-manager:v1_20210416
-  target: registry.suse.com/rancher/charts/longhornio-longhorn-share-manager:v1_20210416
-  type: image
-- source: longhornio/longhorn-share-manager:v1_20210416_patch1
-  target: registry.suse.com/rancher/charts/longhornio-longhorn-share-manager:v1_20210416_patch1
-  type: image
-- source: longhornio/longhorn-share-manager:v1_20210820
-  target: registry.suse.com/rancher/charts/longhornio-longhorn-share-manager:v1_20210820
-  type: image
-- source: longhornio/longhorn-share-manager:v1_20210914
-  target: registry.suse.com/rancher/charts/longhornio-longhorn-share-manager:v1_20210914
-  type: image
-- source: longhornio/longhorn-share-manager:v1_20211020
-  target: registry.suse.com/rancher/charts/longhornio-longhorn-share-manager:v1_20211020
-  type: image
-- source: longhornio/longhorn-share-manager:v1_20211020_patch1
-  target: registry.suse.com/rancher/charts/longhornio-longhorn-share-manager:v1_20211020_patch1
-  type: image
-- source: longhornio/longhorn-share-manager:v1_20220531
-  target: registry.suse.com/rancher/charts/longhornio-longhorn-share-manager:v1_20220531
-  type: image
-- source: longhornio/longhorn-share-manager:v1_20220808
-  target: registry.suse.com/rancher/charts/longhornio-longhorn-share-manager:v1_20220808
-  type: image
-- source: longhornio/longhorn-share-manager:v1_20201204
   target: stgregistry.suse.com/rancher/longhornio-longhorn-share-manager:v1_20201204
   type: image
 - source: longhornio/longhorn-share-manager:v1_20210416
@@ -13062,33 +7875,6 @@ sync:
   type: image
 - source: longhornio/longhorn-share-manager:v1_20220808
   target: stgregistry.suse.com/rancher/longhornio-longhorn-share-manager:v1_20220808
-  type: image
-- source: longhornio/longhorn-share-manager:v1_20201204
-  target: stgregistry.suse.com/rancher/charts/longhornio-longhorn-share-manager:v1_20201204
-  type: image
-- source: longhornio/longhorn-share-manager:v1_20210416
-  target: stgregistry.suse.com/rancher/charts/longhornio-longhorn-share-manager:v1_20210416
-  type: image
-- source: longhornio/longhorn-share-manager:v1_20210416_patch1
-  target: stgregistry.suse.com/rancher/charts/longhornio-longhorn-share-manager:v1_20210416_patch1
-  type: image
-- source: longhornio/longhorn-share-manager:v1_20210820
-  target: stgregistry.suse.com/rancher/charts/longhornio-longhorn-share-manager:v1_20210820
-  type: image
-- source: longhornio/longhorn-share-manager:v1_20210914
-  target: stgregistry.suse.com/rancher/charts/longhornio-longhorn-share-manager:v1_20210914
-  type: image
-- source: longhornio/longhorn-share-manager:v1_20211020
-  target: stgregistry.suse.com/rancher/charts/longhornio-longhorn-share-manager:v1_20211020
-  type: image
-- source: longhornio/longhorn-share-manager:v1_20211020_patch1
-  target: stgregistry.suse.com/rancher/charts/longhornio-longhorn-share-manager:v1_20211020_patch1
-  type: image
-- source: longhornio/longhorn-share-manager:v1_20220531
-  target: stgregistry.suse.com/rancher/charts/longhornio-longhorn-share-manager:v1_20220531
-  type: image
-- source: longhornio/longhorn-share-manager:v1_20220808
-  target: stgregistry.suse.com/rancher/charts/longhornio-longhorn-share-manager:v1_20220808
   type: image
 - source: longhornio/longhorn-share-manager:v1.4.0
   target: docker.io/rancher/mirrored-longhornio-longhorn-share-manager:v1.4.0
@@ -13307,114 +8093,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-longhornio-longhorn-share-manager:v1_20230320
   type: image
 - source: longhornio/longhorn-share-manager:v1.4.0
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1.4.0
-  type: image
-- source: longhornio/longhorn-share-manager:v1.4.1
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1.4.1
-  type: image
-- source: longhornio/longhorn-share-manager:v1.4.2
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1.4.2
-  type: image
-- source: longhornio/longhorn-share-manager:v1.4.3
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1.4.3
-  type: image
-- source: longhornio/longhorn-share-manager:v1.4.4
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1.4.4
-  type: image
-- source: longhornio/longhorn-share-manager:v1.5.0
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1.5.0
-  type: image
-- source: longhornio/longhorn-share-manager:v1.5.1
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1.5.1
-  type: image
-- source: longhornio/longhorn-share-manager:v1.5.2
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1.5.2
-  type: image
-- source: longhornio/longhorn-share-manager:v1.5.3
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1.5.3
-  type: image
-- source: longhornio/longhorn-share-manager:v1.5.4
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1.5.4
-  type: image
-- source: longhornio/longhorn-share-manager:v1.5.5
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1.5.5
-  type: image
-- source: longhornio/longhorn-share-manager:v1.6.0
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1.6.0
-  type: image
-- source: longhornio/longhorn-share-manager:v1.6.1
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1.6.1
-  type: image
-- source: longhornio/longhorn-share-manager:v1.6.2
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1.6.2
-  type: image
-- source: longhornio/longhorn-share-manager:v1.6.3
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1.6.3
-  type: image
-- source: longhornio/longhorn-share-manager:v1.6.4
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1.6.4
-  type: image
-- source: longhornio/longhorn-share-manager:v1.7.0
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1.7.0
-  type: image
-- source: longhornio/longhorn-share-manager:v1.7.1
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1.7.1
-  type: image
-- source: longhornio/longhorn-share-manager:v1.7.2
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1.7.2
-  type: image
-- source: longhornio/longhorn-share-manager:v1.7.3
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1.7.3
-  type: image
-- source: longhornio/longhorn-share-manager:v1.8.1
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1.8.1
-  type: image
-- source: longhornio/longhorn-share-manager:v1.8.2
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1.8.2
-  type: image
-- source: longhornio/longhorn-share-manager:v1.9.1
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1.9.1
-  type: image
-- source: longhornio/longhorn-share-manager:v1.9.2
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1.9.2
-  type: image
-- source: longhornio/longhorn-share-manager:v1_20201204
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1_20201204
-  type: image
-- source: longhornio/longhorn-share-manager:v1_20210416
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1_20210416
-  type: image
-- source: longhornio/longhorn-share-manager:v1_20210416_patch1
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1_20210416_patch1
-  type: image
-- source: longhornio/longhorn-share-manager:v1_20210820
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1_20210820
-  type: image
-- source: longhornio/longhorn-share-manager:v1_20210914
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1_20210914
-  type: image
-- source: longhornio/longhorn-share-manager:v1_20211020
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1_20211020
-  type: image
-- source: longhornio/longhorn-share-manager:v1_20211020_patch1
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1_20211020_patch1
-  type: image
-- source: longhornio/longhorn-share-manager:v1_20211020_patch2
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1_20211020_patch2
-  type: image
-- source: longhornio/longhorn-share-manager:v1_20220531
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1_20220531
-  type: image
-- source: longhornio/longhorn-share-manager:v1_20220808
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1_20220808
-  type: image
-- source: longhornio/longhorn-share-manager:v1_20221003
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1_20221003
-  type: image
-- source: longhornio/longhorn-share-manager:v1_20230320
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1_20230320
-  type: image
-- source: longhornio/longhorn-share-manager:v1.4.0
   target: stgregistry.suse.com/rancher/mirrored-longhornio-longhorn-share-manager:v1.4.0
   type: image
 - source: longhornio/longhorn-share-manager:v1.4.1
@@ -13522,114 +8200,6 @@ sync:
 - source: longhornio/longhorn-share-manager:v1_20230320
   target: stgregistry.suse.com/rancher/mirrored-longhornio-longhorn-share-manager:v1_20230320
   type: image
-- source: longhornio/longhorn-share-manager:v1.4.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1.4.0
-  type: image
-- source: longhornio/longhorn-share-manager:v1.4.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1.4.1
-  type: image
-- source: longhornio/longhorn-share-manager:v1.4.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1.4.2
-  type: image
-- source: longhornio/longhorn-share-manager:v1.4.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1.4.3
-  type: image
-- source: longhornio/longhorn-share-manager:v1.4.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1.4.4
-  type: image
-- source: longhornio/longhorn-share-manager:v1.5.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1.5.0
-  type: image
-- source: longhornio/longhorn-share-manager:v1.5.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1.5.1
-  type: image
-- source: longhornio/longhorn-share-manager:v1.5.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1.5.2
-  type: image
-- source: longhornio/longhorn-share-manager:v1.5.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1.5.3
-  type: image
-- source: longhornio/longhorn-share-manager:v1.5.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1.5.4
-  type: image
-- source: longhornio/longhorn-share-manager:v1.5.5
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1.5.5
-  type: image
-- source: longhornio/longhorn-share-manager:v1.6.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1.6.0
-  type: image
-- source: longhornio/longhorn-share-manager:v1.6.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1.6.1
-  type: image
-- source: longhornio/longhorn-share-manager:v1.6.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1.6.2
-  type: image
-- source: longhornio/longhorn-share-manager:v1.6.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1.6.3
-  type: image
-- source: longhornio/longhorn-share-manager:v1.6.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1.6.4
-  type: image
-- source: longhornio/longhorn-share-manager:v1.7.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1.7.0
-  type: image
-- source: longhornio/longhorn-share-manager:v1.7.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1.7.1
-  type: image
-- source: longhornio/longhorn-share-manager:v1.7.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1.7.2
-  type: image
-- source: longhornio/longhorn-share-manager:v1.7.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1.7.3
-  type: image
-- source: longhornio/longhorn-share-manager:v1.8.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1.8.1
-  type: image
-- source: longhornio/longhorn-share-manager:v1.8.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1.8.2
-  type: image
-- source: longhornio/longhorn-share-manager:v1.9.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1.9.1
-  type: image
-- source: longhornio/longhorn-share-manager:v1.9.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1.9.2
-  type: image
-- source: longhornio/longhorn-share-manager:v1_20201204
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1_20201204
-  type: image
-- source: longhornio/longhorn-share-manager:v1_20210416
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1_20210416
-  type: image
-- source: longhornio/longhorn-share-manager:v1_20210416_patch1
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1_20210416_patch1
-  type: image
-- source: longhornio/longhorn-share-manager:v1_20210820
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1_20210820
-  type: image
-- source: longhornio/longhorn-share-manager:v1_20210914
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1_20210914
-  type: image
-- source: longhornio/longhorn-share-manager:v1_20211020
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1_20211020
-  type: image
-- source: longhornio/longhorn-share-manager:v1_20211020_patch1
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1_20211020_patch1
-  type: image
-- source: longhornio/longhorn-share-manager:v1_20211020_patch2
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1_20211020_patch2
-  type: image
-- source: longhornio/longhorn-share-manager:v1_20220531
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1_20220531
-  type: image
-- source: longhornio/longhorn-share-manager:v1_20220808
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1_20220808
-  type: image
-- source: longhornio/longhorn-share-manager:v1_20221003
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1_20221003
-  type: image
-- source: longhornio/longhorn-share-manager:v1_20230320
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-share-manager:v1_20230320
-  type: image
 - source: longhornio/longhorn-ui:v1.0.2
   target: docker.io/rancher/longhornio-longhorn-ui:v1.0.2
   type: image
@@ -13709,45 +8279,6 @@ sync:
   target: registry.suse.com/rancher/longhornio-longhorn-ui:v1.3.1
   type: image
 - source: longhornio/longhorn-ui:v1.0.2
-  target: registry.suse.com/rancher/charts/longhornio-longhorn-ui:v1.0.2
-  type: image
-- source: longhornio/longhorn-ui:v1.1.0
-  target: registry.suse.com/rancher/charts/longhornio-longhorn-ui:v1.1.0
-  type: image
-- source: longhornio/longhorn-ui:v1.1.1
-  target: registry.suse.com/rancher/charts/longhornio-longhorn-ui:v1.1.1
-  type: image
-- source: longhornio/longhorn-ui:v1.1.2
-  target: registry.suse.com/rancher/charts/longhornio-longhorn-ui:v1.1.2
-  type: image
-- source: longhornio/longhorn-ui:v1.1.3
-  target: registry.suse.com/rancher/charts/longhornio-longhorn-ui:v1.1.3
-  type: image
-- source: longhornio/longhorn-ui:v1.2.0
-  target: registry.suse.com/rancher/charts/longhornio-longhorn-ui:v1.2.0
-  type: image
-- source: longhornio/longhorn-ui:v1.2.1
-  target: registry.suse.com/rancher/charts/longhornio-longhorn-ui:v1.2.1
-  type: image
-- source: longhornio/longhorn-ui:v1.2.2
-  target: registry.suse.com/rancher/charts/longhornio-longhorn-ui:v1.2.2
-  type: image
-- source: longhornio/longhorn-ui:v1.2.3
-  target: registry.suse.com/rancher/charts/longhornio-longhorn-ui:v1.2.3
-  type: image
-- source: longhornio/longhorn-ui:v1.2.4
-  target: registry.suse.com/rancher/charts/longhornio-longhorn-ui:v1.2.4
-  type: image
-- source: longhornio/longhorn-ui:v1.2.5
-  target: registry.suse.com/rancher/charts/longhornio-longhorn-ui:v1.2.5
-  type: image
-- source: longhornio/longhorn-ui:v1.3.0
-  target: registry.suse.com/rancher/charts/longhornio-longhorn-ui:v1.3.0
-  type: image
-- source: longhornio/longhorn-ui:v1.3.1
-  target: registry.suse.com/rancher/charts/longhornio-longhorn-ui:v1.3.1
-  type: image
-- source: longhornio/longhorn-ui:v1.0.2
   target: stgregistry.suse.com/rancher/longhornio-longhorn-ui:v1.0.2
   type: image
 - source: longhornio/longhorn-ui:v1.1.0
@@ -13785,45 +8316,6 @@ sync:
   type: image
 - source: longhornio/longhorn-ui:v1.3.1
   target: stgregistry.suse.com/rancher/longhornio-longhorn-ui:v1.3.1
-  type: image
-- source: longhornio/longhorn-ui:v1.0.2
-  target: stgregistry.suse.com/rancher/charts/longhornio-longhorn-ui:v1.0.2
-  type: image
-- source: longhornio/longhorn-ui:v1.1.0
-  target: stgregistry.suse.com/rancher/charts/longhornio-longhorn-ui:v1.1.0
-  type: image
-- source: longhornio/longhorn-ui:v1.1.1
-  target: stgregistry.suse.com/rancher/charts/longhornio-longhorn-ui:v1.1.1
-  type: image
-- source: longhornio/longhorn-ui:v1.1.2
-  target: stgregistry.suse.com/rancher/charts/longhornio-longhorn-ui:v1.1.2
-  type: image
-- source: longhornio/longhorn-ui:v1.1.3
-  target: stgregistry.suse.com/rancher/charts/longhornio-longhorn-ui:v1.1.3
-  type: image
-- source: longhornio/longhorn-ui:v1.2.0
-  target: stgregistry.suse.com/rancher/charts/longhornio-longhorn-ui:v1.2.0
-  type: image
-- source: longhornio/longhorn-ui:v1.2.1
-  target: stgregistry.suse.com/rancher/charts/longhornio-longhorn-ui:v1.2.1
-  type: image
-- source: longhornio/longhorn-ui:v1.2.2
-  target: stgregistry.suse.com/rancher/charts/longhornio-longhorn-ui:v1.2.2
-  type: image
-- source: longhornio/longhorn-ui:v1.2.3
-  target: stgregistry.suse.com/rancher/charts/longhornio-longhorn-ui:v1.2.3
-  type: image
-- source: longhornio/longhorn-ui:v1.2.4
-  target: stgregistry.suse.com/rancher/charts/longhornio-longhorn-ui:v1.2.4
-  type: image
-- source: longhornio/longhorn-ui:v1.2.5
-  target: stgregistry.suse.com/rancher/charts/longhornio-longhorn-ui:v1.2.5
-  type: image
-- source: longhornio/longhorn-ui:v1.3.0
-  target: stgregistry.suse.com/rancher/charts/longhornio-longhorn-ui:v1.3.0
-  type: image
-- source: longhornio/longhorn-ui:v1.3.1
-  target: stgregistry.suse.com/rancher/charts/longhornio-longhorn-ui:v1.3.1
   type: image
 - source: longhornio/longhorn-ui:v1.1.0
   target: docker.io/rancher/mirrored-longhornio-longhorn-ui:v1.1.0
@@ -14060,123 +8552,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-longhornio-longhorn-ui:v1.9.2
   type: image
 - source: longhornio/longhorn-ui:v1.1.0
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.1.0
-  type: image
-- source: longhornio/longhorn-ui:v1.1.1
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.1.1
-  type: image
-- source: longhornio/longhorn-ui:v1.1.2
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.1.2
-  type: image
-- source: longhornio/longhorn-ui:v1.1.3
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.1.3
-  type: image
-- source: longhornio/longhorn-ui:v1.2.0
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.2.0
-  type: image
-- source: longhornio/longhorn-ui:v1.2.1
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.2.1
-  type: image
-- source: longhornio/longhorn-ui:v1.2.2
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.2.2
-  type: image
-- source: longhornio/longhorn-ui:v1.2.3
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.2.3
-  type: image
-- source: longhornio/longhorn-ui:v1.2.4
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.2.4
-  type: image
-- source: longhornio/longhorn-ui:v1.2.5
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.2.5
-  type: image
-- source: longhornio/longhorn-ui:v1.2.6
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.2.6
-  type: image
-- source: longhornio/longhorn-ui:v1.3.0
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.3.0
-  type: image
-- source: longhornio/longhorn-ui:v1.3.1
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.3.1
-  type: image
-- source: longhornio/longhorn-ui:v1.3.2
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.3.2
-  type: image
-- source: longhornio/longhorn-ui:v1.3.3
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.3.3
-  type: image
-- source: longhornio/longhorn-ui:v1.4.0
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.4.0
-  type: image
-- source: longhornio/longhorn-ui:v1.4.1
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.4.1
-  type: image
-- source: longhornio/longhorn-ui:v1.4.2
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.4.2
-  type: image
-- source: longhornio/longhorn-ui:v1.4.3
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.4.3
-  type: image
-- source: longhornio/longhorn-ui:v1.4.4
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.4.4
-  type: image
-- source: longhornio/longhorn-ui:v1.5.0
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.5.0
-  type: image
-- source: longhornio/longhorn-ui:v1.5.1
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.5.1
-  type: image
-- source: longhornio/longhorn-ui:v1.5.2
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.5.2
-  type: image
-- source: longhornio/longhorn-ui:v1.5.3
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.5.3
-  type: image
-- source: longhornio/longhorn-ui:v1.5.4
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.5.4
-  type: image
-- source: longhornio/longhorn-ui:v1.5.5
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.5.5
-  type: image
-- source: longhornio/longhorn-ui:v1.6.0
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.6.0
-  type: image
-- source: longhornio/longhorn-ui:v1.6.1
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.6.1
-  type: image
-- source: longhornio/longhorn-ui:v1.6.2
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.6.2
-  type: image
-- source: longhornio/longhorn-ui:v1.6.3
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.6.3
-  type: image
-- source: longhornio/longhorn-ui:v1.6.4
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.6.4
-  type: image
-- source: longhornio/longhorn-ui:v1.7.0
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.7.0
-  type: image
-- source: longhornio/longhorn-ui:v1.7.1
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.7.1
-  type: image
-- source: longhornio/longhorn-ui:v1.7.2
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.7.2
-  type: image
-- source: longhornio/longhorn-ui:v1.7.3
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.7.3
-  type: image
-- source: longhornio/longhorn-ui:v1.8.1
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.8.1
-  type: image
-- source: longhornio/longhorn-ui:v1.8.2
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.8.2
-  type: image
-- source: longhornio/longhorn-ui:v1.9.1
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.9.1
-  type: image
-- source: longhornio/longhorn-ui:v1.9.2
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.9.2
-  type: image
-- source: longhornio/longhorn-ui:v1.1.0
   target: stgregistry.suse.com/rancher/mirrored-longhornio-longhorn-ui:v1.1.0
   type: image
 - source: longhornio/longhorn-ui:v1.1.1
@@ -14293,123 +8668,6 @@ sync:
 - source: longhornio/longhorn-ui:v1.9.2
   target: stgregistry.suse.com/rancher/mirrored-longhornio-longhorn-ui:v1.9.2
   type: image
-- source: longhornio/longhorn-ui:v1.1.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.1.0
-  type: image
-- source: longhornio/longhorn-ui:v1.1.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.1.1
-  type: image
-- source: longhornio/longhorn-ui:v1.1.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.1.2
-  type: image
-- source: longhornio/longhorn-ui:v1.1.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.1.3
-  type: image
-- source: longhornio/longhorn-ui:v1.2.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.2.0
-  type: image
-- source: longhornio/longhorn-ui:v1.2.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.2.1
-  type: image
-- source: longhornio/longhorn-ui:v1.2.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.2.2
-  type: image
-- source: longhornio/longhorn-ui:v1.2.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.2.3
-  type: image
-- source: longhornio/longhorn-ui:v1.2.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.2.4
-  type: image
-- source: longhornio/longhorn-ui:v1.2.5
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.2.5
-  type: image
-- source: longhornio/longhorn-ui:v1.2.6
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.2.6
-  type: image
-- source: longhornio/longhorn-ui:v1.3.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.3.0
-  type: image
-- source: longhornio/longhorn-ui:v1.3.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.3.1
-  type: image
-- source: longhornio/longhorn-ui:v1.3.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.3.2
-  type: image
-- source: longhornio/longhorn-ui:v1.3.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.3.3
-  type: image
-- source: longhornio/longhorn-ui:v1.4.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.4.0
-  type: image
-- source: longhornio/longhorn-ui:v1.4.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.4.1
-  type: image
-- source: longhornio/longhorn-ui:v1.4.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.4.2
-  type: image
-- source: longhornio/longhorn-ui:v1.4.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.4.3
-  type: image
-- source: longhornio/longhorn-ui:v1.4.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.4.4
-  type: image
-- source: longhornio/longhorn-ui:v1.5.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.5.0
-  type: image
-- source: longhornio/longhorn-ui:v1.5.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.5.1
-  type: image
-- source: longhornio/longhorn-ui:v1.5.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.5.2
-  type: image
-- source: longhornio/longhorn-ui:v1.5.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.5.3
-  type: image
-- source: longhornio/longhorn-ui:v1.5.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.5.4
-  type: image
-- source: longhornio/longhorn-ui:v1.5.5
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.5.5
-  type: image
-- source: longhornio/longhorn-ui:v1.6.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.6.0
-  type: image
-- source: longhornio/longhorn-ui:v1.6.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.6.1
-  type: image
-- source: longhornio/longhorn-ui:v1.6.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.6.2
-  type: image
-- source: longhornio/longhorn-ui:v1.6.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.6.3
-  type: image
-- source: longhornio/longhorn-ui:v1.6.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.6.4
-  type: image
-- source: longhornio/longhorn-ui:v1.7.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.7.0
-  type: image
-- source: longhornio/longhorn-ui:v1.7.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.7.1
-  type: image
-- source: longhornio/longhorn-ui:v1.7.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.7.2
-  type: image
-- source: longhornio/longhorn-ui:v1.7.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.7.3
-  type: image
-- source: longhornio/longhorn-ui:v1.8.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.8.1
-  type: image
-- source: longhornio/longhorn-ui:v1.8.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.8.2
-  type: image
-- source: longhornio/longhorn-ui:v1.9.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.9.1
-  type: image
-- source: longhornio/longhorn-ui:v1.9.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-longhorn-ui:v1.9.2
-  type: image
 - source: longhornio/openshift-origin-oauth-proxy:4.14
   target: docker.io/rancher/mirrored-longhornio-openshift-origin-oauth-proxy:4.14
   type: image
@@ -14423,22 +8681,10 @@ sync:
   target: registry.suse.com/rancher/mirrored-longhornio-openshift-origin-oauth-proxy:4.15
   type: image
 - source: longhornio/openshift-origin-oauth-proxy:4.14
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-openshift-origin-oauth-proxy:4.14
-  type: image
-- source: longhornio/openshift-origin-oauth-proxy:4.15
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-openshift-origin-oauth-proxy:4.15
-  type: image
-- source: longhornio/openshift-origin-oauth-proxy:4.14
   target: stgregistry.suse.com/rancher/mirrored-longhornio-openshift-origin-oauth-proxy:4.14
   type: image
 - source: longhornio/openshift-origin-oauth-proxy:4.15
   target: stgregistry.suse.com/rancher/mirrored-longhornio-openshift-origin-oauth-proxy:4.15
-  type: image
-- source: longhornio/openshift-origin-oauth-proxy:4.14
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-openshift-origin-oauth-proxy:4.14
-  type: image
-- source: longhornio/openshift-origin-oauth-proxy:4.15
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-openshift-origin-oauth-proxy:4.15
   type: image
 - source: longhornio/support-bundle-kit:v0.0.17
   target: docker.io/rancher/mirrored-longhornio-support-bundle-kit:v0.0.17
@@ -14555,63 +8801,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-longhornio-support-bundle-kit:v0.0.69
   type: image
 - source: longhornio/support-bundle-kit:v0.0.17
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-support-bundle-kit:v0.0.17
-  type: image
-- source: longhornio/support-bundle-kit:v0.0.19
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-support-bundle-kit:v0.0.19
-  type: image
-- source: longhornio/support-bundle-kit:v0.0.24
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-support-bundle-kit:v0.0.24
-  type: image
-- source: longhornio/support-bundle-kit:v0.0.25
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-support-bundle-kit:v0.0.25
-  type: image
-- source: longhornio/support-bundle-kit:v0.0.27
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-support-bundle-kit:v0.0.27
-  type: image
-- source: longhornio/support-bundle-kit:v0.0.33
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-support-bundle-kit:v0.0.33
-  type: image
-- source: longhornio/support-bundle-kit:v0.0.36
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-support-bundle-kit:v0.0.36
-  type: image
-- source: longhornio/support-bundle-kit:v0.0.37
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-support-bundle-kit:v0.0.37
-  type: image
-- source: longhornio/support-bundle-kit:v0.0.41
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-support-bundle-kit:v0.0.41
-  type: image
-- source: longhornio/support-bundle-kit:v0.0.42
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-support-bundle-kit:v0.0.42
-  type: image
-- source: longhornio/support-bundle-kit:v0.0.43
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-support-bundle-kit:v0.0.43
-  type: image
-- source: longhornio/support-bundle-kit:v0.0.45
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-support-bundle-kit:v0.0.45
-  type: image
-- source: longhornio/support-bundle-kit:v0.0.48
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-support-bundle-kit:v0.0.48
-  type: image
-- source: longhornio/support-bundle-kit:v0.0.49
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-support-bundle-kit:v0.0.49
-  type: image
-- source: longhornio/support-bundle-kit:v0.0.51
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-support-bundle-kit:v0.0.51
-  type: image
-- source: longhornio/support-bundle-kit:v0.0.52
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-support-bundle-kit:v0.0.52
-  type: image
-- source: longhornio/support-bundle-kit:v0.0.56
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-support-bundle-kit:v0.0.56
-  type: image
-- source: longhornio/support-bundle-kit:v0.0.61
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-support-bundle-kit:v0.0.61
-  type: image
-- source: longhornio/support-bundle-kit:v0.0.69
-  target: registry.suse.com/rancher/charts/mirrored-longhornio-support-bundle-kit:v0.0.69
-  type: image
-- source: longhornio/support-bundle-kit:v0.0.17
   target: stgregistry.suse.com/rancher/mirrored-longhornio-support-bundle-kit:v0.0.17
   type: image
 - source: longhornio/support-bundle-kit:v0.0.19
@@ -14668,63 +8857,6 @@ sync:
 - source: longhornio/support-bundle-kit:v0.0.69
   target: stgregistry.suse.com/rancher/mirrored-longhornio-support-bundle-kit:v0.0.69
   type: image
-- source: longhornio/support-bundle-kit:v0.0.17
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-support-bundle-kit:v0.0.17
-  type: image
-- source: longhornio/support-bundle-kit:v0.0.19
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-support-bundle-kit:v0.0.19
-  type: image
-- source: longhornio/support-bundle-kit:v0.0.24
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-support-bundle-kit:v0.0.24
-  type: image
-- source: longhornio/support-bundle-kit:v0.0.25
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-support-bundle-kit:v0.0.25
-  type: image
-- source: longhornio/support-bundle-kit:v0.0.27
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-support-bundle-kit:v0.0.27
-  type: image
-- source: longhornio/support-bundle-kit:v0.0.33
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-support-bundle-kit:v0.0.33
-  type: image
-- source: longhornio/support-bundle-kit:v0.0.36
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-support-bundle-kit:v0.0.36
-  type: image
-- source: longhornio/support-bundle-kit:v0.0.37
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-support-bundle-kit:v0.0.37
-  type: image
-- source: longhornio/support-bundle-kit:v0.0.41
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-support-bundle-kit:v0.0.41
-  type: image
-- source: longhornio/support-bundle-kit:v0.0.42
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-support-bundle-kit:v0.0.42
-  type: image
-- source: longhornio/support-bundle-kit:v0.0.43
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-support-bundle-kit:v0.0.43
-  type: image
-- source: longhornio/support-bundle-kit:v0.0.45
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-support-bundle-kit:v0.0.45
-  type: image
-- source: longhornio/support-bundle-kit:v0.0.48
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-support-bundle-kit:v0.0.48
-  type: image
-- source: longhornio/support-bundle-kit:v0.0.49
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-support-bundle-kit:v0.0.49
-  type: image
-- source: longhornio/support-bundle-kit:v0.0.51
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-support-bundle-kit:v0.0.51
-  type: image
-- source: longhornio/support-bundle-kit:v0.0.52
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-support-bundle-kit:v0.0.52
-  type: image
-- source: longhornio/support-bundle-kit:v0.0.56
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-support-bundle-kit:v0.0.56
-  type: image
-- source: longhornio/support-bundle-kit:v0.0.61
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-support-bundle-kit:v0.0.61
-  type: image
-- source: longhornio/support-bundle-kit:v0.0.69
-  target: stgregistry.suse.com/rancher/charts/mirrored-longhornio-support-bundle-kit:v0.0.69
-  type: image
 - source: messagebird/sachet:0.2.3
   target: docker.io/rancher/mirrored-messagebird-sachet:0.2.3
   type: image
@@ -14744,15 +8876,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-messagebird-sachet:0.3.1
   type: image
 - source: messagebird/sachet:0.2.3
-  target: registry.suse.com/rancher/charts/mirrored-messagebird-sachet:0.2.3
-  type: image
-- source: messagebird/sachet:0.2.6
-  target: registry.suse.com/rancher/charts/mirrored-messagebird-sachet:0.2.6
-  type: image
-- source: messagebird/sachet:0.3.1
-  target: registry.suse.com/rancher/charts/mirrored-messagebird-sachet:0.3.1
-  type: image
-- source: messagebird/sachet:0.2.3
   target: stgregistry.suse.com/rancher/mirrored-messagebird-sachet:0.2.3
   type: image
 - source: messagebird/sachet:0.2.6
@@ -14760,15 +8883,6 @@ sync:
   type: image
 - source: messagebird/sachet:0.3.1
   target: stgregistry.suse.com/rancher/mirrored-messagebird-sachet:0.3.1
-  type: image
-- source: messagebird/sachet:0.2.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-messagebird-sachet:0.2.3
-  type: image
-- source: messagebird/sachet:0.2.6
-  target: stgregistry.suse.com/rancher/charts/mirrored-messagebird-sachet:0.2.6
-  type: image
-- source: messagebird/sachet:0.3.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-messagebird-sachet:0.3.1
   type: image
 - source: minio/mc:RELEASE.2022-05-09T04-08-26Z
   target: docker.io/rancher/mirrored-minio-mc:RELEASE.2022-05-09T04-08-26Z
@@ -14807,24 +8921,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-minio-mc:RELEASE.2023-06-28T21-54-17Z
   type: image
 - source: minio/mc:RELEASE.2022-05-09T04-08-26Z
-  target: registry.suse.com/rancher/charts/mirrored-minio-mc:RELEASE.2022-05-09T04-08-26Z
-  type: image
-- source: minio/mc:RELEASE.2022-09-16T09-16-47Z
-  target: registry.suse.com/rancher/charts/mirrored-minio-mc:RELEASE.2022-09-16T09-16-47Z
-  type: image
-- source: minio/mc:RELEASE.2022-11-07T23-47-39Z
-  target: registry.suse.com/rancher/charts/mirrored-minio-mc:RELEASE.2022-11-07T23-47-39Z
-  type: image
-- source: minio/mc:RELEASE.2022-12-13T00-23-28Z
-  target: registry.suse.com/rancher/charts/mirrored-minio-mc:RELEASE.2022-12-13T00-23-28Z
-  type: image
-- source: minio/mc:RELEASE.2023-01-28T20-29-38Z
-  target: registry.suse.com/rancher/charts/mirrored-minio-mc:RELEASE.2023-01-28T20-29-38Z
-  type: image
-- source: minio/mc:RELEASE.2023-06-28T21-54-17Z
-  target: registry.suse.com/rancher/charts/mirrored-minio-mc:RELEASE.2023-06-28T21-54-17Z
-  type: image
-- source: minio/mc:RELEASE.2022-05-09T04-08-26Z
   target: stgregistry.suse.com/rancher/mirrored-minio-mc:RELEASE.2022-05-09T04-08-26Z
   type: image
 - source: minio/mc:RELEASE.2022-09-16T09-16-47Z
@@ -14841,24 +8937,6 @@ sync:
   type: image
 - source: minio/mc:RELEASE.2023-06-28T21-54-17Z
   target: stgregistry.suse.com/rancher/mirrored-minio-mc:RELEASE.2023-06-28T21-54-17Z
-  type: image
-- source: minio/mc:RELEASE.2022-05-09T04-08-26Z
-  target: stgregistry.suse.com/rancher/charts/mirrored-minio-mc:RELEASE.2022-05-09T04-08-26Z
-  type: image
-- source: minio/mc:RELEASE.2022-09-16T09-16-47Z
-  target: stgregistry.suse.com/rancher/charts/mirrored-minio-mc:RELEASE.2022-09-16T09-16-47Z
-  type: image
-- source: minio/mc:RELEASE.2022-11-07T23-47-39Z
-  target: stgregistry.suse.com/rancher/charts/mirrored-minio-mc:RELEASE.2022-11-07T23-47-39Z
-  type: image
-- source: minio/mc:RELEASE.2022-12-13T00-23-28Z
-  target: stgregistry.suse.com/rancher/charts/mirrored-minio-mc:RELEASE.2022-12-13T00-23-28Z
-  type: image
-- source: minio/mc:RELEASE.2023-01-28T20-29-38Z
-  target: stgregistry.suse.com/rancher/charts/mirrored-minio-mc:RELEASE.2023-01-28T20-29-38Z
-  type: image
-- source: minio/mc:RELEASE.2023-06-28T21-54-17Z
-  target: stgregistry.suse.com/rancher/charts/mirrored-minio-mc:RELEASE.2023-06-28T21-54-17Z
   type: image
 - source: minio/minio:RELEASE.2020-07-13T18-09-56Z
   target: docker.io/rancher/mirrored-minio-minio:RELEASE.2020-07-13T18-09-56Z
@@ -14903,27 +8981,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-minio-minio:RELEASE.2023-07-07T07-13-57Z
   type: image
 - source: minio/minio:RELEASE.2020-07-13T18-09-56Z
-  target: registry.suse.com/rancher/charts/mirrored-minio-minio:RELEASE.2020-07-13T18-09-56Z
-  type: image
-- source: minio/minio:RELEASE.2022-05-08T23-50-31Z
-  target: registry.suse.com/rancher/charts/mirrored-minio-minio:RELEASE.2022-05-08T23-50-31Z
-  type: image
-- source: minio/minio:RELEASE.2022-09-17T00-09-45Z
-  target: registry.suse.com/rancher/charts/mirrored-minio-minio:RELEASE.2022-09-17T00-09-45Z
-  type: image
-- source: minio/minio:RELEASE.2022-11-11T03-44-20Z
-  target: registry.suse.com/rancher/charts/mirrored-minio-minio:RELEASE.2022-11-11T03-44-20Z
-  type: image
-- source: minio/minio:RELEASE.2022-12-12T19-27-27Z
-  target: registry.suse.com/rancher/charts/mirrored-minio-minio:RELEASE.2022-12-12T19-27-27Z
-  type: image
-- source: minio/minio:RELEASE.2023-02-10T18-48-39Z
-  target: registry.suse.com/rancher/charts/mirrored-minio-minio:RELEASE.2023-02-10T18-48-39Z
-  type: image
-- source: minio/minio:RELEASE.2023-07-07T07-13-57Z
-  target: registry.suse.com/rancher/charts/mirrored-minio-minio:RELEASE.2023-07-07T07-13-57Z
-  type: image
-- source: minio/minio:RELEASE.2020-07-13T18-09-56Z
   target: stgregistry.suse.com/rancher/mirrored-minio-minio:RELEASE.2020-07-13T18-09-56Z
   type: image
 - source: minio/minio:RELEASE.2022-05-08T23-50-31Z
@@ -14944,27 +9001,6 @@ sync:
 - source: minio/minio:RELEASE.2023-07-07T07-13-57Z
   target: stgregistry.suse.com/rancher/mirrored-minio-minio:RELEASE.2023-07-07T07-13-57Z
   type: image
-- source: minio/minio:RELEASE.2020-07-13T18-09-56Z
-  target: stgregistry.suse.com/rancher/charts/mirrored-minio-minio:RELEASE.2020-07-13T18-09-56Z
-  type: image
-- source: minio/minio:RELEASE.2022-05-08T23-50-31Z
-  target: stgregistry.suse.com/rancher/charts/mirrored-minio-minio:RELEASE.2022-05-08T23-50-31Z
-  type: image
-- source: minio/minio:RELEASE.2022-09-17T00-09-45Z
-  target: stgregistry.suse.com/rancher/charts/mirrored-minio-minio:RELEASE.2022-09-17T00-09-45Z
-  type: image
-- source: minio/minio:RELEASE.2022-11-11T03-44-20Z
-  target: stgregistry.suse.com/rancher/charts/mirrored-minio-minio:RELEASE.2022-11-11T03-44-20Z
-  type: image
-- source: minio/minio:RELEASE.2022-12-12T19-27-27Z
-  target: stgregistry.suse.com/rancher/charts/mirrored-minio-minio:RELEASE.2022-12-12T19-27-27Z
-  type: image
-- source: minio/minio:RELEASE.2023-02-10T18-48-39Z
-  target: stgregistry.suse.com/rancher/charts/mirrored-minio-minio:RELEASE.2023-02-10T18-48-39Z
-  type: image
-- source: minio/minio:RELEASE.2023-07-07T07-13-57Z
-  target: stgregistry.suse.com/rancher/charts/mirrored-minio-minio:RELEASE.2023-07-07T07-13-57Z
-  type: image
 - source: neuvector/compliance-config:1.0.0
   target: docker.io/rancher/mirrored-neuvector-compliance-config:1.0.0
   type: image
@@ -14978,22 +9014,10 @@ sync:
   target: registry.suse.com/rancher/mirrored-neuvector-compliance-config:1.0.1
   type: image
 - source: neuvector/compliance-config:1.0.0
-  target: registry.suse.com/rancher/charts/mirrored-neuvector-compliance-config:1.0.0
-  type: image
-- source: neuvector/compliance-config:1.0.1
-  target: registry.suse.com/rancher/charts/mirrored-neuvector-compliance-config:1.0.1
-  type: image
-- source: neuvector/compliance-config:1.0.0
   target: stgregistry.suse.com/rancher/mirrored-neuvector-compliance-config:1.0.0
   type: image
 - source: neuvector/compliance-config:1.0.1
   target: stgregistry.suse.com/rancher/mirrored-neuvector-compliance-config:1.0.1
-  type: image
-- source: neuvector/compliance-config:1.0.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-compliance-config:1.0.0
-  type: image
-- source: neuvector/compliance-config:1.0.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-compliance-config:1.0.1
   type: image
 - source: neuvector/controller:5.0.0
   target: docker.io/rancher/mirrored-neuvector-controller:5.0.0
@@ -15146,81 +9170,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-neuvector-controller:5.4.1
   type: image
 - source: neuvector/controller:5.0.0
-  target: registry.suse.com/rancher/charts/mirrored-neuvector-controller:5.0.0
-  type: image
-- source: neuvector/controller:5.0.0-b1
-  target: registry.suse.com/rancher/charts/mirrored-neuvector-controller:5.0.0-b1
-  type: image
-- source: neuvector/controller:5.0.0-b2
-  target: registry.suse.com/rancher/charts/mirrored-neuvector-controller:5.0.0-b2
-  type: image
-- source: neuvector/controller:5.0.1
-  target: registry.suse.com/rancher/charts/mirrored-neuvector-controller:5.0.1
-  type: image
-- source: neuvector/controller:5.0.2
-  target: registry.suse.com/rancher/charts/mirrored-neuvector-controller:5.0.2
-  type: image
-- source: neuvector/controller:5.0.3
-  target: registry.suse.com/rancher/charts/mirrored-neuvector-controller:5.0.3
-  type: image
-- source: neuvector/controller:5.0.4
-  target: registry.suse.com/rancher/charts/mirrored-neuvector-controller:5.0.4
-  type: image
-- source: neuvector/controller:5.1.0
-  target: registry.suse.com/rancher/charts/mirrored-neuvector-controller:5.1.0
-  type: image
-- source: neuvector/controller:5.1.1
-  target: registry.suse.com/rancher/charts/mirrored-neuvector-controller:5.1.1
-  type: image
-- source: neuvector/controller:5.1.2
-  target: registry.suse.com/rancher/charts/mirrored-neuvector-controller:5.1.2
-  type: image
-- source: neuvector/controller:5.1.3
-  target: registry.suse.com/rancher/charts/mirrored-neuvector-controller:5.1.3
-  type: image
-- source: neuvector/controller:5.2.0
-  target: registry.suse.com/rancher/charts/mirrored-neuvector-controller:5.2.0
-  type: image
-- source: neuvector/controller:5.2.0-s1
-  target: registry.suse.com/rancher/charts/mirrored-neuvector-controller:5.2.0-s1
-  type: image
-- source: neuvector/controller:5.2.1
-  target: registry.suse.com/rancher/charts/mirrored-neuvector-controller:5.2.1
-  type: image
-- source: neuvector/controller:5.2.2
-  target: registry.suse.com/rancher/charts/mirrored-neuvector-controller:5.2.2
-  type: image
-- source: neuvector/controller:5.2.2-s1
-  target: registry.suse.com/rancher/charts/mirrored-neuvector-controller:5.2.2-s1
-  type: image
-- source: neuvector/controller:5.2.3
-  target: registry.suse.com/rancher/charts/mirrored-neuvector-controller:5.2.3
-  type: image
-- source: neuvector/controller:5.2.4
-  target: registry.suse.com/rancher/charts/mirrored-neuvector-controller:5.2.4
-  type: image
-- source: neuvector/controller:5.2.4-s1
-  target: registry.suse.com/rancher/charts/mirrored-neuvector-controller:5.2.4-s1
-  type: image
-- source: neuvector/controller:5.3.0
-  target: registry.suse.com/rancher/charts/mirrored-neuvector-controller:5.3.0
-  type: image
-- source: neuvector/controller:5.3.2
-  target: registry.suse.com/rancher/charts/mirrored-neuvector-controller:5.3.2
-  type: image
-- source: neuvector/controller:5.3.3
-  target: registry.suse.com/rancher/charts/mirrored-neuvector-controller:5.3.3
-  type: image
-- source: neuvector/controller:5.3.4
-  target: registry.suse.com/rancher/charts/mirrored-neuvector-controller:5.3.4
-  type: image
-- source: neuvector/controller:5.4.0
-  target: registry.suse.com/rancher/charts/mirrored-neuvector-controller:5.4.0
-  type: image
-- source: neuvector/controller:5.4.1
-  target: registry.suse.com/rancher/charts/mirrored-neuvector-controller:5.4.1
-  type: image
-- source: neuvector/controller:5.0.0
   target: stgregistry.suse.com/rancher/mirrored-neuvector-controller:5.0.0
   type: image
 - source: neuvector/controller:5.0.0-b1
@@ -15294,81 +9243,6 @@ sync:
   type: image
 - source: neuvector/controller:5.4.1
   target: stgregistry.suse.com/rancher/mirrored-neuvector-controller:5.4.1
-  type: image
-- source: neuvector/controller:5.0.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-controller:5.0.0
-  type: image
-- source: neuvector/controller:5.0.0-b1
-  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-controller:5.0.0-b1
-  type: image
-- source: neuvector/controller:5.0.0-b2
-  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-controller:5.0.0-b2
-  type: image
-- source: neuvector/controller:5.0.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-controller:5.0.1
-  type: image
-- source: neuvector/controller:5.0.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-controller:5.0.2
-  type: image
-- source: neuvector/controller:5.0.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-controller:5.0.3
-  type: image
-- source: neuvector/controller:5.0.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-controller:5.0.4
-  type: image
-- source: neuvector/controller:5.1.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-controller:5.1.0
-  type: image
-- source: neuvector/controller:5.1.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-controller:5.1.1
-  type: image
-- source: neuvector/controller:5.1.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-controller:5.1.2
-  type: image
-- source: neuvector/controller:5.1.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-controller:5.1.3
-  type: image
-- source: neuvector/controller:5.2.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-controller:5.2.0
-  type: image
-- source: neuvector/controller:5.2.0-s1
-  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-controller:5.2.0-s1
-  type: image
-- source: neuvector/controller:5.2.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-controller:5.2.1
-  type: image
-- source: neuvector/controller:5.2.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-controller:5.2.2
-  type: image
-- source: neuvector/controller:5.2.2-s1
-  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-controller:5.2.2-s1
-  type: image
-- source: neuvector/controller:5.2.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-controller:5.2.3
-  type: image
-- source: neuvector/controller:5.2.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-controller:5.2.4
-  type: image
-- source: neuvector/controller:5.2.4-s1
-  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-controller:5.2.4-s1
-  type: image
-- source: neuvector/controller:5.3.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-controller:5.3.0
-  type: image
-- source: neuvector/controller:5.3.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-controller:5.3.2
-  type: image
-- source: neuvector/controller:5.3.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-controller:5.3.3
-  type: image
-- source: neuvector/controller:5.3.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-controller:5.3.4
-  type: image
-- source: neuvector/controller:5.4.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-controller:5.4.0
-  type: image
-- source: neuvector/controller:5.4.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-controller:5.4.1
   type: image
 - source: neuvector/enforcer:5.0.0
   target: docker.io/rancher/mirrored-neuvector-enforcer:5.0.0
@@ -15521,81 +9395,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-neuvector-enforcer:5.4.1
   type: image
 - source: neuvector/enforcer:5.0.0
-  target: registry.suse.com/rancher/charts/mirrored-neuvector-enforcer:5.0.0
-  type: image
-- source: neuvector/enforcer:5.0.0-b1
-  target: registry.suse.com/rancher/charts/mirrored-neuvector-enforcer:5.0.0-b1
-  type: image
-- source: neuvector/enforcer:5.0.0-b2
-  target: registry.suse.com/rancher/charts/mirrored-neuvector-enforcer:5.0.0-b2
-  type: image
-- source: neuvector/enforcer:5.0.1
-  target: registry.suse.com/rancher/charts/mirrored-neuvector-enforcer:5.0.1
-  type: image
-- source: neuvector/enforcer:5.0.2
-  target: registry.suse.com/rancher/charts/mirrored-neuvector-enforcer:5.0.2
-  type: image
-- source: neuvector/enforcer:5.0.3
-  target: registry.suse.com/rancher/charts/mirrored-neuvector-enforcer:5.0.3
-  type: image
-- source: neuvector/enforcer:5.0.4
-  target: registry.suse.com/rancher/charts/mirrored-neuvector-enforcer:5.0.4
-  type: image
-- source: neuvector/enforcer:5.1.0
-  target: registry.suse.com/rancher/charts/mirrored-neuvector-enforcer:5.1.0
-  type: image
-- source: neuvector/enforcer:5.1.1
-  target: registry.suse.com/rancher/charts/mirrored-neuvector-enforcer:5.1.1
-  type: image
-- source: neuvector/enforcer:5.1.2
-  target: registry.suse.com/rancher/charts/mirrored-neuvector-enforcer:5.1.2
-  type: image
-- source: neuvector/enforcer:5.1.3
-  target: registry.suse.com/rancher/charts/mirrored-neuvector-enforcer:5.1.3
-  type: image
-- source: neuvector/enforcer:5.2.0
-  target: registry.suse.com/rancher/charts/mirrored-neuvector-enforcer:5.2.0
-  type: image
-- source: neuvector/enforcer:5.2.0-s1
-  target: registry.suse.com/rancher/charts/mirrored-neuvector-enforcer:5.2.0-s1
-  type: image
-- source: neuvector/enforcer:5.2.1
-  target: registry.suse.com/rancher/charts/mirrored-neuvector-enforcer:5.2.1
-  type: image
-- source: neuvector/enforcer:5.2.2
-  target: registry.suse.com/rancher/charts/mirrored-neuvector-enforcer:5.2.2
-  type: image
-- source: neuvector/enforcer:5.2.2-s1
-  target: registry.suse.com/rancher/charts/mirrored-neuvector-enforcer:5.2.2-s1
-  type: image
-- source: neuvector/enforcer:5.2.3
-  target: registry.suse.com/rancher/charts/mirrored-neuvector-enforcer:5.2.3
-  type: image
-- source: neuvector/enforcer:5.2.4
-  target: registry.suse.com/rancher/charts/mirrored-neuvector-enforcer:5.2.4
-  type: image
-- source: neuvector/enforcer:5.2.4-s1
-  target: registry.suse.com/rancher/charts/mirrored-neuvector-enforcer:5.2.4-s1
-  type: image
-- source: neuvector/enforcer:5.3.0
-  target: registry.suse.com/rancher/charts/mirrored-neuvector-enforcer:5.3.0
-  type: image
-- source: neuvector/enforcer:5.3.2
-  target: registry.suse.com/rancher/charts/mirrored-neuvector-enforcer:5.3.2
-  type: image
-- source: neuvector/enforcer:5.3.3
-  target: registry.suse.com/rancher/charts/mirrored-neuvector-enforcer:5.3.3
-  type: image
-- source: neuvector/enforcer:5.3.4
-  target: registry.suse.com/rancher/charts/mirrored-neuvector-enforcer:5.3.4
-  type: image
-- source: neuvector/enforcer:5.4.0
-  target: registry.suse.com/rancher/charts/mirrored-neuvector-enforcer:5.4.0
-  type: image
-- source: neuvector/enforcer:5.4.1
-  target: registry.suse.com/rancher/charts/mirrored-neuvector-enforcer:5.4.1
-  type: image
-- source: neuvector/enforcer:5.0.0
   target: stgregistry.suse.com/rancher/mirrored-neuvector-enforcer:5.0.0
   type: image
 - source: neuvector/enforcer:5.0.0-b1
@@ -15669,81 +9468,6 @@ sync:
   type: image
 - source: neuvector/enforcer:5.4.1
   target: stgregistry.suse.com/rancher/mirrored-neuvector-enforcer:5.4.1
-  type: image
-- source: neuvector/enforcer:5.0.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-enforcer:5.0.0
-  type: image
-- source: neuvector/enforcer:5.0.0-b1
-  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-enforcer:5.0.0-b1
-  type: image
-- source: neuvector/enforcer:5.0.0-b2
-  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-enforcer:5.0.0-b2
-  type: image
-- source: neuvector/enforcer:5.0.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-enforcer:5.0.1
-  type: image
-- source: neuvector/enforcer:5.0.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-enforcer:5.0.2
-  type: image
-- source: neuvector/enforcer:5.0.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-enforcer:5.0.3
-  type: image
-- source: neuvector/enforcer:5.0.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-enforcer:5.0.4
-  type: image
-- source: neuvector/enforcer:5.1.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-enforcer:5.1.0
-  type: image
-- source: neuvector/enforcer:5.1.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-enforcer:5.1.1
-  type: image
-- source: neuvector/enforcer:5.1.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-enforcer:5.1.2
-  type: image
-- source: neuvector/enforcer:5.1.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-enforcer:5.1.3
-  type: image
-- source: neuvector/enforcer:5.2.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-enforcer:5.2.0
-  type: image
-- source: neuvector/enforcer:5.2.0-s1
-  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-enforcer:5.2.0-s1
-  type: image
-- source: neuvector/enforcer:5.2.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-enforcer:5.2.1
-  type: image
-- source: neuvector/enforcer:5.2.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-enforcer:5.2.2
-  type: image
-- source: neuvector/enforcer:5.2.2-s1
-  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-enforcer:5.2.2-s1
-  type: image
-- source: neuvector/enforcer:5.2.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-enforcer:5.2.3
-  type: image
-- source: neuvector/enforcer:5.2.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-enforcer:5.2.4
-  type: image
-- source: neuvector/enforcer:5.2.4-s1
-  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-enforcer:5.2.4-s1
-  type: image
-- source: neuvector/enforcer:5.3.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-enforcer:5.3.0
-  type: image
-- source: neuvector/enforcer:5.3.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-enforcer:5.3.2
-  type: image
-- source: neuvector/enforcer:5.3.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-enforcer:5.3.3
-  type: image
-- source: neuvector/enforcer:5.3.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-enforcer:5.3.4
-  type: image
-- source: neuvector/enforcer:5.4.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-enforcer:5.4.0
-  type: image
-- source: neuvector/enforcer:5.4.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-enforcer:5.4.1
   type: image
 - source: neuvector/manager:5.0.0
   target: docker.io/rancher/mirrored-neuvector-manager:5.0.0
@@ -15896,81 +9620,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-neuvector-manager:5.4.1
   type: image
 - source: neuvector/manager:5.0.0
-  target: registry.suse.com/rancher/charts/mirrored-neuvector-manager:5.0.0
-  type: image
-- source: neuvector/manager:5.0.0-b1
-  target: registry.suse.com/rancher/charts/mirrored-neuvector-manager:5.0.0-b1
-  type: image
-- source: neuvector/manager:5.0.0-b2
-  target: registry.suse.com/rancher/charts/mirrored-neuvector-manager:5.0.0-b2
-  type: image
-- source: neuvector/manager:5.0.1
-  target: registry.suse.com/rancher/charts/mirrored-neuvector-manager:5.0.1
-  type: image
-- source: neuvector/manager:5.0.2
-  target: registry.suse.com/rancher/charts/mirrored-neuvector-manager:5.0.2
-  type: image
-- source: neuvector/manager:5.0.3
-  target: registry.suse.com/rancher/charts/mirrored-neuvector-manager:5.0.3
-  type: image
-- source: neuvector/manager:5.0.4
-  target: registry.suse.com/rancher/charts/mirrored-neuvector-manager:5.0.4
-  type: image
-- source: neuvector/manager:5.1.0
-  target: registry.suse.com/rancher/charts/mirrored-neuvector-manager:5.1.0
-  type: image
-- source: neuvector/manager:5.1.1
-  target: registry.suse.com/rancher/charts/mirrored-neuvector-manager:5.1.1
-  type: image
-- source: neuvector/manager:5.1.2
-  target: registry.suse.com/rancher/charts/mirrored-neuvector-manager:5.1.2
-  type: image
-- source: neuvector/manager:5.1.3
-  target: registry.suse.com/rancher/charts/mirrored-neuvector-manager:5.1.3
-  type: image
-- source: neuvector/manager:5.2.0
-  target: registry.suse.com/rancher/charts/mirrored-neuvector-manager:5.2.0
-  type: image
-- source: neuvector/manager:5.2.0-s1
-  target: registry.suse.com/rancher/charts/mirrored-neuvector-manager:5.2.0-s1
-  type: image
-- source: neuvector/manager:5.2.1
-  target: registry.suse.com/rancher/charts/mirrored-neuvector-manager:5.2.1
-  type: image
-- source: neuvector/manager:5.2.2
-  target: registry.suse.com/rancher/charts/mirrored-neuvector-manager:5.2.2
-  type: image
-- source: neuvector/manager:5.2.2-s1
-  target: registry.suse.com/rancher/charts/mirrored-neuvector-manager:5.2.2-s1
-  type: image
-- source: neuvector/manager:5.2.3
-  target: registry.suse.com/rancher/charts/mirrored-neuvector-manager:5.2.3
-  type: image
-- source: neuvector/manager:5.2.4
-  target: registry.suse.com/rancher/charts/mirrored-neuvector-manager:5.2.4
-  type: image
-- source: neuvector/manager:5.2.4-s1
-  target: registry.suse.com/rancher/charts/mirrored-neuvector-manager:5.2.4-s1
-  type: image
-- source: neuvector/manager:5.3.0
-  target: registry.suse.com/rancher/charts/mirrored-neuvector-manager:5.3.0
-  type: image
-- source: neuvector/manager:5.3.2
-  target: registry.suse.com/rancher/charts/mirrored-neuvector-manager:5.3.2
-  type: image
-- source: neuvector/manager:5.3.3
-  target: registry.suse.com/rancher/charts/mirrored-neuvector-manager:5.3.3
-  type: image
-- source: neuvector/manager:5.3.4
-  target: registry.suse.com/rancher/charts/mirrored-neuvector-manager:5.3.4
-  type: image
-- source: neuvector/manager:5.4.0
-  target: registry.suse.com/rancher/charts/mirrored-neuvector-manager:5.4.0
-  type: image
-- source: neuvector/manager:5.4.1
-  target: registry.suse.com/rancher/charts/mirrored-neuvector-manager:5.4.1
-  type: image
-- source: neuvector/manager:5.0.0
   target: stgregistry.suse.com/rancher/mirrored-neuvector-manager:5.0.0
   type: image
 - source: neuvector/manager:5.0.0-b1
@@ -16045,81 +9694,6 @@ sync:
 - source: neuvector/manager:5.4.1
   target: stgregistry.suse.com/rancher/mirrored-neuvector-manager:5.4.1
   type: image
-- source: neuvector/manager:5.0.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-manager:5.0.0
-  type: image
-- source: neuvector/manager:5.0.0-b1
-  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-manager:5.0.0-b1
-  type: image
-- source: neuvector/manager:5.0.0-b2
-  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-manager:5.0.0-b2
-  type: image
-- source: neuvector/manager:5.0.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-manager:5.0.1
-  type: image
-- source: neuvector/manager:5.0.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-manager:5.0.2
-  type: image
-- source: neuvector/manager:5.0.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-manager:5.0.3
-  type: image
-- source: neuvector/manager:5.0.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-manager:5.0.4
-  type: image
-- source: neuvector/manager:5.1.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-manager:5.1.0
-  type: image
-- source: neuvector/manager:5.1.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-manager:5.1.1
-  type: image
-- source: neuvector/manager:5.1.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-manager:5.1.2
-  type: image
-- source: neuvector/manager:5.1.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-manager:5.1.3
-  type: image
-- source: neuvector/manager:5.2.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-manager:5.2.0
-  type: image
-- source: neuvector/manager:5.2.0-s1
-  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-manager:5.2.0-s1
-  type: image
-- source: neuvector/manager:5.2.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-manager:5.2.1
-  type: image
-- source: neuvector/manager:5.2.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-manager:5.2.2
-  type: image
-- source: neuvector/manager:5.2.2-s1
-  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-manager:5.2.2-s1
-  type: image
-- source: neuvector/manager:5.2.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-manager:5.2.3
-  type: image
-- source: neuvector/manager:5.2.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-manager:5.2.4
-  type: image
-- source: neuvector/manager:5.2.4-s1
-  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-manager:5.2.4-s1
-  type: image
-- source: neuvector/manager:5.3.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-manager:5.3.0
-  type: image
-- source: neuvector/manager:5.3.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-manager:5.3.2
-  type: image
-- source: neuvector/manager:5.3.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-manager:5.3.3
-  type: image
-- source: neuvector/manager:5.3.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-manager:5.3.4
-  type: image
-- source: neuvector/manager:5.4.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-manager:5.4.0
-  type: image
-- source: neuvector/manager:5.4.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-manager:5.4.1
-  type: image
 - source: neuvector/prometheus-exporter:1-1.0.0
   target: docker.io/rancher/mirrored-neuvector-prometheus-exporter:1-1.0.0
   type: image
@@ -16169,30 +9743,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-neuvector-prometheus-exporter:5.3.2
   type: image
 - source: neuvector/prometheus-exporter:1-1.0.0
-  target: registry.suse.com/rancher/charts/mirrored-neuvector-prometheus-exporter:1-1.0.0
-  type: image
-- source: neuvector/prometheus-exporter:5.2.0
-  target: registry.suse.com/rancher/charts/mirrored-neuvector-prometheus-exporter:5.2.0
-  type: image
-- source: neuvector/prometheus-exporter:5.2.1
-  target: registry.suse.com/rancher/charts/mirrored-neuvector-prometheus-exporter:5.2.1
-  type: image
-- source: neuvector/prometheus-exporter:5.2.2
-  target: registry.suse.com/rancher/charts/mirrored-neuvector-prometheus-exporter:5.2.2
-  type: image
-- source: neuvector/prometheus-exporter:5.2.3
-  target: registry.suse.com/rancher/charts/mirrored-neuvector-prometheus-exporter:5.2.3
-  type: image
-- source: neuvector/prometheus-exporter:5.2.4
-  target: registry.suse.com/rancher/charts/mirrored-neuvector-prometheus-exporter:5.2.4
-  type: image
-- source: neuvector/prometheus-exporter:5.3.0
-  target: registry.suse.com/rancher/charts/mirrored-neuvector-prometheus-exporter:5.3.0
-  type: image
-- source: neuvector/prometheus-exporter:5.3.2
-  target: registry.suse.com/rancher/charts/mirrored-neuvector-prometheus-exporter:5.3.2
-  type: image
-- source: neuvector/prometheus-exporter:1-1.0.0
   target: stgregistry.suse.com/rancher/mirrored-neuvector-prometheus-exporter:1-1.0.0
   type: image
 - source: neuvector/prometheus-exporter:5.2.0
@@ -16215,30 +9765,6 @@ sync:
   type: image
 - source: neuvector/prometheus-exporter:5.3.2
   target: stgregistry.suse.com/rancher/mirrored-neuvector-prometheus-exporter:5.3.2
-  type: image
-- source: neuvector/prometheus-exporter:1-1.0.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-prometheus-exporter:1-1.0.0
-  type: image
-- source: neuvector/prometheus-exporter:5.2.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-prometheus-exporter:5.2.0
-  type: image
-- source: neuvector/prometheus-exporter:5.2.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-prometheus-exporter:5.2.1
-  type: image
-- source: neuvector/prometheus-exporter:5.2.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-prometheus-exporter:5.2.2
-  type: image
-- source: neuvector/prometheus-exporter:5.2.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-prometheus-exporter:5.2.3
-  type: image
-- source: neuvector/prometheus-exporter:5.2.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-prometheus-exporter:5.2.4
-  type: image
-- source: neuvector/prometheus-exporter:5.3.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-prometheus-exporter:5.3.0
-  type: image
-- source: neuvector/prometheus-exporter:5.3.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-prometheus-exporter:5.3.2
   type: image
 - source: neuvector/registry-adapter:0.1.0
   target: docker.io/rancher/mirrored-neuvector-registry-adapter:0.1.0
@@ -16277,24 +9803,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-neuvector-registry-adapter:0.1.3
   type: image
 - source: neuvector/registry-adapter:0.1.0
-  target: registry.suse.com/rancher/charts/mirrored-neuvector-registry-adapter:0.1.0
-  type: image
-- source: neuvector/registry-adapter:0.1.1
-  target: registry.suse.com/rancher/charts/mirrored-neuvector-registry-adapter:0.1.1
-  type: image
-- source: neuvector/registry-adapter:0.1.1-s1
-  target: registry.suse.com/rancher/charts/mirrored-neuvector-registry-adapter:0.1.1-s1
-  type: image
-- source: neuvector/registry-adapter:0.1.1-s2
-  target: registry.suse.com/rancher/charts/mirrored-neuvector-registry-adapter:0.1.1-s2
-  type: image
-- source: neuvector/registry-adapter:0.1.2
-  target: registry.suse.com/rancher/charts/mirrored-neuvector-registry-adapter:0.1.2
-  type: image
-- source: neuvector/registry-adapter:0.1.3
-  target: registry.suse.com/rancher/charts/mirrored-neuvector-registry-adapter:0.1.3
-  type: image
-- source: neuvector/registry-adapter:0.1.0
   target: stgregistry.suse.com/rancher/mirrored-neuvector-registry-adapter:0.1.0
   type: image
 - source: neuvector/registry-adapter:0.1.1
@@ -16311,24 +9819,6 @@ sync:
   type: image
 - source: neuvector/registry-adapter:0.1.3
   target: stgregistry.suse.com/rancher/mirrored-neuvector-registry-adapter:0.1.3
-  type: image
-- source: neuvector/registry-adapter:0.1.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-registry-adapter:0.1.0
-  type: image
-- source: neuvector/registry-adapter:0.1.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-registry-adapter:0.1.1
-  type: image
-- source: neuvector/registry-adapter:0.1.1-s1
-  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-registry-adapter:0.1.1-s1
-  type: image
-- source: neuvector/registry-adapter:0.1.1-s2
-  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-registry-adapter:0.1.1-s2
-  type: image
-- source: neuvector/registry-adapter:0.1.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-registry-adapter:0.1.2
-  type: image
-- source: neuvector/registry-adapter:0.1.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-neuvector-registry-adapter:0.1.3
   type: image
 - source: openpolicyagent/gatekeeper:v3.10.0
   target: docker.io/rancher/mirrored-openpolicyagent-gatekeeper:v3.10.0
@@ -16403,42 +9893,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-openpolicyagent-gatekeeper:v3.9.0
   type: image
 - source: openpolicyagent/gatekeeper:v3.10.0
-  target: registry.suse.com/rancher/charts/mirrored-openpolicyagent-gatekeeper:v3.10.0
-  type: image
-- source: openpolicyagent/gatekeeper:v3.12.0
-  target: registry.suse.com/rancher/charts/mirrored-openpolicyagent-gatekeeper:v3.12.0
-  type: image
-- source: openpolicyagent/gatekeeper:v3.13.0
-  target: registry.suse.com/rancher/charts/mirrored-openpolicyagent-gatekeeper:v3.13.0
-  type: image
-- source: openpolicyagent/gatekeeper:v3.3.0
-  target: registry.suse.com/rancher/charts/mirrored-openpolicyagent-gatekeeper:v3.3.0
-  type: image
-- source: openpolicyagent/gatekeeper:v3.4.0
-  target: registry.suse.com/rancher/charts/mirrored-openpolicyagent-gatekeeper:v3.4.0
-  type: image
-- source: openpolicyagent/gatekeeper:v3.5.1
-  target: registry.suse.com/rancher/charts/mirrored-openpolicyagent-gatekeeper:v3.5.1
-  type: image
-- source: openpolicyagent/gatekeeper:v3.5.2
-  target: registry.suse.com/rancher/charts/mirrored-openpolicyagent-gatekeeper:v3.5.2
-  type: image
-- source: openpolicyagent/gatekeeper:v3.6.0
-  target: registry.suse.com/rancher/charts/mirrored-openpolicyagent-gatekeeper:v3.6.0
-  type: image
-- source: openpolicyagent/gatekeeper:v3.7.0
-  target: registry.suse.com/rancher/charts/mirrored-openpolicyagent-gatekeeper:v3.7.0
-  type: image
-- source: openpolicyagent/gatekeeper:v3.7.1
-  target: registry.suse.com/rancher/charts/mirrored-openpolicyagent-gatekeeper:v3.7.1
-  type: image
-- source: openpolicyagent/gatekeeper:v3.8.1
-  target: registry.suse.com/rancher/charts/mirrored-openpolicyagent-gatekeeper:v3.8.1
-  type: image
-- source: openpolicyagent/gatekeeper:v3.9.0
-  target: registry.suse.com/rancher/charts/mirrored-openpolicyagent-gatekeeper:v3.9.0
-  type: image
-- source: openpolicyagent/gatekeeper:v3.10.0
   target: stgregistry.suse.com/rancher/mirrored-openpolicyagent-gatekeeper:v3.10.0
   type: image
 - source: openpolicyagent/gatekeeper:v3.12.0
@@ -16474,42 +9928,6 @@ sync:
 - source: openpolicyagent/gatekeeper:v3.9.0
   target: stgregistry.suse.com/rancher/mirrored-openpolicyagent-gatekeeper:v3.9.0
   type: image
-- source: openpolicyagent/gatekeeper:v3.10.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-openpolicyagent-gatekeeper:v3.10.0
-  type: image
-- source: openpolicyagent/gatekeeper:v3.12.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-openpolicyagent-gatekeeper:v3.12.0
-  type: image
-- source: openpolicyagent/gatekeeper:v3.13.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-openpolicyagent-gatekeeper:v3.13.0
-  type: image
-- source: openpolicyagent/gatekeeper:v3.3.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-openpolicyagent-gatekeeper:v3.3.0
-  type: image
-- source: openpolicyagent/gatekeeper:v3.4.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-openpolicyagent-gatekeeper:v3.4.0
-  type: image
-- source: openpolicyagent/gatekeeper:v3.5.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-openpolicyagent-gatekeeper:v3.5.1
-  type: image
-- source: openpolicyagent/gatekeeper:v3.5.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-openpolicyagent-gatekeeper:v3.5.2
-  type: image
-- source: openpolicyagent/gatekeeper:v3.6.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-openpolicyagent-gatekeeper:v3.6.0
-  type: image
-- source: openpolicyagent/gatekeeper:v3.7.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-openpolicyagent-gatekeeper:v3.7.0
-  type: image
-- source: openpolicyagent/gatekeeper:v3.7.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-openpolicyagent-gatekeeper:v3.7.1
-  type: image
-- source: openpolicyagent/gatekeeper:v3.8.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-openpolicyagent-gatekeeper:v3.8.1
-  type: image
-- source: openpolicyagent/gatekeeper:v3.9.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-openpolicyagent-gatekeeper:v3.9.0
-  type: image
 - source: openpolicyagent/gatekeeper:v3.1.0
   target: docker.io/rancher/openpolicyagent-gatekeeper:v3.1.0
   type: image
@@ -16535,18 +9953,6 @@ sync:
   target: registry.suse.com/rancher/openpolicyagent-gatekeeper:v3.3.0
   type: image
 - source: openpolicyagent/gatekeeper:v3.1.0
-  target: registry.suse.com/rancher/charts/openpolicyagent-gatekeeper:v3.1.0
-  type: image
-- source: openpolicyagent/gatekeeper:v3.1.1
-  target: registry.suse.com/rancher/charts/openpolicyagent-gatekeeper:v3.1.1
-  type: image
-- source: openpolicyagent/gatekeeper:v3.2.1
-  target: registry.suse.com/rancher/charts/openpolicyagent-gatekeeper:v3.2.1
-  type: image
-- source: openpolicyagent/gatekeeper:v3.3.0
-  target: registry.suse.com/rancher/charts/openpolicyagent-gatekeeper:v3.3.0
-  type: image
-- source: openpolicyagent/gatekeeper:v3.1.0
   target: stgregistry.suse.com/rancher/openpolicyagent-gatekeeper:v3.1.0
   type: image
 - source: openpolicyagent/gatekeeper:v3.1.1
@@ -16557,18 +9963,6 @@ sync:
   type: image
 - source: openpolicyagent/gatekeeper:v3.3.0
   target: stgregistry.suse.com/rancher/openpolicyagent-gatekeeper:v3.3.0
-  type: image
-- source: openpolicyagent/gatekeeper:v3.1.0
-  target: stgregistry.suse.com/rancher/charts/openpolicyagent-gatekeeper:v3.1.0
-  type: image
-- source: openpolicyagent/gatekeeper:v3.1.1
-  target: stgregistry.suse.com/rancher/charts/openpolicyagent-gatekeeper:v3.1.1
-  type: image
-- source: openpolicyagent/gatekeeper:v3.2.1
-  target: stgregistry.suse.com/rancher/charts/openpolicyagent-gatekeeper:v3.2.1
-  type: image
-- source: openpolicyagent/gatekeeper:v3.3.0
-  target: stgregistry.suse.com/rancher/charts/openpolicyagent-gatekeeper:v3.3.0
   type: image
 - source: openpolicyagent/gatekeeper-crds:v3.10.0
   target: docker.io/rancher/mirrored-openpolicyagent-gatekeeper-crds:v3.10.0
@@ -16619,30 +10013,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-openpolicyagent-gatekeeper-crds:v3.9.0
   type: image
 - source: openpolicyagent/gatekeeper-crds:v3.10.0
-  target: registry.suse.com/rancher/charts/mirrored-openpolicyagent-gatekeeper-crds:v3.10.0
-  type: image
-- source: openpolicyagent/gatekeeper-crds:v3.12.0
-  target: registry.suse.com/rancher/charts/mirrored-openpolicyagent-gatekeeper-crds:v3.12.0
-  type: image
-- source: openpolicyagent/gatekeeper-crds:v3.13.0
-  target: registry.suse.com/rancher/charts/mirrored-openpolicyagent-gatekeeper-crds:v3.13.0
-  type: image
-- source: openpolicyagent/gatekeeper-crds:v3.6.0
-  target: registry.suse.com/rancher/charts/mirrored-openpolicyagent-gatekeeper-crds:v3.6.0
-  type: image
-- source: openpolicyagent/gatekeeper-crds:v3.7.0
-  target: registry.suse.com/rancher/charts/mirrored-openpolicyagent-gatekeeper-crds:v3.7.0
-  type: image
-- source: openpolicyagent/gatekeeper-crds:v3.7.1
-  target: registry.suse.com/rancher/charts/mirrored-openpolicyagent-gatekeeper-crds:v3.7.1
-  type: image
-- source: openpolicyagent/gatekeeper-crds:v3.8.1
-  target: registry.suse.com/rancher/charts/mirrored-openpolicyagent-gatekeeper-crds:v3.8.1
-  type: image
-- source: openpolicyagent/gatekeeper-crds:v3.9.0
-  target: registry.suse.com/rancher/charts/mirrored-openpolicyagent-gatekeeper-crds:v3.9.0
-  type: image
-- source: openpolicyagent/gatekeeper-crds:v3.10.0
   target: stgregistry.suse.com/rancher/mirrored-openpolicyagent-gatekeeper-crds:v3.10.0
   type: image
 - source: openpolicyagent/gatekeeper-crds:v3.12.0
@@ -16666,30 +10036,6 @@ sync:
 - source: openpolicyagent/gatekeeper-crds:v3.9.0
   target: stgregistry.suse.com/rancher/mirrored-openpolicyagent-gatekeeper-crds:v3.9.0
   type: image
-- source: openpolicyagent/gatekeeper-crds:v3.10.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-openpolicyagent-gatekeeper-crds:v3.10.0
-  type: image
-- source: openpolicyagent/gatekeeper-crds:v3.12.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-openpolicyagent-gatekeeper-crds:v3.12.0
-  type: image
-- source: openpolicyagent/gatekeeper-crds:v3.13.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-openpolicyagent-gatekeeper-crds:v3.13.0
-  type: image
-- source: openpolicyagent/gatekeeper-crds:v3.6.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-openpolicyagent-gatekeeper-crds:v3.6.0
-  type: image
-- source: openpolicyagent/gatekeeper-crds:v3.7.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-openpolicyagent-gatekeeper-crds:v3.7.0
-  type: image
-- source: openpolicyagent/gatekeeper-crds:v3.7.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-openpolicyagent-gatekeeper-crds:v3.7.1
-  type: image
-- source: openpolicyagent/gatekeeper-crds:v3.8.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-openpolicyagent-gatekeeper-crds:v3.8.1
-  type: image
-- source: openpolicyagent/gatekeeper-crds:v3.9.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-openpolicyagent-gatekeeper-crds:v3.9.0
-  type: image
 - source: openzipkin/zipkin:2.14.2
   target: docker.io/rancher/mirrored-openzipkin-zipkin:2.14.2
   type: image
@@ -16697,13 +10043,7 @@ sync:
   target: registry.suse.com/rancher/mirrored-openzipkin-zipkin:2.14.2
   type: image
 - source: openzipkin/zipkin:2.14.2
-  target: registry.suse.com/rancher/charts/mirrored-openzipkin-zipkin:2.14.2
-  type: image
-- source: openzipkin/zipkin:2.14.2
   target: stgregistry.suse.com/rancher/mirrored-openzipkin-zipkin:2.14.2
-  type: image
-- source: openzipkin/zipkin:2.14.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-openzipkin-zipkin:2.14.2
   type: image
 - source: paketobuildpacks/builder:0.2.220-full
   target: docker.io/rancher/mirrored-paketobuildpacks-builder:0.2.220-full
@@ -16748,27 +10088,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-paketobuildpacks-builder:0.2.95-full
   type: image
 - source: paketobuildpacks/builder:0.2.220-full
-  target: registry.suse.com/rancher/charts/mirrored-paketobuildpacks-builder:0.2.220-full
-  type: image
-- source: paketobuildpacks/builder:0.2.234-full
-  target: registry.suse.com/rancher/charts/mirrored-paketobuildpacks-builder:0.2.234-full
-  type: image
-- source: paketobuildpacks/builder:0.2.289-full
-  target: registry.suse.com/rancher/charts/mirrored-paketobuildpacks-builder:0.2.289-full
-  type: image
-- source: paketobuildpacks/builder:0.2.407-full
-  target: registry.suse.com/rancher/charts/mirrored-paketobuildpacks-builder:0.2.407-full
-  type: image
-- source: paketobuildpacks/builder:0.2.441-full
-  target: registry.suse.com/rancher/charts/mirrored-paketobuildpacks-builder:0.2.441-full
-  type: image
-- source: paketobuildpacks/builder:0.2.443-full
-  target: registry.suse.com/rancher/charts/mirrored-paketobuildpacks-builder:0.2.443-full
-  type: image
-- source: paketobuildpacks/builder:0.2.95-full
-  target: registry.suse.com/rancher/charts/mirrored-paketobuildpacks-builder:0.2.95-full
-  type: image
-- source: paketobuildpacks/builder:0.2.220-full
   target: stgregistry.suse.com/rancher/mirrored-paketobuildpacks-builder:0.2.220-full
   type: image
 - source: paketobuildpacks/builder:0.2.234-full
@@ -16789,27 +10108,6 @@ sync:
 - source: paketobuildpacks/builder:0.2.95-full
   target: stgregistry.suse.com/rancher/mirrored-paketobuildpacks-builder:0.2.95-full
   type: image
-- source: paketobuildpacks/builder:0.2.220-full
-  target: stgregistry.suse.com/rancher/charts/mirrored-paketobuildpacks-builder:0.2.220-full
-  type: image
-- source: paketobuildpacks/builder:0.2.234-full
-  target: stgregistry.suse.com/rancher/charts/mirrored-paketobuildpacks-builder:0.2.234-full
-  type: image
-- source: paketobuildpacks/builder:0.2.289-full
-  target: stgregistry.suse.com/rancher/charts/mirrored-paketobuildpacks-builder:0.2.289-full
-  type: image
-- source: paketobuildpacks/builder:0.2.407-full
-  target: stgregistry.suse.com/rancher/charts/mirrored-paketobuildpacks-builder:0.2.407-full
-  type: image
-- source: paketobuildpacks/builder:0.2.441-full
-  target: stgregistry.suse.com/rancher/charts/mirrored-paketobuildpacks-builder:0.2.441-full
-  type: image
-- source: paketobuildpacks/builder:0.2.443-full
-  target: stgregistry.suse.com/rancher/charts/mirrored-paketobuildpacks-builder:0.2.443-full
-  type: image
-- source: paketobuildpacks/builder:0.2.95-full
-  target: stgregistry.suse.com/rancher/charts/mirrored-paketobuildpacks-builder:0.2.95-full
-  type: image
 - source: plugins/docker:18.09
   target: docker.io/rancher/mirrored-plugins-docker:18.09
   type: image
@@ -16823,22 +10121,10 @@ sync:
   target: registry.suse.com/rancher/mirrored-plugins-docker:19.03.8
   type: image
 - source: plugins/docker:18.09
-  target: registry.suse.com/rancher/charts/mirrored-plugins-docker:18.09
-  type: image
-- source: plugins/docker:19.03.8
-  target: registry.suse.com/rancher/charts/mirrored-plugins-docker:19.03.8
-  type: image
-- source: plugins/docker:18.09
   target: stgregistry.suse.com/rancher/mirrored-plugins-docker:18.09
   type: image
 - source: plugins/docker:19.03.8
   target: stgregistry.suse.com/rancher/mirrored-plugins-docker:19.03.8
-  type: image
-- source: plugins/docker:18.09
-  target: stgregistry.suse.com/rancher/charts/mirrored-plugins-docker:18.09
-  type: image
-- source: plugins/docker:19.03.8
-  target: stgregistry.suse.com/rancher/charts/mirrored-plugins-docker:19.03.8
   type: image
 - source: prom/alertmanager:v0.21.0
   target: docker.io/rancher/mirrored-prom-alertmanager:v0.21.0
@@ -16847,13 +10133,7 @@ sync:
   target: registry.suse.com/rancher/mirrored-prom-alertmanager:v0.21.0
   type: image
 - source: prom/alertmanager:v0.21.0
-  target: registry.suse.com/rancher/charts/mirrored-prom-alertmanager:v0.21.0
-  type: image
-- source: prom/alertmanager:v0.21.0
   target: stgregistry.suse.com/rancher/mirrored-prom-alertmanager:v0.21.0
-  type: image
-- source: prom/alertmanager:v0.21.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-prom-alertmanager:v0.21.0
   type: image
 - source: prom/alertmanager:v0.21.0
   target: docker.io/rancher/prom-alertmanager:v0.21.0
@@ -16862,13 +10142,7 @@ sync:
   target: registry.suse.com/rancher/prom-alertmanager:v0.21.0
   type: image
 - source: prom/alertmanager:v0.21.0
-  target: registry.suse.com/rancher/charts/prom-alertmanager:v0.21.0
-  type: image
-- source: prom/alertmanager:v0.21.0
   target: stgregistry.suse.com/rancher/prom-alertmanager:v0.21.0
-  type: image
-- source: prom/alertmanager:v0.21.0
-  target: stgregistry.suse.com/rancher/charts/prom-alertmanager:v0.21.0
   type: image
 - source: prom/node-exporter:v1.0.1
   target: docker.io/rancher/mirrored-prom-node-exporter:v1.0.1
@@ -16877,13 +10151,7 @@ sync:
   target: registry.suse.com/rancher/mirrored-prom-node-exporter:v1.0.1
   type: image
 - source: prom/node-exporter:v1.0.1
-  target: registry.suse.com/rancher/charts/mirrored-prom-node-exporter:v1.0.1
-  type: image
-- source: prom/node-exporter:v1.0.1
   target: stgregistry.suse.com/rancher/mirrored-prom-node-exporter:v1.0.1
-  type: image
-- source: prom/node-exporter:v1.0.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-prom-node-exporter:v1.0.1
   type: image
 - source: prom/node-exporter:v1.0.1
   target: docker.io/rancher/prom-node-exporter:v1.0.1
@@ -16898,22 +10166,10 @@ sync:
   target: registry.suse.com/rancher/prom-node-exporter:v1.3.1
   type: image
 - source: prom/node-exporter:v1.0.1
-  target: registry.suse.com/rancher/charts/prom-node-exporter:v1.0.1
-  type: image
-- source: prom/node-exporter:v1.3.1
-  target: registry.suse.com/rancher/charts/prom-node-exporter:v1.3.1
-  type: image
-- source: prom/node-exporter:v1.0.1
   target: stgregistry.suse.com/rancher/prom-node-exporter:v1.0.1
   type: image
 - source: prom/node-exporter:v1.3.1
   target: stgregistry.suse.com/rancher/prom-node-exporter:v1.3.1
-  type: image
-- source: prom/node-exporter:v1.0.1
-  target: stgregistry.suse.com/rancher/charts/prom-node-exporter:v1.0.1
-  type: image
-- source: prom/node-exporter:v1.3.1
-  target: stgregistry.suse.com/rancher/charts/prom-node-exporter:v1.3.1
   type: image
 - source: prom/prometheus:v2.12.0
   target: docker.io/rancher/mirrored-prom-prometheus:v2.12.0
@@ -16922,13 +10178,7 @@ sync:
   target: registry.suse.com/rancher/mirrored-prom-prometheus:v2.12.0
   type: image
 - source: prom/prometheus:v2.12.0
-  target: registry.suse.com/rancher/charts/mirrored-prom-prometheus:v2.12.0
-  type: image
-- source: prom/prometheus:v2.12.0
   target: stgregistry.suse.com/rancher/mirrored-prom-prometheus:v2.12.0
-  type: image
-- source: prom/prometheus:v2.12.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-prom-prometheus:v2.12.0
   type: image
 - source: prom/prometheus:v2.18.2
   target: docker.io/rancher/prom-prometheus:v2.18.2
@@ -16937,13 +10187,7 @@ sync:
   target: registry.suse.com/rancher/prom-prometheus:v2.18.2
   type: image
 - source: prom/prometheus:v2.18.2
-  target: registry.suse.com/rancher/charts/prom-prometheus:v2.18.2
-  type: image
-- source: prom/prometheus:v2.18.2
   target: stgregistry.suse.com/rancher/prom-prometheus:v2.18.2
-  type: image
-- source: prom/prometheus:v2.18.2
-  target: stgregistry.suse.com/rancher/charts/prom-prometheus:v2.18.2
   type: image
 - source: pstauffer/curl:v1.0.3
   target: docker.io/rancher/mirrored-pstauffer-curl:v1.0.3
@@ -16952,13 +10196,7 @@ sync:
   target: registry.suse.com/rancher/mirrored-pstauffer-curl:v1.0.3
   type: image
 - source: pstauffer/curl:v1.0.3
-  target: registry.suse.com/rancher/charts/mirrored-pstauffer-curl:v1.0.3
-  type: image
-- source: pstauffer/curl:v1.0.3
   target: stgregistry.suse.com/rancher/mirrored-pstauffer-curl:v1.0.3
-  type: image
-- source: pstauffer/curl:v1.0.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-pstauffer-curl:v1.0.3
   type: image
 - source: quay.io/brancz/kube-rbac-proxy:v0.18.0
   target: docker.io/rancher/mirrored-brancz-kube-rbac-proxy:v0.18.0
@@ -16973,22 +10211,10 @@ sync:
   target: registry.suse.com/rancher/mirrored-brancz-kube-rbac-proxy:v0.18.2
   type: image
 - source: quay.io/brancz/kube-rbac-proxy:v0.18.0
-  target: registry.suse.com/rancher/charts/mirrored-brancz-kube-rbac-proxy:v0.18.0
-  type: image
-- source: quay.io/brancz/kube-rbac-proxy:v0.18.2
-  target: registry.suse.com/rancher/charts/mirrored-brancz-kube-rbac-proxy:v0.18.2
-  type: image
-- source: quay.io/brancz/kube-rbac-proxy:v0.18.0
   target: stgregistry.suse.com/rancher/mirrored-brancz-kube-rbac-proxy:v0.18.0
   type: image
 - source: quay.io/brancz/kube-rbac-proxy:v0.18.2
   target: stgregistry.suse.com/rancher/mirrored-brancz-kube-rbac-proxy:v0.18.2
-  type: image
-- source: quay.io/brancz/kube-rbac-proxy:v0.18.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-brancz-kube-rbac-proxy:v0.18.0
-  type: image
-- source: quay.io/brancz/kube-rbac-proxy:v0.18.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-brancz-kube-rbac-proxy:v0.18.2
   type: image
 - source: quay.io/calico/apiserver:v3.20.1
   target: docker.io/rancher/mirrored-calico-apiserver:v3.20.1
@@ -17201,111 +10427,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-calico-apiserver:v3.30.3
   type: image
 - source: quay.io/calico/apiserver:v3.20.1
-  target: registry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.20.1
-  type: image
-- source: quay.io/calico/apiserver:v3.20.2
-  target: registry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.20.2
-  type: image
-- source: quay.io/calico/apiserver:v3.21.2
-  target: registry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.21.2
-  type: image
-- source: quay.io/calico/apiserver:v3.21.4
-  target: registry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.21.4
-  type: image
-- source: quay.io/calico/apiserver:v3.21.5
-  target: registry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.21.5
-  type: image
-- source: quay.io/calico/apiserver:v3.22.0
-  target: registry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.22.0
-  type: image
-- source: quay.io/calico/apiserver:v3.22.1
-  target: registry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.22.1
-  type: image
-- source: quay.io/calico/apiserver:v3.22.2
-  target: registry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.22.2
-  type: image
-- source: quay.io/calico/apiserver:v3.22.5
-  target: registry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.22.5
-  type: image
-- source: quay.io/calico/apiserver:v3.23.0
-  target: registry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.23.0
-  type: image
-- source: quay.io/calico/apiserver:v3.23.1
-  target: registry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.23.1
-  type: image
-- source: quay.io/calico/apiserver:v3.23.3
-  target: registry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.23.3
-  type: image
-- source: quay.io/calico/apiserver:v3.24.1
-  target: registry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.24.1
-  type: image
-- source: quay.io/calico/apiserver:v3.24.5
-  target: registry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.24.5
-  type: image
-- source: quay.io/calico/apiserver:v3.25.0
-  target: registry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.25.0
-  type: image
-- source: quay.io/calico/apiserver:v3.25.2
-  target: registry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.25.2
-  type: image
-- source: quay.io/calico/apiserver:v3.26.1
-  target: registry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.26.1
-  type: image
-- source: quay.io/calico/apiserver:v3.26.2
-  target: registry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.26.2
-  type: image
-- source: quay.io/calico/apiserver:v3.26.3
-  target: registry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.26.3
-  type: image
-- source: quay.io/calico/apiserver:v3.26.4
-  target: registry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.26.4
-  type: image
-- source: quay.io/calico/apiserver:v3.27.0
-  target: registry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.27.0
-  type: image
-- source: quay.io/calico/apiserver:v3.27.2
-  target: registry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.27.2
-  type: image
-- source: quay.io/calico/apiserver:v3.27.3
-  target: registry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.27.3
-  type: image
-- source: quay.io/calico/apiserver:v3.27.4
-  target: registry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.27.4
-  type: image
-- source: quay.io/calico/apiserver:v3.28.0
-  target: registry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.28.0
-  type: image
-- source: quay.io/calico/apiserver:v3.28.1
-  target: registry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.28.1
-  type: image
-- source: quay.io/calico/apiserver:v3.28.2
-  target: registry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.28.2
-  type: image
-- source: quay.io/calico/apiserver:v3.29.0
-  target: registry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.29.0
-  type: image
-- source: quay.io/calico/apiserver:v3.29.1
-  target: registry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.29.1
-  type: image
-- source: quay.io/calico/apiserver:v3.29.2
-  target: registry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.29.2
-  type: image
-- source: quay.io/calico/apiserver:v3.29.3
-  target: registry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.29.3
-  type: image
-- source: quay.io/calico/apiserver:v3.30.0
-  target: registry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.30.0
-  type: image
-- source: quay.io/calico/apiserver:v3.30.1
-  target: registry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.30.1
-  type: image
-- source: quay.io/calico/apiserver:v3.30.2
-  target: registry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.30.2
-  type: image
-- source: quay.io/calico/apiserver:v3.30.3
-  target: registry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.30.3
-  type: image
-- source: quay.io/calico/apiserver:v3.20.1
   target: stgregistry.suse.com/rancher/mirrored-calico-apiserver:v3.20.1
   type: image
 - source: quay.io/calico/apiserver:v3.20.2
@@ -17410,111 +10531,6 @@ sync:
 - source: quay.io/calico/apiserver:v3.30.3
   target: stgregistry.suse.com/rancher/mirrored-calico-apiserver:v3.30.3
   type: image
-- source: quay.io/calico/apiserver:v3.20.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.20.1
-  type: image
-- source: quay.io/calico/apiserver:v3.20.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.20.2
-  type: image
-- source: quay.io/calico/apiserver:v3.21.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.21.2
-  type: image
-- source: quay.io/calico/apiserver:v3.21.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.21.4
-  type: image
-- source: quay.io/calico/apiserver:v3.21.5
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.21.5
-  type: image
-- source: quay.io/calico/apiserver:v3.22.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.22.0
-  type: image
-- source: quay.io/calico/apiserver:v3.22.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.22.1
-  type: image
-- source: quay.io/calico/apiserver:v3.22.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.22.2
-  type: image
-- source: quay.io/calico/apiserver:v3.22.5
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.22.5
-  type: image
-- source: quay.io/calico/apiserver:v3.23.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.23.0
-  type: image
-- source: quay.io/calico/apiserver:v3.23.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.23.1
-  type: image
-- source: quay.io/calico/apiserver:v3.23.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.23.3
-  type: image
-- source: quay.io/calico/apiserver:v3.24.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.24.1
-  type: image
-- source: quay.io/calico/apiserver:v3.24.5
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.24.5
-  type: image
-- source: quay.io/calico/apiserver:v3.25.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.25.0
-  type: image
-- source: quay.io/calico/apiserver:v3.25.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.25.2
-  type: image
-- source: quay.io/calico/apiserver:v3.26.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.26.1
-  type: image
-- source: quay.io/calico/apiserver:v3.26.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.26.2
-  type: image
-- source: quay.io/calico/apiserver:v3.26.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.26.3
-  type: image
-- source: quay.io/calico/apiserver:v3.26.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.26.4
-  type: image
-- source: quay.io/calico/apiserver:v3.27.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.27.0
-  type: image
-- source: quay.io/calico/apiserver:v3.27.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.27.2
-  type: image
-- source: quay.io/calico/apiserver:v3.27.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.27.3
-  type: image
-- source: quay.io/calico/apiserver:v3.27.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.27.4
-  type: image
-- source: quay.io/calico/apiserver:v3.28.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.28.0
-  type: image
-- source: quay.io/calico/apiserver:v3.28.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.28.1
-  type: image
-- source: quay.io/calico/apiserver:v3.28.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.28.2
-  type: image
-- source: quay.io/calico/apiserver:v3.29.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.29.0
-  type: image
-- source: quay.io/calico/apiserver:v3.29.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.29.1
-  type: image
-- source: quay.io/calico/apiserver:v3.29.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.29.2
-  type: image
-- source: quay.io/calico/apiserver:v3.29.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.29.3
-  type: image
-- source: quay.io/calico/apiserver:v3.30.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.30.0
-  type: image
-- source: quay.io/calico/apiserver:v3.30.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.30.1
-  type: image
-- source: quay.io/calico/apiserver:v3.30.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.30.2
-  type: image
-- source: quay.io/calico/apiserver:v3.30.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-apiserver:v3.30.3
-  type: image
 - source: quay.io/calico/cni:v3.16.5
   target: docker.io/rancher/calico-cni:v3.16.5
   type: image
@@ -17546,21 +10562,6 @@ sync:
   target: registry.suse.com/rancher/calico-cni:v3.18.1
   type: image
 - source: quay.io/calico/cni:v3.16.5
-  target: registry.suse.com/rancher/charts/calico-cni:v3.16.5
-  type: image
-- source: quay.io/calico/cni:v3.16.6
-  target: registry.suse.com/rancher/charts/calico-cni:v3.16.6
-  type: image
-- source: quay.io/calico/cni:v3.17.1
-  target: registry.suse.com/rancher/charts/calico-cni:v3.17.1
-  type: image
-- source: quay.io/calico/cni:v3.17.2
-  target: registry.suse.com/rancher/charts/calico-cni:v3.17.2
-  type: image
-- source: quay.io/calico/cni:v3.18.1
-  target: registry.suse.com/rancher/charts/calico-cni:v3.18.1
-  type: image
-- source: quay.io/calico/cni:v3.16.5
   target: stgregistry.suse.com/rancher/calico-cni:v3.16.5
   type: image
 - source: quay.io/calico/cni:v3.16.6
@@ -17574,21 +10575,6 @@ sync:
   type: image
 - source: quay.io/calico/cni:v3.18.1
   target: stgregistry.suse.com/rancher/calico-cni:v3.18.1
-  type: image
-- source: quay.io/calico/cni:v3.16.5
-  target: stgregistry.suse.com/rancher/charts/calico-cni:v3.16.5
-  type: image
-- source: quay.io/calico/cni:v3.16.6
-  target: stgregistry.suse.com/rancher/charts/calico-cni:v3.16.6
-  type: image
-- source: quay.io/calico/cni:v3.17.1
-  target: stgregistry.suse.com/rancher/charts/calico-cni:v3.17.1
-  type: image
-- source: quay.io/calico/cni:v3.17.2
-  target: stgregistry.suse.com/rancher/charts/calico-cni:v3.17.2
-  type: image
-- source: quay.io/calico/cni:v3.18.1
-  target: stgregistry.suse.com/rancher/charts/calico-cni:v3.18.1
   type: image
 - source: quay.io/calico/cni:v3.13.4
   target: docker.io/rancher/mirrored-calico-cni:v3.13.4
@@ -17849,135 +10835,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-calico-cni:v3.30.3
   type: image
 - source: quay.io/calico/cni:v3.13.4
-  target: registry.suse.com/rancher/charts/mirrored-calico-cni:v3.13.4
-  type: image
-- source: quay.io/calico/cni:v3.16.5
-  target: registry.suse.com/rancher/charts/mirrored-calico-cni:v3.16.5
-  type: image
-- source: quay.io/calico/cni:v3.17.2
-  target: registry.suse.com/rancher/charts/mirrored-calico-cni:v3.17.2
-  type: image
-- source: quay.io/calico/cni:v3.18.1
-  target: registry.suse.com/rancher/charts/mirrored-calico-cni:v3.18.1
-  type: image
-- source: quay.io/calico/cni:v3.19.0
-  target: registry.suse.com/rancher/charts/mirrored-calico-cni:v3.19.0
-  type: image
-- source: quay.io/calico/cni:v3.19.1
-  target: registry.suse.com/rancher/charts/mirrored-calico-cni:v3.19.1
-  type: image
-- source: quay.io/calico/cni:v3.19.2
-  target: registry.suse.com/rancher/charts/mirrored-calico-cni:v3.19.2
-  type: image
-- source: quay.io/calico/cni:v3.20.1
-  target: registry.suse.com/rancher/charts/mirrored-calico-cni:v3.20.1
-  type: image
-- source: quay.io/calico/cni:v3.20.2
-  target: registry.suse.com/rancher/charts/mirrored-calico-cni:v3.20.2
-  type: image
-- source: quay.io/calico/cni:v3.21.1
-  target: registry.suse.com/rancher/charts/mirrored-calico-cni:v3.21.1
-  type: image
-- source: quay.io/calico/cni:v3.21.2
-  target: registry.suse.com/rancher/charts/mirrored-calico-cni:v3.21.2
-  type: image
-- source: quay.io/calico/cni:v3.21.4
-  target: registry.suse.com/rancher/charts/mirrored-calico-cni:v3.21.4
-  type: image
-- source: quay.io/calico/cni:v3.21.5
-  target: registry.suse.com/rancher/charts/mirrored-calico-cni:v3.21.5
-  type: image
-- source: quay.io/calico/cni:v3.22.0
-  target: registry.suse.com/rancher/charts/mirrored-calico-cni:v3.22.0
-  type: image
-- source: quay.io/calico/cni:v3.22.1
-  target: registry.suse.com/rancher/charts/mirrored-calico-cni:v3.22.1
-  type: image
-- source: quay.io/calico/cni:v3.22.2
-  target: registry.suse.com/rancher/charts/mirrored-calico-cni:v3.22.2
-  type: image
-- source: quay.io/calico/cni:v3.22.5
-  target: registry.suse.com/rancher/charts/mirrored-calico-cni:v3.22.5
-  type: image
-- source: quay.io/calico/cni:v3.23.0
-  target: registry.suse.com/rancher/charts/mirrored-calico-cni:v3.23.0
-  type: image
-- source: quay.io/calico/cni:v3.23.1
-  target: registry.suse.com/rancher/charts/mirrored-calico-cni:v3.23.1
-  type: image
-- source: quay.io/calico/cni:v3.23.3
-  target: registry.suse.com/rancher/charts/mirrored-calico-cni:v3.23.3
-  type: image
-- source: quay.io/calico/cni:v3.24.1
-  target: registry.suse.com/rancher/charts/mirrored-calico-cni:v3.24.1
-  type: image
-- source: quay.io/calico/cni:v3.24.5
-  target: registry.suse.com/rancher/charts/mirrored-calico-cni:v3.24.5
-  type: image
-- source: quay.io/calico/cni:v3.25.0
-  target: registry.suse.com/rancher/charts/mirrored-calico-cni:v3.25.0
-  type: image
-- source: quay.io/calico/cni:v3.25.2
-  target: registry.suse.com/rancher/charts/mirrored-calico-cni:v3.25.2
-  type: image
-- source: quay.io/calico/cni:v3.26.1
-  target: registry.suse.com/rancher/charts/mirrored-calico-cni:v3.26.1
-  type: image
-- source: quay.io/calico/cni:v3.26.2
-  target: registry.suse.com/rancher/charts/mirrored-calico-cni:v3.26.2
-  type: image
-- source: quay.io/calico/cni:v3.26.3
-  target: registry.suse.com/rancher/charts/mirrored-calico-cni:v3.26.3
-  type: image
-- source: quay.io/calico/cni:v3.26.4
-  target: registry.suse.com/rancher/charts/mirrored-calico-cni:v3.26.4
-  type: image
-- source: quay.io/calico/cni:v3.27.0
-  target: registry.suse.com/rancher/charts/mirrored-calico-cni:v3.27.0
-  type: image
-- source: quay.io/calico/cni:v3.27.2
-  target: registry.suse.com/rancher/charts/mirrored-calico-cni:v3.27.2
-  type: image
-- source: quay.io/calico/cni:v3.27.3
-  target: registry.suse.com/rancher/charts/mirrored-calico-cni:v3.27.3
-  type: image
-- source: quay.io/calico/cni:v3.27.4
-  target: registry.suse.com/rancher/charts/mirrored-calico-cni:v3.27.4
-  type: image
-- source: quay.io/calico/cni:v3.28.0
-  target: registry.suse.com/rancher/charts/mirrored-calico-cni:v3.28.0
-  type: image
-- source: quay.io/calico/cni:v3.28.1
-  target: registry.suse.com/rancher/charts/mirrored-calico-cni:v3.28.1
-  type: image
-- source: quay.io/calico/cni:v3.28.2
-  target: registry.suse.com/rancher/charts/mirrored-calico-cni:v3.28.2
-  type: image
-- source: quay.io/calico/cni:v3.29.0
-  target: registry.suse.com/rancher/charts/mirrored-calico-cni:v3.29.0
-  type: image
-- source: quay.io/calico/cni:v3.29.1
-  target: registry.suse.com/rancher/charts/mirrored-calico-cni:v3.29.1
-  type: image
-- source: quay.io/calico/cni:v3.29.2
-  target: registry.suse.com/rancher/charts/mirrored-calico-cni:v3.29.2
-  type: image
-- source: quay.io/calico/cni:v3.29.3
-  target: registry.suse.com/rancher/charts/mirrored-calico-cni:v3.29.3
-  type: image
-- source: quay.io/calico/cni:v3.30.0
-  target: registry.suse.com/rancher/charts/mirrored-calico-cni:v3.30.0
-  type: image
-- source: quay.io/calico/cni:v3.30.1
-  target: registry.suse.com/rancher/charts/mirrored-calico-cni:v3.30.1
-  type: image
-- source: quay.io/calico/cni:v3.30.2
-  target: registry.suse.com/rancher/charts/mirrored-calico-cni:v3.30.2
-  type: image
-- source: quay.io/calico/cni:v3.30.3
-  target: registry.suse.com/rancher/charts/mirrored-calico-cni:v3.30.3
-  type: image
-- source: quay.io/calico/cni:v3.13.4
   target: stgregistry.suse.com/rancher/mirrored-calico-cni:v3.13.4
   type: image
 - source: quay.io/calico/cni:v3.16.5
@@ -18106,135 +10963,6 @@ sync:
 - source: quay.io/calico/cni:v3.30.3
   target: stgregistry.suse.com/rancher/mirrored-calico-cni:v3.30.3
   type: image
-- source: quay.io/calico/cni:v3.13.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-cni:v3.13.4
-  type: image
-- source: quay.io/calico/cni:v3.16.5
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-cni:v3.16.5
-  type: image
-- source: quay.io/calico/cni:v3.17.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-cni:v3.17.2
-  type: image
-- source: quay.io/calico/cni:v3.18.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-cni:v3.18.1
-  type: image
-- source: quay.io/calico/cni:v3.19.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-cni:v3.19.0
-  type: image
-- source: quay.io/calico/cni:v3.19.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-cni:v3.19.1
-  type: image
-- source: quay.io/calico/cni:v3.19.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-cni:v3.19.2
-  type: image
-- source: quay.io/calico/cni:v3.20.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-cni:v3.20.1
-  type: image
-- source: quay.io/calico/cni:v3.20.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-cni:v3.20.2
-  type: image
-- source: quay.io/calico/cni:v3.21.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-cni:v3.21.1
-  type: image
-- source: quay.io/calico/cni:v3.21.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-cni:v3.21.2
-  type: image
-- source: quay.io/calico/cni:v3.21.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-cni:v3.21.4
-  type: image
-- source: quay.io/calico/cni:v3.21.5
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-cni:v3.21.5
-  type: image
-- source: quay.io/calico/cni:v3.22.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-cni:v3.22.0
-  type: image
-- source: quay.io/calico/cni:v3.22.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-cni:v3.22.1
-  type: image
-- source: quay.io/calico/cni:v3.22.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-cni:v3.22.2
-  type: image
-- source: quay.io/calico/cni:v3.22.5
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-cni:v3.22.5
-  type: image
-- source: quay.io/calico/cni:v3.23.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-cni:v3.23.0
-  type: image
-- source: quay.io/calico/cni:v3.23.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-cni:v3.23.1
-  type: image
-- source: quay.io/calico/cni:v3.23.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-cni:v3.23.3
-  type: image
-- source: quay.io/calico/cni:v3.24.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-cni:v3.24.1
-  type: image
-- source: quay.io/calico/cni:v3.24.5
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-cni:v3.24.5
-  type: image
-- source: quay.io/calico/cni:v3.25.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-cni:v3.25.0
-  type: image
-- source: quay.io/calico/cni:v3.25.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-cni:v3.25.2
-  type: image
-- source: quay.io/calico/cni:v3.26.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-cni:v3.26.1
-  type: image
-- source: quay.io/calico/cni:v3.26.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-cni:v3.26.2
-  type: image
-- source: quay.io/calico/cni:v3.26.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-cni:v3.26.3
-  type: image
-- source: quay.io/calico/cni:v3.26.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-cni:v3.26.4
-  type: image
-- source: quay.io/calico/cni:v3.27.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-cni:v3.27.0
-  type: image
-- source: quay.io/calico/cni:v3.27.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-cni:v3.27.2
-  type: image
-- source: quay.io/calico/cni:v3.27.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-cni:v3.27.3
-  type: image
-- source: quay.io/calico/cni:v3.27.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-cni:v3.27.4
-  type: image
-- source: quay.io/calico/cni:v3.28.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-cni:v3.28.0
-  type: image
-- source: quay.io/calico/cni:v3.28.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-cni:v3.28.1
-  type: image
-- source: quay.io/calico/cni:v3.28.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-cni:v3.28.2
-  type: image
-- source: quay.io/calico/cni:v3.29.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-cni:v3.29.0
-  type: image
-- source: quay.io/calico/cni:v3.29.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-cni:v3.29.1
-  type: image
-- source: quay.io/calico/cni:v3.29.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-cni:v3.29.2
-  type: image
-- source: quay.io/calico/cni:v3.29.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-cni:v3.29.3
-  type: image
-- source: quay.io/calico/cni:v3.30.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-cni:v3.30.0
-  type: image
-- source: quay.io/calico/cni:v3.30.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-cni:v3.30.1
-  type: image
-- source: quay.io/calico/cni:v3.30.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-cni:v3.30.2
-  type: image
-- source: quay.io/calico/cni:v3.30.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-cni:v3.30.3
-  type: image
 - source: quay.io/calico/csi:v3.27.0
   target: docker.io/rancher/mirrored-calico-csi:v3.27.0
   type: image
@@ -18326,51 +11054,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-calico-csi:v3.30.3
   type: image
 - source: quay.io/calico/csi:v3.27.0
-  target: registry.suse.com/rancher/charts/mirrored-calico-csi:v3.27.0
-  type: image
-- source: quay.io/calico/csi:v3.27.2
-  target: registry.suse.com/rancher/charts/mirrored-calico-csi:v3.27.2
-  type: image
-- source: quay.io/calico/csi:v3.27.3
-  target: registry.suse.com/rancher/charts/mirrored-calico-csi:v3.27.3
-  type: image
-- source: quay.io/calico/csi:v3.27.4
-  target: registry.suse.com/rancher/charts/mirrored-calico-csi:v3.27.4
-  type: image
-- source: quay.io/calico/csi:v3.28.0
-  target: registry.suse.com/rancher/charts/mirrored-calico-csi:v3.28.0
-  type: image
-- source: quay.io/calico/csi:v3.28.1
-  target: registry.suse.com/rancher/charts/mirrored-calico-csi:v3.28.1
-  type: image
-- source: quay.io/calico/csi:v3.28.2
-  target: registry.suse.com/rancher/charts/mirrored-calico-csi:v3.28.2
-  type: image
-- source: quay.io/calico/csi:v3.29.0
-  target: registry.suse.com/rancher/charts/mirrored-calico-csi:v3.29.0
-  type: image
-- source: quay.io/calico/csi:v3.29.1
-  target: registry.suse.com/rancher/charts/mirrored-calico-csi:v3.29.1
-  type: image
-- source: quay.io/calico/csi:v3.29.2
-  target: registry.suse.com/rancher/charts/mirrored-calico-csi:v3.29.2
-  type: image
-- source: quay.io/calico/csi:v3.29.3
-  target: registry.suse.com/rancher/charts/mirrored-calico-csi:v3.29.3
-  type: image
-- source: quay.io/calico/csi:v3.30.0
-  target: registry.suse.com/rancher/charts/mirrored-calico-csi:v3.30.0
-  type: image
-- source: quay.io/calico/csi:v3.30.1
-  target: registry.suse.com/rancher/charts/mirrored-calico-csi:v3.30.1
-  type: image
-- source: quay.io/calico/csi:v3.30.2
-  target: registry.suse.com/rancher/charts/mirrored-calico-csi:v3.30.2
-  type: image
-- source: quay.io/calico/csi:v3.30.3
-  target: registry.suse.com/rancher/charts/mirrored-calico-csi:v3.30.3
-  type: image
-- source: quay.io/calico/csi:v3.27.0
   target: stgregistry.suse.com/rancher/mirrored-calico-csi:v3.27.0
   type: image
 - source: quay.io/calico/csi:v3.27.2
@@ -18415,51 +11098,6 @@ sync:
 - source: quay.io/calico/csi:v3.30.3
   target: stgregistry.suse.com/rancher/mirrored-calico-csi:v3.30.3
   type: image
-- source: quay.io/calico/csi:v3.27.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-csi:v3.27.0
-  type: image
-- source: quay.io/calico/csi:v3.27.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-csi:v3.27.2
-  type: image
-- source: quay.io/calico/csi:v3.27.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-csi:v3.27.3
-  type: image
-- source: quay.io/calico/csi:v3.27.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-csi:v3.27.4
-  type: image
-- source: quay.io/calico/csi:v3.28.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-csi:v3.28.0
-  type: image
-- source: quay.io/calico/csi:v3.28.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-csi:v3.28.1
-  type: image
-- source: quay.io/calico/csi:v3.28.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-csi:v3.28.2
-  type: image
-- source: quay.io/calico/csi:v3.29.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-csi:v3.29.0
-  type: image
-- source: quay.io/calico/csi:v3.29.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-csi:v3.29.1
-  type: image
-- source: quay.io/calico/csi:v3.29.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-csi:v3.29.2
-  type: image
-- source: quay.io/calico/csi:v3.29.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-csi:v3.29.3
-  type: image
-- source: quay.io/calico/csi:v3.30.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-csi:v3.30.0
-  type: image
-- source: quay.io/calico/csi:v3.30.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-csi:v3.30.1
-  type: image
-- source: quay.io/calico/csi:v3.30.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-csi:v3.30.2
-  type: image
-- source: quay.io/calico/csi:v3.30.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-csi:v3.30.3
-  type: image
 - source: quay.io/calico/ctl:v3.16.5
   target: docker.io/rancher/calico-ctl:v3.16.5
   type: image
@@ -18503,27 +11141,6 @@ sync:
   target: registry.suse.com/rancher/calico-ctl:v3.19.2
   type: image
 - source: quay.io/calico/ctl:v3.16.5
-  target: registry.suse.com/rancher/charts/calico-ctl:v3.16.5
-  type: image
-- source: quay.io/calico/ctl:v3.16.6
-  target: registry.suse.com/rancher/charts/calico-ctl:v3.16.6
-  type: image
-- source: quay.io/calico/ctl:v3.17.1
-  target: registry.suse.com/rancher/charts/calico-ctl:v3.17.1
-  type: image
-- source: quay.io/calico/ctl:v3.17.2
-  target: registry.suse.com/rancher/charts/calico-ctl:v3.17.2
-  type: image
-- source: quay.io/calico/ctl:v3.18.1
-  target: registry.suse.com/rancher/charts/calico-ctl:v3.18.1
-  type: image
-- source: quay.io/calico/ctl:v3.19.1
-  target: registry.suse.com/rancher/charts/calico-ctl:v3.19.1
-  type: image
-- source: quay.io/calico/ctl:v3.19.2
-  target: registry.suse.com/rancher/charts/calico-ctl:v3.19.2
-  type: image
-- source: quay.io/calico/ctl:v3.16.5
   target: stgregistry.suse.com/rancher/calico-ctl:v3.16.5
   type: image
 - source: quay.io/calico/ctl:v3.16.6
@@ -18543,27 +11160,6 @@ sync:
   type: image
 - source: quay.io/calico/ctl:v3.19.2
   target: stgregistry.suse.com/rancher/calico-ctl:v3.19.2
-  type: image
-- source: quay.io/calico/ctl:v3.16.5
-  target: stgregistry.suse.com/rancher/charts/calico-ctl:v3.16.5
-  type: image
-- source: quay.io/calico/ctl:v3.16.6
-  target: stgregistry.suse.com/rancher/charts/calico-ctl:v3.16.6
-  type: image
-- source: quay.io/calico/ctl:v3.17.1
-  target: stgregistry.suse.com/rancher/charts/calico-ctl:v3.17.1
-  type: image
-- source: quay.io/calico/ctl:v3.17.2
-  target: stgregistry.suse.com/rancher/charts/calico-ctl:v3.17.2
-  type: image
-- source: quay.io/calico/ctl:v3.18.1
-  target: stgregistry.suse.com/rancher/charts/calico-ctl:v3.18.1
-  type: image
-- source: quay.io/calico/ctl:v3.19.1
-  target: stgregistry.suse.com/rancher/charts/calico-ctl:v3.19.1
-  type: image
-- source: quay.io/calico/ctl:v3.19.2
-  target: stgregistry.suse.com/rancher/charts/calico-ctl:v3.19.2
   type: image
 - source: quay.io/calico/ctl:v3.13.4
   target: docker.io/rancher/mirrored-calico-ctl:v3.13.4
@@ -18824,135 +11420,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-calico-ctl:v3.30.3
   type: image
 - source: quay.io/calico/ctl:v3.13.4
-  target: registry.suse.com/rancher/charts/mirrored-calico-ctl:v3.13.4
-  type: image
-- source: quay.io/calico/ctl:v3.16.5
-  target: registry.suse.com/rancher/charts/mirrored-calico-ctl:v3.16.5
-  type: image
-- source: quay.io/calico/ctl:v3.17.2
-  target: registry.suse.com/rancher/charts/mirrored-calico-ctl:v3.17.2
-  type: image
-- source: quay.io/calico/ctl:v3.18.1
-  target: registry.suse.com/rancher/charts/mirrored-calico-ctl:v3.18.1
-  type: image
-- source: quay.io/calico/ctl:v3.19.0
-  target: registry.suse.com/rancher/charts/mirrored-calico-ctl:v3.19.0
-  type: image
-- source: quay.io/calico/ctl:v3.19.1
-  target: registry.suse.com/rancher/charts/mirrored-calico-ctl:v3.19.1
-  type: image
-- source: quay.io/calico/ctl:v3.19.2
-  target: registry.suse.com/rancher/charts/mirrored-calico-ctl:v3.19.2
-  type: image
-- source: quay.io/calico/ctl:v3.20.1
-  target: registry.suse.com/rancher/charts/mirrored-calico-ctl:v3.20.1
-  type: image
-- source: quay.io/calico/ctl:v3.20.2
-  target: registry.suse.com/rancher/charts/mirrored-calico-ctl:v3.20.2
-  type: image
-- source: quay.io/calico/ctl:v3.21.1
-  target: registry.suse.com/rancher/charts/mirrored-calico-ctl:v3.21.1
-  type: image
-- source: quay.io/calico/ctl:v3.21.2
-  target: registry.suse.com/rancher/charts/mirrored-calico-ctl:v3.21.2
-  type: image
-- source: quay.io/calico/ctl:v3.21.4
-  target: registry.suse.com/rancher/charts/mirrored-calico-ctl:v3.21.4
-  type: image
-- source: quay.io/calico/ctl:v3.21.5
-  target: registry.suse.com/rancher/charts/mirrored-calico-ctl:v3.21.5
-  type: image
-- source: quay.io/calico/ctl:v3.22.0
-  target: registry.suse.com/rancher/charts/mirrored-calico-ctl:v3.22.0
-  type: image
-- source: quay.io/calico/ctl:v3.22.1
-  target: registry.suse.com/rancher/charts/mirrored-calico-ctl:v3.22.1
-  type: image
-- source: quay.io/calico/ctl:v3.22.2
-  target: registry.suse.com/rancher/charts/mirrored-calico-ctl:v3.22.2
-  type: image
-- source: quay.io/calico/ctl:v3.22.5
-  target: registry.suse.com/rancher/charts/mirrored-calico-ctl:v3.22.5
-  type: image
-- source: quay.io/calico/ctl:v3.23.0
-  target: registry.suse.com/rancher/charts/mirrored-calico-ctl:v3.23.0
-  type: image
-- source: quay.io/calico/ctl:v3.23.1
-  target: registry.suse.com/rancher/charts/mirrored-calico-ctl:v3.23.1
-  type: image
-- source: quay.io/calico/ctl:v3.23.3
-  target: registry.suse.com/rancher/charts/mirrored-calico-ctl:v3.23.3
-  type: image
-- source: quay.io/calico/ctl:v3.24.1
-  target: registry.suse.com/rancher/charts/mirrored-calico-ctl:v3.24.1
-  type: image
-- source: quay.io/calico/ctl:v3.24.5
-  target: registry.suse.com/rancher/charts/mirrored-calico-ctl:v3.24.5
-  type: image
-- source: quay.io/calico/ctl:v3.25.0
-  target: registry.suse.com/rancher/charts/mirrored-calico-ctl:v3.25.0
-  type: image
-- source: quay.io/calico/ctl:v3.25.2
-  target: registry.suse.com/rancher/charts/mirrored-calico-ctl:v3.25.2
-  type: image
-- source: quay.io/calico/ctl:v3.26.1
-  target: registry.suse.com/rancher/charts/mirrored-calico-ctl:v3.26.1
-  type: image
-- source: quay.io/calico/ctl:v3.26.2
-  target: registry.suse.com/rancher/charts/mirrored-calico-ctl:v3.26.2
-  type: image
-- source: quay.io/calico/ctl:v3.26.3
-  target: registry.suse.com/rancher/charts/mirrored-calico-ctl:v3.26.3
-  type: image
-- source: quay.io/calico/ctl:v3.26.4
-  target: registry.suse.com/rancher/charts/mirrored-calico-ctl:v3.26.4
-  type: image
-- source: quay.io/calico/ctl:v3.27.0
-  target: registry.suse.com/rancher/charts/mirrored-calico-ctl:v3.27.0
-  type: image
-- source: quay.io/calico/ctl:v3.27.2
-  target: registry.suse.com/rancher/charts/mirrored-calico-ctl:v3.27.2
-  type: image
-- source: quay.io/calico/ctl:v3.27.3
-  target: registry.suse.com/rancher/charts/mirrored-calico-ctl:v3.27.3
-  type: image
-- source: quay.io/calico/ctl:v3.27.4
-  target: registry.suse.com/rancher/charts/mirrored-calico-ctl:v3.27.4
-  type: image
-- source: quay.io/calico/ctl:v3.28.0
-  target: registry.suse.com/rancher/charts/mirrored-calico-ctl:v3.28.0
-  type: image
-- source: quay.io/calico/ctl:v3.28.1
-  target: registry.suse.com/rancher/charts/mirrored-calico-ctl:v3.28.1
-  type: image
-- source: quay.io/calico/ctl:v3.28.2
-  target: registry.suse.com/rancher/charts/mirrored-calico-ctl:v3.28.2
-  type: image
-- source: quay.io/calico/ctl:v3.29.0
-  target: registry.suse.com/rancher/charts/mirrored-calico-ctl:v3.29.0
-  type: image
-- source: quay.io/calico/ctl:v3.29.1
-  target: registry.suse.com/rancher/charts/mirrored-calico-ctl:v3.29.1
-  type: image
-- source: quay.io/calico/ctl:v3.29.2
-  target: registry.suse.com/rancher/charts/mirrored-calico-ctl:v3.29.2
-  type: image
-- source: quay.io/calico/ctl:v3.29.3
-  target: registry.suse.com/rancher/charts/mirrored-calico-ctl:v3.29.3
-  type: image
-- source: quay.io/calico/ctl:v3.30.0
-  target: registry.suse.com/rancher/charts/mirrored-calico-ctl:v3.30.0
-  type: image
-- source: quay.io/calico/ctl:v3.30.1
-  target: registry.suse.com/rancher/charts/mirrored-calico-ctl:v3.30.1
-  type: image
-- source: quay.io/calico/ctl:v3.30.2
-  target: registry.suse.com/rancher/charts/mirrored-calico-ctl:v3.30.2
-  type: image
-- source: quay.io/calico/ctl:v3.30.3
-  target: registry.suse.com/rancher/charts/mirrored-calico-ctl:v3.30.3
-  type: image
-- source: quay.io/calico/ctl:v3.13.4
   target: stgregistry.suse.com/rancher/mirrored-calico-ctl:v3.13.4
   type: image
 - source: quay.io/calico/ctl:v3.16.5
@@ -19081,135 +11548,6 @@ sync:
 - source: quay.io/calico/ctl:v3.30.3
   target: stgregistry.suse.com/rancher/mirrored-calico-ctl:v3.30.3
   type: image
-- source: quay.io/calico/ctl:v3.13.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-ctl:v3.13.4
-  type: image
-- source: quay.io/calico/ctl:v3.16.5
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-ctl:v3.16.5
-  type: image
-- source: quay.io/calico/ctl:v3.17.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-ctl:v3.17.2
-  type: image
-- source: quay.io/calico/ctl:v3.18.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-ctl:v3.18.1
-  type: image
-- source: quay.io/calico/ctl:v3.19.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-ctl:v3.19.0
-  type: image
-- source: quay.io/calico/ctl:v3.19.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-ctl:v3.19.1
-  type: image
-- source: quay.io/calico/ctl:v3.19.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-ctl:v3.19.2
-  type: image
-- source: quay.io/calico/ctl:v3.20.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-ctl:v3.20.1
-  type: image
-- source: quay.io/calico/ctl:v3.20.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-ctl:v3.20.2
-  type: image
-- source: quay.io/calico/ctl:v3.21.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-ctl:v3.21.1
-  type: image
-- source: quay.io/calico/ctl:v3.21.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-ctl:v3.21.2
-  type: image
-- source: quay.io/calico/ctl:v3.21.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-ctl:v3.21.4
-  type: image
-- source: quay.io/calico/ctl:v3.21.5
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-ctl:v3.21.5
-  type: image
-- source: quay.io/calico/ctl:v3.22.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-ctl:v3.22.0
-  type: image
-- source: quay.io/calico/ctl:v3.22.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-ctl:v3.22.1
-  type: image
-- source: quay.io/calico/ctl:v3.22.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-ctl:v3.22.2
-  type: image
-- source: quay.io/calico/ctl:v3.22.5
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-ctl:v3.22.5
-  type: image
-- source: quay.io/calico/ctl:v3.23.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-ctl:v3.23.0
-  type: image
-- source: quay.io/calico/ctl:v3.23.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-ctl:v3.23.1
-  type: image
-- source: quay.io/calico/ctl:v3.23.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-ctl:v3.23.3
-  type: image
-- source: quay.io/calico/ctl:v3.24.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-ctl:v3.24.1
-  type: image
-- source: quay.io/calico/ctl:v3.24.5
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-ctl:v3.24.5
-  type: image
-- source: quay.io/calico/ctl:v3.25.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-ctl:v3.25.0
-  type: image
-- source: quay.io/calico/ctl:v3.25.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-ctl:v3.25.2
-  type: image
-- source: quay.io/calico/ctl:v3.26.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-ctl:v3.26.1
-  type: image
-- source: quay.io/calico/ctl:v3.26.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-ctl:v3.26.2
-  type: image
-- source: quay.io/calico/ctl:v3.26.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-ctl:v3.26.3
-  type: image
-- source: quay.io/calico/ctl:v3.26.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-ctl:v3.26.4
-  type: image
-- source: quay.io/calico/ctl:v3.27.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-ctl:v3.27.0
-  type: image
-- source: quay.io/calico/ctl:v3.27.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-ctl:v3.27.2
-  type: image
-- source: quay.io/calico/ctl:v3.27.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-ctl:v3.27.3
-  type: image
-- source: quay.io/calico/ctl:v3.27.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-ctl:v3.27.4
-  type: image
-- source: quay.io/calico/ctl:v3.28.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-ctl:v3.28.0
-  type: image
-- source: quay.io/calico/ctl:v3.28.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-ctl:v3.28.1
-  type: image
-- source: quay.io/calico/ctl:v3.28.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-ctl:v3.28.2
-  type: image
-- source: quay.io/calico/ctl:v3.29.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-ctl:v3.29.0
-  type: image
-- source: quay.io/calico/ctl:v3.29.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-ctl:v3.29.1
-  type: image
-- source: quay.io/calico/ctl:v3.29.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-ctl:v3.29.2
-  type: image
-- source: quay.io/calico/ctl:v3.29.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-ctl:v3.29.3
-  type: image
-- source: quay.io/calico/ctl:v3.30.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-ctl:v3.30.0
-  type: image
-- source: quay.io/calico/ctl:v3.30.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-ctl:v3.30.1
-  type: image
-- source: quay.io/calico/ctl:v3.30.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-ctl:v3.30.2
-  type: image
-- source: quay.io/calico/ctl:v3.30.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-ctl:v3.30.3
-  type: image
 - source: quay.io/calico/envoy-gateway:v3.30.0
   target: docker.io/rancher/mirrored-calico-envoy-gateway:v3.30.0
   type: image
@@ -19235,18 +11573,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-calico-envoy-gateway:v3.30.3
   type: image
 - source: quay.io/calico/envoy-gateway:v3.30.0
-  target: registry.suse.com/rancher/charts/mirrored-calico-envoy-gateway:v3.30.0
-  type: image
-- source: quay.io/calico/envoy-gateway:v3.30.1
-  target: registry.suse.com/rancher/charts/mirrored-calico-envoy-gateway:v3.30.1
-  type: image
-- source: quay.io/calico/envoy-gateway:v3.30.2
-  target: registry.suse.com/rancher/charts/mirrored-calico-envoy-gateway:v3.30.2
-  type: image
-- source: quay.io/calico/envoy-gateway:v3.30.3
-  target: registry.suse.com/rancher/charts/mirrored-calico-envoy-gateway:v3.30.3
-  type: image
-- source: quay.io/calico/envoy-gateway:v3.30.0
   target: stgregistry.suse.com/rancher/mirrored-calico-envoy-gateway:v3.30.0
   type: image
 - source: quay.io/calico/envoy-gateway:v3.30.1
@@ -19257,18 +11583,6 @@ sync:
   type: image
 - source: quay.io/calico/envoy-gateway:v3.30.3
   target: stgregistry.suse.com/rancher/mirrored-calico-envoy-gateway:v3.30.3
-  type: image
-- source: quay.io/calico/envoy-gateway:v3.30.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-envoy-gateway:v3.30.0
-  type: image
-- source: quay.io/calico/envoy-gateway:v3.30.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-envoy-gateway:v3.30.1
-  type: image
-- source: quay.io/calico/envoy-gateway:v3.30.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-envoy-gateway:v3.30.2
-  type: image
-- source: quay.io/calico/envoy-gateway:v3.30.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-envoy-gateway:v3.30.3
   type: image
 - source: quay.io/calico/envoy-proxy:v3.30.0
   target: docker.io/rancher/mirrored-calico-envoy-proxy:v3.30.0
@@ -19295,18 +11609,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-calico-envoy-proxy:v3.30.3
   type: image
 - source: quay.io/calico/envoy-proxy:v3.30.0
-  target: registry.suse.com/rancher/charts/mirrored-calico-envoy-proxy:v3.30.0
-  type: image
-- source: quay.io/calico/envoy-proxy:v3.30.1
-  target: registry.suse.com/rancher/charts/mirrored-calico-envoy-proxy:v3.30.1
-  type: image
-- source: quay.io/calico/envoy-proxy:v3.30.2
-  target: registry.suse.com/rancher/charts/mirrored-calico-envoy-proxy:v3.30.2
-  type: image
-- source: quay.io/calico/envoy-proxy:v3.30.3
-  target: registry.suse.com/rancher/charts/mirrored-calico-envoy-proxy:v3.30.3
-  type: image
-- source: quay.io/calico/envoy-proxy:v3.30.0
   target: stgregistry.suse.com/rancher/mirrored-calico-envoy-proxy:v3.30.0
   type: image
 - source: quay.io/calico/envoy-proxy:v3.30.1
@@ -19317,18 +11619,6 @@ sync:
   type: image
 - source: quay.io/calico/envoy-proxy:v3.30.3
   target: stgregistry.suse.com/rancher/mirrored-calico-envoy-proxy:v3.30.3
-  type: image
-- source: quay.io/calico/envoy-proxy:v3.30.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-envoy-proxy:v3.30.0
-  type: image
-- source: quay.io/calico/envoy-proxy:v3.30.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-envoy-proxy:v3.30.1
-  type: image
-- source: quay.io/calico/envoy-proxy:v3.30.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-envoy-proxy:v3.30.2
-  type: image
-- source: quay.io/calico/envoy-proxy:v3.30.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-envoy-proxy:v3.30.3
   type: image
 - source: quay.io/calico/envoy-ratelimit:v3.30.0
   target: docker.io/rancher/mirrored-calico-envoy-ratelimit:v3.30.0
@@ -19355,18 +11645,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-calico-envoy-ratelimit:v3.30.3
   type: image
 - source: quay.io/calico/envoy-ratelimit:v3.30.0
-  target: registry.suse.com/rancher/charts/mirrored-calico-envoy-ratelimit:v3.30.0
-  type: image
-- source: quay.io/calico/envoy-ratelimit:v3.30.1
-  target: registry.suse.com/rancher/charts/mirrored-calico-envoy-ratelimit:v3.30.1
-  type: image
-- source: quay.io/calico/envoy-ratelimit:v3.30.2
-  target: registry.suse.com/rancher/charts/mirrored-calico-envoy-ratelimit:v3.30.2
-  type: image
-- source: quay.io/calico/envoy-ratelimit:v3.30.3
-  target: registry.suse.com/rancher/charts/mirrored-calico-envoy-ratelimit:v3.30.3
-  type: image
-- source: quay.io/calico/envoy-ratelimit:v3.30.0
   target: stgregistry.suse.com/rancher/mirrored-calico-envoy-ratelimit:v3.30.0
   type: image
 - source: quay.io/calico/envoy-ratelimit:v3.30.1
@@ -19377,18 +11655,6 @@ sync:
   type: image
 - source: quay.io/calico/envoy-ratelimit:v3.30.3
   target: stgregistry.suse.com/rancher/mirrored-calico-envoy-ratelimit:v3.30.3
-  type: image
-- source: quay.io/calico/envoy-ratelimit:v3.30.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-envoy-ratelimit:v3.30.0
-  type: image
-- source: quay.io/calico/envoy-ratelimit:v3.30.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-envoy-ratelimit:v3.30.1
-  type: image
-- source: quay.io/calico/envoy-ratelimit:v3.30.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-envoy-ratelimit:v3.30.2
-  type: image
-- source: quay.io/calico/envoy-ratelimit:v3.30.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-envoy-ratelimit:v3.30.3
   type: image
 - source: quay.io/calico/goldmane:v3.30.0
   target: docker.io/rancher/mirrored-calico-goldmane:v3.30.0
@@ -19415,18 +11681,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-calico-goldmane:v3.30.3
   type: image
 - source: quay.io/calico/goldmane:v3.30.0
-  target: registry.suse.com/rancher/charts/mirrored-calico-goldmane:v3.30.0
-  type: image
-- source: quay.io/calico/goldmane:v3.30.1
-  target: registry.suse.com/rancher/charts/mirrored-calico-goldmane:v3.30.1
-  type: image
-- source: quay.io/calico/goldmane:v3.30.2
-  target: registry.suse.com/rancher/charts/mirrored-calico-goldmane:v3.30.2
-  type: image
-- source: quay.io/calico/goldmane:v3.30.3
-  target: registry.suse.com/rancher/charts/mirrored-calico-goldmane:v3.30.3
-  type: image
-- source: quay.io/calico/goldmane:v3.30.0
   target: stgregistry.suse.com/rancher/mirrored-calico-goldmane:v3.30.0
   type: image
 - source: quay.io/calico/goldmane:v3.30.1
@@ -19437,18 +11691,6 @@ sync:
   type: image
 - source: quay.io/calico/goldmane:v3.30.3
   target: stgregistry.suse.com/rancher/mirrored-calico-goldmane:v3.30.3
-  type: image
-- source: quay.io/calico/goldmane:v3.30.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-goldmane:v3.30.0
-  type: image
-- source: quay.io/calico/goldmane:v3.30.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-goldmane:v3.30.1
-  type: image
-- source: quay.io/calico/goldmane:v3.30.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-goldmane:v3.30.2
-  type: image
-- source: quay.io/calico/goldmane:v3.30.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-goldmane:v3.30.3
   type: image
 - source: quay.io/calico/kube-controllers:v3.16.5
   target: docker.io/rancher/calico-kube-controllers:v3.16.5
@@ -19481,21 +11723,6 @@ sync:
   target: registry.suse.com/rancher/calico-kube-controllers:v3.18.1
   type: image
 - source: quay.io/calico/kube-controllers:v3.16.5
-  target: registry.suse.com/rancher/charts/calico-kube-controllers:v3.16.5
-  type: image
-- source: quay.io/calico/kube-controllers:v3.16.6
-  target: registry.suse.com/rancher/charts/calico-kube-controllers:v3.16.6
-  type: image
-- source: quay.io/calico/kube-controllers:v3.17.1
-  target: registry.suse.com/rancher/charts/calico-kube-controllers:v3.17.1
-  type: image
-- source: quay.io/calico/kube-controllers:v3.17.2
-  target: registry.suse.com/rancher/charts/calico-kube-controllers:v3.17.2
-  type: image
-- source: quay.io/calico/kube-controllers:v3.18.1
-  target: registry.suse.com/rancher/charts/calico-kube-controllers:v3.18.1
-  type: image
-- source: quay.io/calico/kube-controllers:v3.16.5
   target: stgregistry.suse.com/rancher/calico-kube-controllers:v3.16.5
   type: image
 - source: quay.io/calico/kube-controllers:v3.16.6
@@ -19509,21 +11736,6 @@ sync:
   type: image
 - source: quay.io/calico/kube-controllers:v3.18.1
   target: stgregistry.suse.com/rancher/calico-kube-controllers:v3.18.1
-  type: image
-- source: quay.io/calico/kube-controllers:v3.16.5
-  target: stgregistry.suse.com/rancher/charts/calico-kube-controllers:v3.16.5
-  type: image
-- source: quay.io/calico/kube-controllers:v3.16.6
-  target: stgregistry.suse.com/rancher/charts/calico-kube-controllers:v3.16.6
-  type: image
-- source: quay.io/calico/kube-controllers:v3.17.1
-  target: stgregistry.suse.com/rancher/charts/calico-kube-controllers:v3.17.1
-  type: image
-- source: quay.io/calico/kube-controllers:v3.17.2
-  target: stgregistry.suse.com/rancher/charts/calico-kube-controllers:v3.17.2
-  type: image
-- source: quay.io/calico/kube-controllers:v3.18.1
-  target: stgregistry.suse.com/rancher/charts/calico-kube-controllers:v3.18.1
   type: image
 - source: quay.io/calico/kube-controllers:v3.13.4
   target: docker.io/rancher/mirrored-calico-kube-controllers:v3.13.4
@@ -19784,135 +11996,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-calico-kube-controllers:v3.30.3
   type: image
 - source: quay.io/calico/kube-controllers:v3.13.4
-  target: registry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.13.4
-  type: image
-- source: quay.io/calico/kube-controllers:v3.16.5
-  target: registry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.16.5
-  type: image
-- source: quay.io/calico/kube-controllers:v3.17.2
-  target: registry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.17.2
-  type: image
-- source: quay.io/calico/kube-controllers:v3.18.1
-  target: registry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.18.1
-  type: image
-- source: quay.io/calico/kube-controllers:v3.19.0
-  target: registry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.19.0
-  type: image
-- source: quay.io/calico/kube-controllers:v3.19.1
-  target: registry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.19.1
-  type: image
-- source: quay.io/calico/kube-controllers:v3.19.2
-  target: registry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.19.2
-  type: image
-- source: quay.io/calico/kube-controllers:v3.20.1
-  target: registry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.20.1
-  type: image
-- source: quay.io/calico/kube-controllers:v3.20.2
-  target: registry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.20.2
-  type: image
-- source: quay.io/calico/kube-controllers:v3.21.1
-  target: registry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.21.1
-  type: image
-- source: quay.io/calico/kube-controllers:v3.21.2
-  target: registry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.21.2
-  type: image
-- source: quay.io/calico/kube-controllers:v3.21.4
-  target: registry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.21.4
-  type: image
-- source: quay.io/calico/kube-controllers:v3.21.5
-  target: registry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.21.5
-  type: image
-- source: quay.io/calico/kube-controllers:v3.22.0
-  target: registry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.22.0
-  type: image
-- source: quay.io/calico/kube-controllers:v3.22.1
-  target: registry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.22.1
-  type: image
-- source: quay.io/calico/kube-controllers:v3.22.2
-  target: registry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.22.2
-  type: image
-- source: quay.io/calico/kube-controllers:v3.22.5
-  target: registry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.22.5
-  type: image
-- source: quay.io/calico/kube-controllers:v3.23.0
-  target: registry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.23.0
-  type: image
-- source: quay.io/calico/kube-controllers:v3.23.1
-  target: registry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.23.1
-  type: image
-- source: quay.io/calico/kube-controllers:v3.23.3
-  target: registry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.23.3
-  type: image
-- source: quay.io/calico/kube-controllers:v3.24.1
-  target: registry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.24.1
-  type: image
-- source: quay.io/calico/kube-controllers:v3.24.5
-  target: registry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.24.5
-  type: image
-- source: quay.io/calico/kube-controllers:v3.25.0
-  target: registry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.25.0
-  type: image
-- source: quay.io/calico/kube-controllers:v3.25.2
-  target: registry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.25.2
-  type: image
-- source: quay.io/calico/kube-controllers:v3.26.1
-  target: registry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.26.1
-  type: image
-- source: quay.io/calico/kube-controllers:v3.26.2
-  target: registry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.26.2
-  type: image
-- source: quay.io/calico/kube-controllers:v3.26.3
-  target: registry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.26.3
-  type: image
-- source: quay.io/calico/kube-controllers:v3.26.4
-  target: registry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.26.4
-  type: image
-- source: quay.io/calico/kube-controllers:v3.27.0
-  target: registry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.27.0
-  type: image
-- source: quay.io/calico/kube-controllers:v3.27.2
-  target: registry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.27.2
-  type: image
-- source: quay.io/calico/kube-controllers:v3.27.3
-  target: registry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.27.3
-  type: image
-- source: quay.io/calico/kube-controllers:v3.27.4
-  target: registry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.27.4
-  type: image
-- source: quay.io/calico/kube-controllers:v3.28.0
-  target: registry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.28.0
-  type: image
-- source: quay.io/calico/kube-controllers:v3.28.1
-  target: registry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.28.1
-  type: image
-- source: quay.io/calico/kube-controllers:v3.28.2
-  target: registry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.28.2
-  type: image
-- source: quay.io/calico/kube-controllers:v3.29.0
-  target: registry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.29.0
-  type: image
-- source: quay.io/calico/kube-controllers:v3.29.1
-  target: registry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.29.1
-  type: image
-- source: quay.io/calico/kube-controllers:v3.29.2
-  target: registry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.29.2
-  type: image
-- source: quay.io/calico/kube-controllers:v3.29.3
-  target: registry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.29.3
-  type: image
-- source: quay.io/calico/kube-controllers:v3.30.0
-  target: registry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.30.0
-  type: image
-- source: quay.io/calico/kube-controllers:v3.30.1
-  target: registry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.30.1
-  type: image
-- source: quay.io/calico/kube-controllers:v3.30.2
-  target: registry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.30.2
-  type: image
-- source: quay.io/calico/kube-controllers:v3.30.3
-  target: registry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.30.3
-  type: image
-- source: quay.io/calico/kube-controllers:v3.13.4
   target: stgregistry.suse.com/rancher/mirrored-calico-kube-controllers:v3.13.4
   type: image
 - source: quay.io/calico/kube-controllers:v3.16.5
@@ -20041,135 +12124,6 @@ sync:
 - source: quay.io/calico/kube-controllers:v3.30.3
   target: stgregistry.suse.com/rancher/mirrored-calico-kube-controllers:v3.30.3
   type: image
-- source: quay.io/calico/kube-controllers:v3.13.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.13.4
-  type: image
-- source: quay.io/calico/kube-controllers:v3.16.5
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.16.5
-  type: image
-- source: quay.io/calico/kube-controllers:v3.17.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.17.2
-  type: image
-- source: quay.io/calico/kube-controllers:v3.18.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.18.1
-  type: image
-- source: quay.io/calico/kube-controllers:v3.19.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.19.0
-  type: image
-- source: quay.io/calico/kube-controllers:v3.19.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.19.1
-  type: image
-- source: quay.io/calico/kube-controllers:v3.19.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.19.2
-  type: image
-- source: quay.io/calico/kube-controllers:v3.20.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.20.1
-  type: image
-- source: quay.io/calico/kube-controllers:v3.20.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.20.2
-  type: image
-- source: quay.io/calico/kube-controllers:v3.21.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.21.1
-  type: image
-- source: quay.io/calico/kube-controllers:v3.21.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.21.2
-  type: image
-- source: quay.io/calico/kube-controllers:v3.21.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.21.4
-  type: image
-- source: quay.io/calico/kube-controllers:v3.21.5
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.21.5
-  type: image
-- source: quay.io/calico/kube-controllers:v3.22.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.22.0
-  type: image
-- source: quay.io/calico/kube-controllers:v3.22.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.22.1
-  type: image
-- source: quay.io/calico/kube-controllers:v3.22.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.22.2
-  type: image
-- source: quay.io/calico/kube-controllers:v3.22.5
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.22.5
-  type: image
-- source: quay.io/calico/kube-controllers:v3.23.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.23.0
-  type: image
-- source: quay.io/calico/kube-controllers:v3.23.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.23.1
-  type: image
-- source: quay.io/calico/kube-controllers:v3.23.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.23.3
-  type: image
-- source: quay.io/calico/kube-controllers:v3.24.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.24.1
-  type: image
-- source: quay.io/calico/kube-controllers:v3.24.5
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.24.5
-  type: image
-- source: quay.io/calico/kube-controllers:v3.25.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.25.0
-  type: image
-- source: quay.io/calico/kube-controllers:v3.25.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.25.2
-  type: image
-- source: quay.io/calico/kube-controllers:v3.26.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.26.1
-  type: image
-- source: quay.io/calico/kube-controllers:v3.26.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.26.2
-  type: image
-- source: quay.io/calico/kube-controllers:v3.26.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.26.3
-  type: image
-- source: quay.io/calico/kube-controllers:v3.26.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.26.4
-  type: image
-- source: quay.io/calico/kube-controllers:v3.27.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.27.0
-  type: image
-- source: quay.io/calico/kube-controllers:v3.27.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.27.2
-  type: image
-- source: quay.io/calico/kube-controllers:v3.27.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.27.3
-  type: image
-- source: quay.io/calico/kube-controllers:v3.27.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.27.4
-  type: image
-- source: quay.io/calico/kube-controllers:v3.28.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.28.0
-  type: image
-- source: quay.io/calico/kube-controllers:v3.28.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.28.1
-  type: image
-- source: quay.io/calico/kube-controllers:v3.28.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.28.2
-  type: image
-- source: quay.io/calico/kube-controllers:v3.29.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.29.0
-  type: image
-- source: quay.io/calico/kube-controllers:v3.29.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.29.1
-  type: image
-- source: quay.io/calico/kube-controllers:v3.29.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.29.2
-  type: image
-- source: quay.io/calico/kube-controllers:v3.29.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.29.3
-  type: image
-- source: quay.io/calico/kube-controllers:v3.30.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.30.0
-  type: image
-- source: quay.io/calico/kube-controllers:v3.30.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.30.1
-  type: image
-- source: quay.io/calico/kube-controllers:v3.30.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.30.2
-  type: image
-- source: quay.io/calico/kube-controllers:v3.30.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-kube-controllers:v3.30.3
-  type: image
 - source: quay.io/calico/node:v3.16.5
   target: docker.io/rancher/calico-node:v3.16.5
   type: image
@@ -20201,21 +12155,6 @@ sync:
   target: registry.suse.com/rancher/calico-node:v3.18.1
   type: image
 - source: quay.io/calico/node:v3.16.5
-  target: registry.suse.com/rancher/charts/calico-node:v3.16.5
-  type: image
-- source: quay.io/calico/node:v3.16.6
-  target: registry.suse.com/rancher/charts/calico-node:v3.16.6
-  type: image
-- source: quay.io/calico/node:v3.17.1
-  target: registry.suse.com/rancher/charts/calico-node:v3.17.1
-  type: image
-- source: quay.io/calico/node:v3.17.2
-  target: registry.suse.com/rancher/charts/calico-node:v3.17.2
-  type: image
-- source: quay.io/calico/node:v3.18.1
-  target: registry.suse.com/rancher/charts/calico-node:v3.18.1
-  type: image
-- source: quay.io/calico/node:v3.16.5
   target: stgregistry.suse.com/rancher/calico-node:v3.16.5
   type: image
 - source: quay.io/calico/node:v3.16.6
@@ -20229,21 +12168,6 @@ sync:
   type: image
 - source: quay.io/calico/node:v3.18.1
   target: stgregistry.suse.com/rancher/calico-node:v3.18.1
-  type: image
-- source: quay.io/calico/node:v3.16.5
-  target: stgregistry.suse.com/rancher/charts/calico-node:v3.16.5
-  type: image
-- source: quay.io/calico/node:v3.16.6
-  target: stgregistry.suse.com/rancher/charts/calico-node:v3.16.6
-  type: image
-- source: quay.io/calico/node:v3.17.1
-  target: stgregistry.suse.com/rancher/charts/calico-node:v3.17.1
-  type: image
-- source: quay.io/calico/node:v3.17.2
-  target: stgregistry.suse.com/rancher/charts/calico-node:v3.17.2
-  type: image
-- source: quay.io/calico/node:v3.18.1
-  target: stgregistry.suse.com/rancher/charts/calico-node:v3.18.1
   type: image
 - source: quay.io/calico/node:v3.13.4
   target: docker.io/rancher/mirrored-calico-node:v3.13.4
@@ -20504,135 +12428,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-calico-node:v3.30.3
   type: image
 - source: quay.io/calico/node:v3.13.4
-  target: registry.suse.com/rancher/charts/mirrored-calico-node:v3.13.4
-  type: image
-- source: quay.io/calico/node:v3.16.5
-  target: registry.suse.com/rancher/charts/mirrored-calico-node:v3.16.5
-  type: image
-- source: quay.io/calico/node:v3.17.2
-  target: registry.suse.com/rancher/charts/mirrored-calico-node:v3.17.2
-  type: image
-- source: quay.io/calico/node:v3.18.1
-  target: registry.suse.com/rancher/charts/mirrored-calico-node:v3.18.1
-  type: image
-- source: quay.io/calico/node:v3.19.0
-  target: registry.suse.com/rancher/charts/mirrored-calico-node:v3.19.0
-  type: image
-- source: quay.io/calico/node:v3.19.1
-  target: registry.suse.com/rancher/charts/mirrored-calico-node:v3.19.1
-  type: image
-- source: quay.io/calico/node:v3.19.2
-  target: registry.suse.com/rancher/charts/mirrored-calico-node:v3.19.2
-  type: image
-- source: quay.io/calico/node:v3.20.1
-  target: registry.suse.com/rancher/charts/mirrored-calico-node:v3.20.1
-  type: image
-- source: quay.io/calico/node:v3.20.2
-  target: registry.suse.com/rancher/charts/mirrored-calico-node:v3.20.2
-  type: image
-- source: quay.io/calico/node:v3.21.1
-  target: registry.suse.com/rancher/charts/mirrored-calico-node:v3.21.1
-  type: image
-- source: quay.io/calico/node:v3.21.2
-  target: registry.suse.com/rancher/charts/mirrored-calico-node:v3.21.2
-  type: image
-- source: quay.io/calico/node:v3.21.4
-  target: registry.suse.com/rancher/charts/mirrored-calico-node:v3.21.4
-  type: image
-- source: quay.io/calico/node:v3.21.5
-  target: registry.suse.com/rancher/charts/mirrored-calico-node:v3.21.5
-  type: image
-- source: quay.io/calico/node:v3.22.0
-  target: registry.suse.com/rancher/charts/mirrored-calico-node:v3.22.0
-  type: image
-- source: quay.io/calico/node:v3.22.1
-  target: registry.suse.com/rancher/charts/mirrored-calico-node:v3.22.1
-  type: image
-- source: quay.io/calico/node:v3.22.2
-  target: registry.suse.com/rancher/charts/mirrored-calico-node:v3.22.2
-  type: image
-- source: quay.io/calico/node:v3.22.5
-  target: registry.suse.com/rancher/charts/mirrored-calico-node:v3.22.5
-  type: image
-- source: quay.io/calico/node:v3.23.0
-  target: registry.suse.com/rancher/charts/mirrored-calico-node:v3.23.0
-  type: image
-- source: quay.io/calico/node:v3.23.1
-  target: registry.suse.com/rancher/charts/mirrored-calico-node:v3.23.1
-  type: image
-- source: quay.io/calico/node:v3.23.3
-  target: registry.suse.com/rancher/charts/mirrored-calico-node:v3.23.3
-  type: image
-- source: quay.io/calico/node:v3.24.1
-  target: registry.suse.com/rancher/charts/mirrored-calico-node:v3.24.1
-  type: image
-- source: quay.io/calico/node:v3.24.5
-  target: registry.suse.com/rancher/charts/mirrored-calico-node:v3.24.5
-  type: image
-- source: quay.io/calico/node:v3.25.0
-  target: registry.suse.com/rancher/charts/mirrored-calico-node:v3.25.0
-  type: image
-- source: quay.io/calico/node:v3.25.2
-  target: registry.suse.com/rancher/charts/mirrored-calico-node:v3.25.2
-  type: image
-- source: quay.io/calico/node:v3.26.1
-  target: registry.suse.com/rancher/charts/mirrored-calico-node:v3.26.1
-  type: image
-- source: quay.io/calico/node:v3.26.2
-  target: registry.suse.com/rancher/charts/mirrored-calico-node:v3.26.2
-  type: image
-- source: quay.io/calico/node:v3.26.3
-  target: registry.suse.com/rancher/charts/mirrored-calico-node:v3.26.3
-  type: image
-- source: quay.io/calico/node:v3.26.4
-  target: registry.suse.com/rancher/charts/mirrored-calico-node:v3.26.4
-  type: image
-- source: quay.io/calico/node:v3.27.0
-  target: registry.suse.com/rancher/charts/mirrored-calico-node:v3.27.0
-  type: image
-- source: quay.io/calico/node:v3.27.2
-  target: registry.suse.com/rancher/charts/mirrored-calico-node:v3.27.2
-  type: image
-- source: quay.io/calico/node:v3.27.3
-  target: registry.suse.com/rancher/charts/mirrored-calico-node:v3.27.3
-  type: image
-- source: quay.io/calico/node:v3.27.4
-  target: registry.suse.com/rancher/charts/mirrored-calico-node:v3.27.4
-  type: image
-- source: quay.io/calico/node:v3.28.0
-  target: registry.suse.com/rancher/charts/mirrored-calico-node:v3.28.0
-  type: image
-- source: quay.io/calico/node:v3.28.1
-  target: registry.suse.com/rancher/charts/mirrored-calico-node:v3.28.1
-  type: image
-- source: quay.io/calico/node:v3.28.2
-  target: registry.suse.com/rancher/charts/mirrored-calico-node:v3.28.2
-  type: image
-- source: quay.io/calico/node:v3.29.0
-  target: registry.suse.com/rancher/charts/mirrored-calico-node:v3.29.0
-  type: image
-- source: quay.io/calico/node:v3.29.1
-  target: registry.suse.com/rancher/charts/mirrored-calico-node:v3.29.1
-  type: image
-- source: quay.io/calico/node:v3.29.2
-  target: registry.suse.com/rancher/charts/mirrored-calico-node:v3.29.2
-  type: image
-- source: quay.io/calico/node:v3.29.3
-  target: registry.suse.com/rancher/charts/mirrored-calico-node:v3.29.3
-  type: image
-- source: quay.io/calico/node:v3.30.0
-  target: registry.suse.com/rancher/charts/mirrored-calico-node:v3.30.0
-  type: image
-- source: quay.io/calico/node:v3.30.1
-  target: registry.suse.com/rancher/charts/mirrored-calico-node:v3.30.1
-  type: image
-- source: quay.io/calico/node:v3.30.2
-  target: registry.suse.com/rancher/charts/mirrored-calico-node:v3.30.2
-  type: image
-- source: quay.io/calico/node:v3.30.3
-  target: registry.suse.com/rancher/charts/mirrored-calico-node:v3.30.3
-  type: image
-- source: quay.io/calico/node:v3.13.4
   target: stgregistry.suse.com/rancher/mirrored-calico-node:v3.13.4
   type: image
 - source: quay.io/calico/node:v3.16.5
@@ -20761,135 +12556,6 @@ sync:
 - source: quay.io/calico/node:v3.30.3
   target: stgregistry.suse.com/rancher/mirrored-calico-node:v3.30.3
   type: image
-- source: quay.io/calico/node:v3.13.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-node:v3.13.4
-  type: image
-- source: quay.io/calico/node:v3.16.5
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-node:v3.16.5
-  type: image
-- source: quay.io/calico/node:v3.17.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-node:v3.17.2
-  type: image
-- source: quay.io/calico/node:v3.18.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-node:v3.18.1
-  type: image
-- source: quay.io/calico/node:v3.19.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-node:v3.19.0
-  type: image
-- source: quay.io/calico/node:v3.19.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-node:v3.19.1
-  type: image
-- source: quay.io/calico/node:v3.19.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-node:v3.19.2
-  type: image
-- source: quay.io/calico/node:v3.20.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-node:v3.20.1
-  type: image
-- source: quay.io/calico/node:v3.20.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-node:v3.20.2
-  type: image
-- source: quay.io/calico/node:v3.21.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-node:v3.21.1
-  type: image
-- source: quay.io/calico/node:v3.21.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-node:v3.21.2
-  type: image
-- source: quay.io/calico/node:v3.21.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-node:v3.21.4
-  type: image
-- source: quay.io/calico/node:v3.21.5
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-node:v3.21.5
-  type: image
-- source: quay.io/calico/node:v3.22.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-node:v3.22.0
-  type: image
-- source: quay.io/calico/node:v3.22.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-node:v3.22.1
-  type: image
-- source: quay.io/calico/node:v3.22.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-node:v3.22.2
-  type: image
-- source: quay.io/calico/node:v3.22.5
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-node:v3.22.5
-  type: image
-- source: quay.io/calico/node:v3.23.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-node:v3.23.0
-  type: image
-- source: quay.io/calico/node:v3.23.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-node:v3.23.1
-  type: image
-- source: quay.io/calico/node:v3.23.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-node:v3.23.3
-  type: image
-- source: quay.io/calico/node:v3.24.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-node:v3.24.1
-  type: image
-- source: quay.io/calico/node:v3.24.5
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-node:v3.24.5
-  type: image
-- source: quay.io/calico/node:v3.25.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-node:v3.25.0
-  type: image
-- source: quay.io/calico/node:v3.25.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-node:v3.25.2
-  type: image
-- source: quay.io/calico/node:v3.26.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-node:v3.26.1
-  type: image
-- source: quay.io/calico/node:v3.26.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-node:v3.26.2
-  type: image
-- source: quay.io/calico/node:v3.26.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-node:v3.26.3
-  type: image
-- source: quay.io/calico/node:v3.26.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-node:v3.26.4
-  type: image
-- source: quay.io/calico/node:v3.27.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-node:v3.27.0
-  type: image
-- source: quay.io/calico/node:v3.27.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-node:v3.27.2
-  type: image
-- source: quay.io/calico/node:v3.27.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-node:v3.27.3
-  type: image
-- source: quay.io/calico/node:v3.27.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-node:v3.27.4
-  type: image
-- source: quay.io/calico/node:v3.28.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-node:v3.28.0
-  type: image
-- source: quay.io/calico/node:v3.28.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-node:v3.28.1
-  type: image
-- source: quay.io/calico/node:v3.28.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-node:v3.28.2
-  type: image
-- source: quay.io/calico/node:v3.29.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-node:v3.29.0
-  type: image
-- source: quay.io/calico/node:v3.29.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-node:v3.29.1
-  type: image
-- source: quay.io/calico/node:v3.29.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-node:v3.29.2
-  type: image
-- source: quay.io/calico/node:v3.29.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-node:v3.29.3
-  type: image
-- source: quay.io/calico/node:v3.30.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-node:v3.30.0
-  type: image
-- source: quay.io/calico/node:v3.30.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-node:v3.30.1
-  type: image
-- source: quay.io/calico/node:v3.30.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-node:v3.30.2
-  type: image
-- source: quay.io/calico/node:v3.30.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-node:v3.30.3
-  type: image
 - source: quay.io/calico/node-driver-registrar:v3.27.0
   target: docker.io/rancher/mirrored-calico-node-driver-registrar:v3.27.0
   type: image
@@ -20981,51 +12647,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-calico-node-driver-registrar:v3.30.3
   type: image
 - source: quay.io/calico/node-driver-registrar:v3.27.0
-  target: registry.suse.com/rancher/charts/mirrored-calico-node-driver-registrar:v3.27.0
-  type: image
-- source: quay.io/calico/node-driver-registrar:v3.27.2
-  target: registry.suse.com/rancher/charts/mirrored-calico-node-driver-registrar:v3.27.2
-  type: image
-- source: quay.io/calico/node-driver-registrar:v3.27.3
-  target: registry.suse.com/rancher/charts/mirrored-calico-node-driver-registrar:v3.27.3
-  type: image
-- source: quay.io/calico/node-driver-registrar:v3.27.4
-  target: registry.suse.com/rancher/charts/mirrored-calico-node-driver-registrar:v3.27.4
-  type: image
-- source: quay.io/calico/node-driver-registrar:v3.28.0
-  target: registry.suse.com/rancher/charts/mirrored-calico-node-driver-registrar:v3.28.0
-  type: image
-- source: quay.io/calico/node-driver-registrar:v3.28.1
-  target: registry.suse.com/rancher/charts/mirrored-calico-node-driver-registrar:v3.28.1
-  type: image
-- source: quay.io/calico/node-driver-registrar:v3.28.2
-  target: registry.suse.com/rancher/charts/mirrored-calico-node-driver-registrar:v3.28.2
-  type: image
-- source: quay.io/calico/node-driver-registrar:v3.29.0
-  target: registry.suse.com/rancher/charts/mirrored-calico-node-driver-registrar:v3.29.0
-  type: image
-- source: quay.io/calico/node-driver-registrar:v3.29.1
-  target: registry.suse.com/rancher/charts/mirrored-calico-node-driver-registrar:v3.29.1
-  type: image
-- source: quay.io/calico/node-driver-registrar:v3.29.2
-  target: registry.suse.com/rancher/charts/mirrored-calico-node-driver-registrar:v3.29.2
-  type: image
-- source: quay.io/calico/node-driver-registrar:v3.29.3
-  target: registry.suse.com/rancher/charts/mirrored-calico-node-driver-registrar:v3.29.3
-  type: image
-- source: quay.io/calico/node-driver-registrar:v3.30.0
-  target: registry.suse.com/rancher/charts/mirrored-calico-node-driver-registrar:v3.30.0
-  type: image
-- source: quay.io/calico/node-driver-registrar:v3.30.1
-  target: registry.suse.com/rancher/charts/mirrored-calico-node-driver-registrar:v3.30.1
-  type: image
-- source: quay.io/calico/node-driver-registrar:v3.30.2
-  target: registry.suse.com/rancher/charts/mirrored-calico-node-driver-registrar:v3.30.2
-  type: image
-- source: quay.io/calico/node-driver-registrar:v3.30.3
-  target: registry.suse.com/rancher/charts/mirrored-calico-node-driver-registrar:v3.30.3
-  type: image
-- source: quay.io/calico/node-driver-registrar:v3.27.0
   target: stgregistry.suse.com/rancher/mirrored-calico-node-driver-registrar:v3.27.0
   type: image
 - source: quay.io/calico/node-driver-registrar:v3.27.2
@@ -21070,51 +12691,6 @@ sync:
 - source: quay.io/calico/node-driver-registrar:v3.30.3
   target: stgregistry.suse.com/rancher/mirrored-calico-node-driver-registrar:v3.30.3
   type: image
-- source: quay.io/calico/node-driver-registrar:v3.27.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-node-driver-registrar:v3.27.0
-  type: image
-- source: quay.io/calico/node-driver-registrar:v3.27.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-node-driver-registrar:v3.27.2
-  type: image
-- source: quay.io/calico/node-driver-registrar:v3.27.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-node-driver-registrar:v3.27.3
-  type: image
-- source: quay.io/calico/node-driver-registrar:v3.27.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-node-driver-registrar:v3.27.4
-  type: image
-- source: quay.io/calico/node-driver-registrar:v3.28.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-node-driver-registrar:v3.28.0
-  type: image
-- source: quay.io/calico/node-driver-registrar:v3.28.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-node-driver-registrar:v3.28.1
-  type: image
-- source: quay.io/calico/node-driver-registrar:v3.28.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-node-driver-registrar:v3.28.2
-  type: image
-- source: quay.io/calico/node-driver-registrar:v3.29.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-node-driver-registrar:v3.29.0
-  type: image
-- source: quay.io/calico/node-driver-registrar:v3.29.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-node-driver-registrar:v3.29.1
-  type: image
-- source: quay.io/calico/node-driver-registrar:v3.29.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-node-driver-registrar:v3.29.2
-  type: image
-- source: quay.io/calico/node-driver-registrar:v3.29.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-node-driver-registrar:v3.29.3
-  type: image
-- source: quay.io/calico/node-driver-registrar:v3.30.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-node-driver-registrar:v3.30.0
-  type: image
-- source: quay.io/calico/node-driver-registrar:v3.30.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-node-driver-registrar:v3.30.1
-  type: image
-- source: quay.io/calico/node-driver-registrar:v3.30.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-node-driver-registrar:v3.30.2
-  type: image
-- source: quay.io/calico/node-driver-registrar:v3.30.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-node-driver-registrar:v3.30.3
-  type: image
 - source: quay.io/calico/pod2daemon-flexvol:v3.16.5
   target: docker.io/rancher/calico-pod2daemon-flexvol:v3.16.5
   type: image
@@ -21146,21 +12722,6 @@ sync:
   target: registry.suse.com/rancher/calico-pod2daemon-flexvol:v3.18.1
   type: image
 - source: quay.io/calico/pod2daemon-flexvol:v3.16.5
-  target: registry.suse.com/rancher/charts/calico-pod2daemon-flexvol:v3.16.5
-  type: image
-- source: quay.io/calico/pod2daemon-flexvol:v3.16.6
-  target: registry.suse.com/rancher/charts/calico-pod2daemon-flexvol:v3.16.6
-  type: image
-- source: quay.io/calico/pod2daemon-flexvol:v3.17.1
-  target: registry.suse.com/rancher/charts/calico-pod2daemon-flexvol:v3.17.1
-  type: image
-- source: quay.io/calico/pod2daemon-flexvol:v3.17.2
-  target: registry.suse.com/rancher/charts/calico-pod2daemon-flexvol:v3.17.2
-  type: image
-- source: quay.io/calico/pod2daemon-flexvol:v3.18.1
-  target: registry.suse.com/rancher/charts/calico-pod2daemon-flexvol:v3.18.1
-  type: image
-- source: quay.io/calico/pod2daemon-flexvol:v3.16.5
   target: stgregistry.suse.com/rancher/calico-pod2daemon-flexvol:v3.16.5
   type: image
 - source: quay.io/calico/pod2daemon-flexvol:v3.16.6
@@ -21174,21 +12735,6 @@ sync:
   type: image
 - source: quay.io/calico/pod2daemon-flexvol:v3.18.1
   target: stgregistry.suse.com/rancher/calico-pod2daemon-flexvol:v3.18.1
-  type: image
-- source: quay.io/calico/pod2daemon-flexvol:v3.16.5
-  target: stgregistry.suse.com/rancher/charts/calico-pod2daemon-flexvol:v3.16.5
-  type: image
-- source: quay.io/calico/pod2daemon-flexvol:v3.16.6
-  target: stgregistry.suse.com/rancher/charts/calico-pod2daemon-flexvol:v3.16.6
-  type: image
-- source: quay.io/calico/pod2daemon-flexvol:v3.17.1
-  target: stgregistry.suse.com/rancher/charts/calico-pod2daemon-flexvol:v3.17.1
-  type: image
-- source: quay.io/calico/pod2daemon-flexvol:v3.17.2
-  target: stgregistry.suse.com/rancher/charts/calico-pod2daemon-flexvol:v3.17.2
-  type: image
-- source: quay.io/calico/pod2daemon-flexvol:v3.18.1
-  target: stgregistry.suse.com/rancher/charts/calico-pod2daemon-flexvol:v3.18.1
   type: image
 - source: quay.io/calico/pod2daemon-flexvol:v3.13.4
   target: docker.io/rancher/mirrored-calico-pod2daemon-flexvol:v3.13.4
@@ -21449,135 +12995,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-calico-pod2daemon-flexvol:v3.30.3
   type: image
 - source: quay.io/calico/pod2daemon-flexvol:v3.13.4
-  target: registry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.13.4
-  type: image
-- source: quay.io/calico/pod2daemon-flexvol:v3.16.5
-  target: registry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.16.5
-  type: image
-- source: quay.io/calico/pod2daemon-flexvol:v3.17.2
-  target: registry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.17.2
-  type: image
-- source: quay.io/calico/pod2daemon-flexvol:v3.18.1
-  target: registry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.18.1
-  type: image
-- source: quay.io/calico/pod2daemon-flexvol:v3.19.0
-  target: registry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.19.0
-  type: image
-- source: quay.io/calico/pod2daemon-flexvol:v3.19.1
-  target: registry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.19.1
-  type: image
-- source: quay.io/calico/pod2daemon-flexvol:v3.19.2
-  target: registry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.19.2
-  type: image
-- source: quay.io/calico/pod2daemon-flexvol:v3.20.1
-  target: registry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.20.1
-  type: image
-- source: quay.io/calico/pod2daemon-flexvol:v3.20.2
-  target: registry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.20.2
-  type: image
-- source: quay.io/calico/pod2daemon-flexvol:v3.21.1
-  target: registry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.21.1
-  type: image
-- source: quay.io/calico/pod2daemon-flexvol:v3.21.2
-  target: registry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.21.2
-  type: image
-- source: quay.io/calico/pod2daemon-flexvol:v3.21.4
-  target: registry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.21.4
-  type: image
-- source: quay.io/calico/pod2daemon-flexvol:v3.21.5
-  target: registry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.21.5
-  type: image
-- source: quay.io/calico/pod2daemon-flexvol:v3.22.0
-  target: registry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.22.0
-  type: image
-- source: quay.io/calico/pod2daemon-flexvol:v3.22.1
-  target: registry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.22.1
-  type: image
-- source: quay.io/calico/pod2daemon-flexvol:v3.22.2
-  target: registry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.22.2
-  type: image
-- source: quay.io/calico/pod2daemon-flexvol:v3.22.5
-  target: registry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.22.5
-  type: image
-- source: quay.io/calico/pod2daemon-flexvol:v3.23.0
-  target: registry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.23.0
-  type: image
-- source: quay.io/calico/pod2daemon-flexvol:v3.23.1
-  target: registry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.23.1
-  type: image
-- source: quay.io/calico/pod2daemon-flexvol:v3.23.3
-  target: registry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.23.3
-  type: image
-- source: quay.io/calico/pod2daemon-flexvol:v3.24.1
-  target: registry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.24.1
-  type: image
-- source: quay.io/calico/pod2daemon-flexvol:v3.24.5
-  target: registry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.24.5
-  type: image
-- source: quay.io/calico/pod2daemon-flexvol:v3.25.0
-  target: registry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.25.0
-  type: image
-- source: quay.io/calico/pod2daemon-flexvol:v3.25.2
-  target: registry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.25.2
-  type: image
-- source: quay.io/calico/pod2daemon-flexvol:v3.26.1
-  target: registry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.26.1
-  type: image
-- source: quay.io/calico/pod2daemon-flexvol:v3.26.2
-  target: registry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.26.2
-  type: image
-- source: quay.io/calico/pod2daemon-flexvol:v3.26.3
-  target: registry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.26.3
-  type: image
-- source: quay.io/calico/pod2daemon-flexvol:v3.26.4
-  target: registry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.26.4
-  type: image
-- source: quay.io/calico/pod2daemon-flexvol:v3.27.0
-  target: registry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.27.0
-  type: image
-- source: quay.io/calico/pod2daemon-flexvol:v3.27.2
-  target: registry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.27.2
-  type: image
-- source: quay.io/calico/pod2daemon-flexvol:v3.27.3
-  target: registry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.27.3
-  type: image
-- source: quay.io/calico/pod2daemon-flexvol:v3.27.4
-  target: registry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.27.4
-  type: image
-- source: quay.io/calico/pod2daemon-flexvol:v3.28.0
-  target: registry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.28.0
-  type: image
-- source: quay.io/calico/pod2daemon-flexvol:v3.28.1
-  target: registry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.28.1
-  type: image
-- source: quay.io/calico/pod2daemon-flexvol:v3.28.2
-  target: registry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.28.2
-  type: image
-- source: quay.io/calico/pod2daemon-flexvol:v3.29.0
-  target: registry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.29.0
-  type: image
-- source: quay.io/calico/pod2daemon-flexvol:v3.29.1
-  target: registry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.29.1
-  type: image
-- source: quay.io/calico/pod2daemon-flexvol:v3.29.2
-  target: registry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.29.2
-  type: image
-- source: quay.io/calico/pod2daemon-flexvol:v3.29.3
-  target: registry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.29.3
-  type: image
-- source: quay.io/calico/pod2daemon-flexvol:v3.30.0
-  target: registry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.30.0
-  type: image
-- source: quay.io/calico/pod2daemon-flexvol:v3.30.1
-  target: registry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.30.1
-  type: image
-- source: quay.io/calico/pod2daemon-flexvol:v3.30.2
-  target: registry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.30.2
-  type: image
-- source: quay.io/calico/pod2daemon-flexvol:v3.30.3
-  target: registry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.30.3
-  type: image
-- source: quay.io/calico/pod2daemon-flexvol:v3.13.4
   target: stgregistry.suse.com/rancher/mirrored-calico-pod2daemon-flexvol:v3.13.4
   type: image
 - source: quay.io/calico/pod2daemon-flexvol:v3.16.5
@@ -21705,135 +13122,6 @@ sync:
   type: image
 - source: quay.io/calico/pod2daemon-flexvol:v3.30.3
   target: stgregistry.suse.com/rancher/mirrored-calico-pod2daemon-flexvol:v3.30.3
-  type: image
-- source: quay.io/calico/pod2daemon-flexvol:v3.13.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.13.4
-  type: image
-- source: quay.io/calico/pod2daemon-flexvol:v3.16.5
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.16.5
-  type: image
-- source: quay.io/calico/pod2daemon-flexvol:v3.17.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.17.2
-  type: image
-- source: quay.io/calico/pod2daemon-flexvol:v3.18.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.18.1
-  type: image
-- source: quay.io/calico/pod2daemon-flexvol:v3.19.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.19.0
-  type: image
-- source: quay.io/calico/pod2daemon-flexvol:v3.19.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.19.1
-  type: image
-- source: quay.io/calico/pod2daemon-flexvol:v3.19.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.19.2
-  type: image
-- source: quay.io/calico/pod2daemon-flexvol:v3.20.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.20.1
-  type: image
-- source: quay.io/calico/pod2daemon-flexvol:v3.20.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.20.2
-  type: image
-- source: quay.io/calico/pod2daemon-flexvol:v3.21.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.21.1
-  type: image
-- source: quay.io/calico/pod2daemon-flexvol:v3.21.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.21.2
-  type: image
-- source: quay.io/calico/pod2daemon-flexvol:v3.21.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.21.4
-  type: image
-- source: quay.io/calico/pod2daemon-flexvol:v3.21.5
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.21.5
-  type: image
-- source: quay.io/calico/pod2daemon-flexvol:v3.22.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.22.0
-  type: image
-- source: quay.io/calico/pod2daemon-flexvol:v3.22.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.22.1
-  type: image
-- source: quay.io/calico/pod2daemon-flexvol:v3.22.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.22.2
-  type: image
-- source: quay.io/calico/pod2daemon-flexvol:v3.22.5
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.22.5
-  type: image
-- source: quay.io/calico/pod2daemon-flexvol:v3.23.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.23.0
-  type: image
-- source: quay.io/calico/pod2daemon-flexvol:v3.23.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.23.1
-  type: image
-- source: quay.io/calico/pod2daemon-flexvol:v3.23.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.23.3
-  type: image
-- source: quay.io/calico/pod2daemon-flexvol:v3.24.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.24.1
-  type: image
-- source: quay.io/calico/pod2daemon-flexvol:v3.24.5
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.24.5
-  type: image
-- source: quay.io/calico/pod2daemon-flexvol:v3.25.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.25.0
-  type: image
-- source: quay.io/calico/pod2daemon-flexvol:v3.25.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.25.2
-  type: image
-- source: quay.io/calico/pod2daemon-flexvol:v3.26.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.26.1
-  type: image
-- source: quay.io/calico/pod2daemon-flexvol:v3.26.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.26.2
-  type: image
-- source: quay.io/calico/pod2daemon-flexvol:v3.26.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.26.3
-  type: image
-- source: quay.io/calico/pod2daemon-flexvol:v3.26.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.26.4
-  type: image
-- source: quay.io/calico/pod2daemon-flexvol:v3.27.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.27.0
-  type: image
-- source: quay.io/calico/pod2daemon-flexvol:v3.27.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.27.2
-  type: image
-- source: quay.io/calico/pod2daemon-flexvol:v3.27.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.27.3
-  type: image
-- source: quay.io/calico/pod2daemon-flexvol:v3.27.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.27.4
-  type: image
-- source: quay.io/calico/pod2daemon-flexvol:v3.28.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.28.0
-  type: image
-- source: quay.io/calico/pod2daemon-flexvol:v3.28.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.28.1
-  type: image
-- source: quay.io/calico/pod2daemon-flexvol:v3.28.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.28.2
-  type: image
-- source: quay.io/calico/pod2daemon-flexvol:v3.29.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.29.0
-  type: image
-- source: quay.io/calico/pod2daemon-flexvol:v3.29.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.29.1
-  type: image
-- source: quay.io/calico/pod2daemon-flexvol:v3.29.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.29.2
-  type: image
-- source: quay.io/calico/pod2daemon-flexvol:v3.29.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.29.3
-  type: image
-- source: quay.io/calico/pod2daemon-flexvol:v3.30.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.30.0
-  type: image
-- source: quay.io/calico/pod2daemon-flexvol:v3.30.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.30.1
-  type: image
-- source: quay.io/calico/pod2daemon-flexvol:v3.30.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.30.2
-  type: image
-- source: quay.io/calico/pod2daemon-flexvol:v3.30.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-pod2daemon-flexvol:v3.30.3
   type: image
 - source: quay.io/calico/typha:v3.18.1
   target: docker.io/rancher/mirrored-calico-typha:v3.18.1
@@ -22070,123 +13358,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-calico-typha:v3.30.3
   type: image
 - source: quay.io/calico/typha:v3.18.1
-  target: registry.suse.com/rancher/charts/mirrored-calico-typha:v3.18.1
-  type: image
-- source: quay.io/calico/typha:v3.19.1
-  target: registry.suse.com/rancher/charts/mirrored-calico-typha:v3.19.1
-  type: image
-- source: quay.io/calico/typha:v3.19.2
-  target: registry.suse.com/rancher/charts/mirrored-calico-typha:v3.19.2
-  type: image
-- source: quay.io/calico/typha:v3.20.1
-  target: registry.suse.com/rancher/charts/mirrored-calico-typha:v3.20.1
-  type: image
-- source: quay.io/calico/typha:v3.20.2
-  target: registry.suse.com/rancher/charts/mirrored-calico-typha:v3.20.2
-  type: image
-- source: quay.io/calico/typha:v3.21.1
-  target: registry.suse.com/rancher/charts/mirrored-calico-typha:v3.21.1
-  type: image
-- source: quay.io/calico/typha:v3.21.2
-  target: registry.suse.com/rancher/charts/mirrored-calico-typha:v3.21.2
-  type: image
-- source: quay.io/calico/typha:v3.21.4
-  target: registry.suse.com/rancher/charts/mirrored-calico-typha:v3.21.4
-  type: image
-- source: quay.io/calico/typha:v3.21.5
-  target: registry.suse.com/rancher/charts/mirrored-calico-typha:v3.21.5
-  type: image
-- source: quay.io/calico/typha:v3.22.0
-  target: registry.suse.com/rancher/charts/mirrored-calico-typha:v3.22.0
-  type: image
-- source: quay.io/calico/typha:v3.22.1
-  target: registry.suse.com/rancher/charts/mirrored-calico-typha:v3.22.1
-  type: image
-- source: quay.io/calico/typha:v3.22.2
-  target: registry.suse.com/rancher/charts/mirrored-calico-typha:v3.22.2
-  type: image
-- source: quay.io/calico/typha:v3.22.5
-  target: registry.suse.com/rancher/charts/mirrored-calico-typha:v3.22.5
-  type: image
-- source: quay.io/calico/typha:v3.23.0
-  target: registry.suse.com/rancher/charts/mirrored-calico-typha:v3.23.0
-  type: image
-- source: quay.io/calico/typha:v3.23.1
-  target: registry.suse.com/rancher/charts/mirrored-calico-typha:v3.23.1
-  type: image
-- source: quay.io/calico/typha:v3.23.3
-  target: registry.suse.com/rancher/charts/mirrored-calico-typha:v3.23.3
-  type: image
-- source: quay.io/calico/typha:v3.24.1
-  target: registry.suse.com/rancher/charts/mirrored-calico-typha:v3.24.1
-  type: image
-- source: quay.io/calico/typha:v3.24.5
-  target: registry.suse.com/rancher/charts/mirrored-calico-typha:v3.24.5
-  type: image
-- source: quay.io/calico/typha:v3.25.0
-  target: registry.suse.com/rancher/charts/mirrored-calico-typha:v3.25.0
-  type: image
-- source: quay.io/calico/typha:v3.25.2
-  target: registry.suse.com/rancher/charts/mirrored-calico-typha:v3.25.2
-  type: image
-- source: quay.io/calico/typha:v3.26.1
-  target: registry.suse.com/rancher/charts/mirrored-calico-typha:v3.26.1
-  type: image
-- source: quay.io/calico/typha:v3.26.2
-  target: registry.suse.com/rancher/charts/mirrored-calico-typha:v3.26.2
-  type: image
-- source: quay.io/calico/typha:v3.26.3
-  target: registry.suse.com/rancher/charts/mirrored-calico-typha:v3.26.3
-  type: image
-- source: quay.io/calico/typha:v3.26.4
-  target: registry.suse.com/rancher/charts/mirrored-calico-typha:v3.26.4
-  type: image
-- source: quay.io/calico/typha:v3.27.0
-  target: registry.suse.com/rancher/charts/mirrored-calico-typha:v3.27.0
-  type: image
-- source: quay.io/calico/typha:v3.27.2
-  target: registry.suse.com/rancher/charts/mirrored-calico-typha:v3.27.2
-  type: image
-- source: quay.io/calico/typha:v3.27.3
-  target: registry.suse.com/rancher/charts/mirrored-calico-typha:v3.27.3
-  type: image
-- source: quay.io/calico/typha:v3.27.4
-  target: registry.suse.com/rancher/charts/mirrored-calico-typha:v3.27.4
-  type: image
-- source: quay.io/calico/typha:v3.28.0
-  target: registry.suse.com/rancher/charts/mirrored-calico-typha:v3.28.0
-  type: image
-- source: quay.io/calico/typha:v3.28.1
-  target: registry.suse.com/rancher/charts/mirrored-calico-typha:v3.28.1
-  type: image
-- source: quay.io/calico/typha:v3.28.2
-  target: registry.suse.com/rancher/charts/mirrored-calico-typha:v3.28.2
-  type: image
-- source: quay.io/calico/typha:v3.29.0
-  target: registry.suse.com/rancher/charts/mirrored-calico-typha:v3.29.0
-  type: image
-- source: quay.io/calico/typha:v3.29.1
-  target: registry.suse.com/rancher/charts/mirrored-calico-typha:v3.29.1
-  type: image
-- source: quay.io/calico/typha:v3.29.2
-  target: registry.suse.com/rancher/charts/mirrored-calico-typha:v3.29.2
-  type: image
-- source: quay.io/calico/typha:v3.29.3
-  target: registry.suse.com/rancher/charts/mirrored-calico-typha:v3.29.3
-  type: image
-- source: quay.io/calico/typha:v3.30.0
-  target: registry.suse.com/rancher/charts/mirrored-calico-typha:v3.30.0
-  type: image
-- source: quay.io/calico/typha:v3.30.1
-  target: registry.suse.com/rancher/charts/mirrored-calico-typha:v3.30.1
-  type: image
-- source: quay.io/calico/typha:v3.30.2
-  target: registry.suse.com/rancher/charts/mirrored-calico-typha:v3.30.2
-  type: image
-- source: quay.io/calico/typha:v3.30.3
-  target: registry.suse.com/rancher/charts/mirrored-calico-typha:v3.30.3
-  type: image
-- source: quay.io/calico/typha:v3.18.1
   target: stgregistry.suse.com/rancher/mirrored-calico-typha:v3.18.1
   type: image
 - source: quay.io/calico/typha:v3.19.1
@@ -22303,123 +13474,6 @@ sync:
 - source: quay.io/calico/typha:v3.30.3
   target: stgregistry.suse.com/rancher/mirrored-calico-typha:v3.30.3
   type: image
-- source: quay.io/calico/typha:v3.18.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-typha:v3.18.1
-  type: image
-- source: quay.io/calico/typha:v3.19.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-typha:v3.19.1
-  type: image
-- source: quay.io/calico/typha:v3.19.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-typha:v3.19.2
-  type: image
-- source: quay.io/calico/typha:v3.20.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-typha:v3.20.1
-  type: image
-- source: quay.io/calico/typha:v3.20.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-typha:v3.20.2
-  type: image
-- source: quay.io/calico/typha:v3.21.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-typha:v3.21.1
-  type: image
-- source: quay.io/calico/typha:v3.21.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-typha:v3.21.2
-  type: image
-- source: quay.io/calico/typha:v3.21.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-typha:v3.21.4
-  type: image
-- source: quay.io/calico/typha:v3.21.5
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-typha:v3.21.5
-  type: image
-- source: quay.io/calico/typha:v3.22.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-typha:v3.22.0
-  type: image
-- source: quay.io/calico/typha:v3.22.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-typha:v3.22.1
-  type: image
-- source: quay.io/calico/typha:v3.22.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-typha:v3.22.2
-  type: image
-- source: quay.io/calico/typha:v3.22.5
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-typha:v3.22.5
-  type: image
-- source: quay.io/calico/typha:v3.23.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-typha:v3.23.0
-  type: image
-- source: quay.io/calico/typha:v3.23.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-typha:v3.23.1
-  type: image
-- source: quay.io/calico/typha:v3.23.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-typha:v3.23.3
-  type: image
-- source: quay.io/calico/typha:v3.24.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-typha:v3.24.1
-  type: image
-- source: quay.io/calico/typha:v3.24.5
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-typha:v3.24.5
-  type: image
-- source: quay.io/calico/typha:v3.25.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-typha:v3.25.0
-  type: image
-- source: quay.io/calico/typha:v3.25.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-typha:v3.25.2
-  type: image
-- source: quay.io/calico/typha:v3.26.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-typha:v3.26.1
-  type: image
-- source: quay.io/calico/typha:v3.26.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-typha:v3.26.2
-  type: image
-- source: quay.io/calico/typha:v3.26.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-typha:v3.26.3
-  type: image
-- source: quay.io/calico/typha:v3.26.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-typha:v3.26.4
-  type: image
-- source: quay.io/calico/typha:v3.27.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-typha:v3.27.0
-  type: image
-- source: quay.io/calico/typha:v3.27.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-typha:v3.27.2
-  type: image
-- source: quay.io/calico/typha:v3.27.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-typha:v3.27.3
-  type: image
-- source: quay.io/calico/typha:v3.27.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-typha:v3.27.4
-  type: image
-- source: quay.io/calico/typha:v3.28.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-typha:v3.28.0
-  type: image
-- source: quay.io/calico/typha:v3.28.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-typha:v3.28.1
-  type: image
-- source: quay.io/calico/typha:v3.28.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-typha:v3.28.2
-  type: image
-- source: quay.io/calico/typha:v3.29.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-typha:v3.29.0
-  type: image
-- source: quay.io/calico/typha:v3.29.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-typha:v3.29.1
-  type: image
-- source: quay.io/calico/typha:v3.29.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-typha:v3.29.2
-  type: image
-- source: quay.io/calico/typha:v3.29.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-typha:v3.29.3
-  type: image
-- source: quay.io/calico/typha:v3.30.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-typha:v3.30.0
-  type: image
-- source: quay.io/calico/typha:v3.30.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-typha:v3.30.1
-  type: image
-- source: quay.io/calico/typha:v3.30.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-typha:v3.30.2
-  type: image
-- source: quay.io/calico/typha:v3.30.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-typha:v3.30.3
-  type: image
 - source: quay.io/calico/whisker:v3.30.0
   target: docker.io/rancher/mirrored-calico-whisker:v3.30.0
   type: image
@@ -22445,18 +13499,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-calico-whisker:v3.30.3
   type: image
 - source: quay.io/calico/whisker:v3.30.0
-  target: registry.suse.com/rancher/charts/mirrored-calico-whisker:v3.30.0
-  type: image
-- source: quay.io/calico/whisker:v3.30.1
-  target: registry.suse.com/rancher/charts/mirrored-calico-whisker:v3.30.1
-  type: image
-- source: quay.io/calico/whisker:v3.30.2
-  target: registry.suse.com/rancher/charts/mirrored-calico-whisker:v3.30.2
-  type: image
-- source: quay.io/calico/whisker:v3.30.3
-  target: registry.suse.com/rancher/charts/mirrored-calico-whisker:v3.30.3
-  type: image
-- source: quay.io/calico/whisker:v3.30.0
   target: stgregistry.suse.com/rancher/mirrored-calico-whisker:v3.30.0
   type: image
 - source: quay.io/calico/whisker:v3.30.1
@@ -22467,18 +13509,6 @@ sync:
   type: image
 - source: quay.io/calico/whisker:v3.30.3
   target: stgregistry.suse.com/rancher/mirrored-calico-whisker:v3.30.3
-  type: image
-- source: quay.io/calico/whisker:v3.30.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-whisker:v3.30.0
-  type: image
-- source: quay.io/calico/whisker:v3.30.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-whisker:v3.30.1
-  type: image
-- source: quay.io/calico/whisker:v3.30.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-whisker:v3.30.2
-  type: image
-- source: quay.io/calico/whisker:v3.30.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-whisker:v3.30.3
   type: image
 - source: quay.io/calico/whisker-backend:v3.30.0
   target: docker.io/rancher/mirrored-calico-whisker-backend:v3.30.0
@@ -22505,18 +13535,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-calico-whisker-backend:v3.30.3
   type: image
 - source: quay.io/calico/whisker-backend:v3.30.0
-  target: registry.suse.com/rancher/charts/mirrored-calico-whisker-backend:v3.30.0
-  type: image
-- source: quay.io/calico/whisker-backend:v3.30.1
-  target: registry.suse.com/rancher/charts/mirrored-calico-whisker-backend:v3.30.1
-  type: image
-- source: quay.io/calico/whisker-backend:v3.30.2
-  target: registry.suse.com/rancher/charts/mirrored-calico-whisker-backend:v3.30.2
-  type: image
-- source: quay.io/calico/whisker-backend:v3.30.3
-  target: registry.suse.com/rancher/charts/mirrored-calico-whisker-backend:v3.30.3
-  type: image
-- source: quay.io/calico/whisker-backend:v3.30.0
   target: stgregistry.suse.com/rancher/mirrored-calico-whisker-backend:v3.30.0
   type: image
 - source: quay.io/calico/whisker-backend:v3.30.1
@@ -22527,18 +13545,6 @@ sync:
   type: image
 - source: quay.io/calico/whisker-backend:v3.30.3
   target: stgregistry.suse.com/rancher/mirrored-calico-whisker-backend:v3.30.3
-  type: image
-- source: quay.io/calico/whisker-backend:v3.30.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-whisker-backend:v3.30.0
-  type: image
-- source: quay.io/calico/whisker-backend:v3.30.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-whisker-backend:v3.30.1
-  type: image
-- source: quay.io/calico/whisker-backend:v3.30.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-whisker-backend:v3.30.2
-  type: image
-- source: quay.io/calico/whisker-backend:v3.30.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-whisker-backend:v3.30.3
   type: image
 - source: quay.io/cilium/certgen:v0.1.11
   target: docker.io/rancher/mirrored-cilium-certgen:v0.1.11
@@ -22589,30 +13595,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-cilium-certgen:v0.2.4
   type: image
 - source: quay.io/cilium/certgen:v0.1.11
-  target: registry.suse.com/rancher/charts/mirrored-cilium-certgen:v0.1.11
-  type: image
-- source: quay.io/cilium/certgen:v0.1.12
-  target: registry.suse.com/rancher/charts/mirrored-cilium-certgen:v0.1.12
-  type: image
-- source: quay.io/cilium/certgen:v0.1.13
-  target: registry.suse.com/rancher/charts/mirrored-cilium-certgen:v0.1.13
-  type: image
-- source: quay.io/cilium/certgen:v0.1.8
-  target: registry.suse.com/rancher/charts/mirrored-cilium-certgen:v0.1.8
-  type: image
-- source: quay.io/cilium/certgen:v0.1.9
-  target: registry.suse.com/rancher/charts/mirrored-cilium-certgen:v0.1.9
-  type: image
-- source: quay.io/cilium/certgen:v0.2.0
-  target: registry.suse.com/rancher/charts/mirrored-cilium-certgen:v0.2.0
-  type: image
-- source: quay.io/cilium/certgen:v0.2.1
-  target: registry.suse.com/rancher/charts/mirrored-cilium-certgen:v0.2.1
-  type: image
-- source: quay.io/cilium/certgen:v0.2.4
-  target: registry.suse.com/rancher/charts/mirrored-cilium-certgen:v0.2.4
-  type: image
-- source: quay.io/cilium/certgen:v0.1.11
   target: stgregistry.suse.com/rancher/mirrored-cilium-certgen:v0.1.11
   type: image
 - source: quay.io/cilium/certgen:v0.1.12
@@ -22635,30 +13617,6 @@ sync:
   type: image
 - source: quay.io/cilium/certgen:v0.2.4
   target: stgregistry.suse.com/rancher/mirrored-cilium-certgen:v0.2.4
-  type: image
-- source: quay.io/cilium/certgen:v0.1.11
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-certgen:v0.1.11
-  type: image
-- source: quay.io/cilium/certgen:v0.1.12
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-certgen:v0.1.12
-  type: image
-- source: quay.io/cilium/certgen:v0.1.13
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-certgen:v0.1.13
-  type: image
-- source: quay.io/cilium/certgen:v0.1.8
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-certgen:v0.1.8
-  type: image
-- source: quay.io/cilium/certgen:v0.1.9
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-certgen:v0.1.9
-  type: image
-- source: quay.io/cilium/certgen:v0.2.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-certgen:v0.2.0
-  type: image
-- source: quay.io/cilium/certgen:v0.2.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-certgen:v0.2.1
-  type: image
-- source: quay.io/cilium/certgen:v0.2.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-certgen:v0.2.4
   type: image
 - source: quay.io/cilium/cilium:v1.10.4
   target: docker.io/rancher/mirrored-cilium-cilium:v1.10.4
@@ -22955,153 +13913,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-cilium-cilium:v1.9.8
   type: image
 - source: quay.io/cilium/cilium:v1.10.4
-  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.10.4
-  type: image
-- source: quay.io/cilium/cilium:v1.10.7
-  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.10.7
-  type: image
-- source: quay.io/cilium/cilium:v1.11.0
-  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.11.0
-  type: image
-- source: quay.io/cilium/cilium:v1.11.1
-  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.11.1
-  type: image
-- source: quay.io/cilium/cilium:v1.11.2
-  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.11.2
-  type: image
-- source: quay.io/cilium/cilium:v1.11.4
-  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.11.4
-  type: image
-- source: quay.io/cilium/cilium:v1.11.5
-  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.11.5
-  type: image
-- source: quay.io/cilium/cilium:v1.12.0
-  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.12.0
-  type: image
-- source: quay.io/cilium/cilium:v1.12.1
-  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.12.1
-  type: image
-- source: quay.io/cilium/cilium:v1.12.3
-  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.12.3
-  type: image
-- source: quay.io/cilium/cilium:v1.12.4
-  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.12.4
-  type: image
-- source: quay.io/cilium/cilium:v1.12.5
-  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.12.5
-  type: image
-- source: quay.io/cilium/cilium:v1.13.0
-  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.13.0
-  type: image
-- source: quay.io/cilium/cilium:v1.13.2
-  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.13.2
-  type: image
-- source: quay.io/cilium/cilium:v1.13.4
-  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.13.4
-  type: image
-- source: quay.io/cilium/cilium:v1.14.0
-  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.14.0
-  type: image
-- source: quay.io/cilium/cilium:v1.14.1
-  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.14.1
-  type: image
-- source: quay.io/cilium/cilium:v1.14.2
-  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.14.2
-  type: image
-- source: quay.io/cilium/cilium:v1.14.3
-  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.14.3
-  type: image
-- source: quay.io/cilium/cilium:v1.14.4
-  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.14.4
-  type: image
-- source: quay.io/cilium/cilium:v1.14.5
-  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.14.5
-  type: image
-- source: quay.io/cilium/cilium:v1.15.0
-  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.15.0
-  type: image
-- source: quay.io/cilium/cilium:v1.15.1
-  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.15.1
-  type: image
-- source: quay.io/cilium/cilium:v1.15.3
-  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.15.3
-  type: image
-- source: quay.io/cilium/cilium:v1.15.4
-  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.15.4
-  type: image
-- source: quay.io/cilium/cilium:v1.15.5
-  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.15.5
-  type: image
-- source: quay.io/cilium/cilium:v1.15.6
-  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.15.6
-  type: image
-- source: quay.io/cilium/cilium:v1.15.7
-  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.15.7
-  type: image
-- source: quay.io/cilium/cilium:v1.16.0
-  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.16.0
-  type: image
-- source: quay.io/cilium/cilium:v1.16.1
-  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.16.1
-  type: image
-- source: quay.io/cilium/cilium:v1.16.2
-  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.16.2
-  type: image
-- source: quay.io/cilium/cilium:v1.16.3
-  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.16.3
-  type: image
-- source: quay.io/cilium/cilium:v1.16.4
-  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.16.4
-  type: image
-- source: quay.io/cilium/cilium:v1.16.5
-  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.16.5
-  type: image
-- source: quay.io/cilium/cilium:v1.16.6
-  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.16.6
-  type: image
-- source: quay.io/cilium/cilium:v1.17.0
-  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.17.0
-  type: image
-- source: quay.io/cilium/cilium:v1.17.1
-  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.17.1
-  type: image
-- source: quay.io/cilium/cilium:v1.17.2
-  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.17.2
-  type: image
-- source: quay.io/cilium/cilium:v1.17.3
-  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.17.3
-  type: image
-- source: quay.io/cilium/cilium:v1.17.4
-  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.17.4
-  type: image
-- source: quay.io/cilium/cilium:v1.17.5
-  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.17.5
-  type: image
-- source: quay.io/cilium/cilium:v1.17.6
-  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.17.6
-  type: image
-- source: quay.io/cilium/cilium:v1.18.0
-  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.18.0
-  type: image
-- source: quay.io/cilium/cilium:v1.18.1
-  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.18.1
-  type: image
-- source: quay.io/cilium/cilium:v1.18.2
-  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.18.2
-  type: image
-- source: quay.io/cilium/cilium:v1.9.12
-  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.9.12
-  type: image
-- source: quay.io/cilium/cilium:v1.9.4
-  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.9.4
-  type: image
-- source: quay.io/cilium/cilium:v1.9.6
-  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.9.6
-  type: image
-- source: quay.io/cilium/cilium:v1.9.8
-  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.9.8
-  type: image
-- source: quay.io/cilium/cilium:v1.10.4
   target: stgregistry.suse.com/rancher/mirrored-cilium-cilium:v1.10.4
   type: image
 - source: quay.io/cilium/cilium:v1.10.7
@@ -23247,153 +14058,6 @@ sync:
   type: image
 - source: quay.io/cilium/cilium:v1.9.8
   target: stgregistry.suse.com/rancher/mirrored-cilium-cilium:v1.9.8
-  type: image
-- source: quay.io/cilium/cilium:v1.10.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.10.4
-  type: image
-- source: quay.io/cilium/cilium:v1.10.7
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.10.7
-  type: image
-- source: quay.io/cilium/cilium:v1.11.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.11.0
-  type: image
-- source: quay.io/cilium/cilium:v1.11.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.11.1
-  type: image
-- source: quay.io/cilium/cilium:v1.11.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.11.2
-  type: image
-- source: quay.io/cilium/cilium:v1.11.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.11.4
-  type: image
-- source: quay.io/cilium/cilium:v1.11.5
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.11.5
-  type: image
-- source: quay.io/cilium/cilium:v1.12.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.12.0
-  type: image
-- source: quay.io/cilium/cilium:v1.12.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.12.1
-  type: image
-- source: quay.io/cilium/cilium:v1.12.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.12.3
-  type: image
-- source: quay.io/cilium/cilium:v1.12.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.12.4
-  type: image
-- source: quay.io/cilium/cilium:v1.12.5
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.12.5
-  type: image
-- source: quay.io/cilium/cilium:v1.13.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.13.0
-  type: image
-- source: quay.io/cilium/cilium:v1.13.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.13.2
-  type: image
-- source: quay.io/cilium/cilium:v1.13.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.13.4
-  type: image
-- source: quay.io/cilium/cilium:v1.14.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.14.0
-  type: image
-- source: quay.io/cilium/cilium:v1.14.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.14.1
-  type: image
-- source: quay.io/cilium/cilium:v1.14.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.14.2
-  type: image
-- source: quay.io/cilium/cilium:v1.14.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.14.3
-  type: image
-- source: quay.io/cilium/cilium:v1.14.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.14.4
-  type: image
-- source: quay.io/cilium/cilium:v1.14.5
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.14.5
-  type: image
-- source: quay.io/cilium/cilium:v1.15.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.15.0
-  type: image
-- source: quay.io/cilium/cilium:v1.15.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.15.1
-  type: image
-- source: quay.io/cilium/cilium:v1.15.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.15.3
-  type: image
-- source: quay.io/cilium/cilium:v1.15.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.15.4
-  type: image
-- source: quay.io/cilium/cilium:v1.15.5
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.15.5
-  type: image
-- source: quay.io/cilium/cilium:v1.15.6
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.15.6
-  type: image
-- source: quay.io/cilium/cilium:v1.15.7
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.15.7
-  type: image
-- source: quay.io/cilium/cilium:v1.16.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.16.0
-  type: image
-- source: quay.io/cilium/cilium:v1.16.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.16.1
-  type: image
-- source: quay.io/cilium/cilium:v1.16.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.16.2
-  type: image
-- source: quay.io/cilium/cilium:v1.16.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.16.3
-  type: image
-- source: quay.io/cilium/cilium:v1.16.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.16.4
-  type: image
-- source: quay.io/cilium/cilium:v1.16.5
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.16.5
-  type: image
-- source: quay.io/cilium/cilium:v1.16.6
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.16.6
-  type: image
-- source: quay.io/cilium/cilium:v1.17.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.17.0
-  type: image
-- source: quay.io/cilium/cilium:v1.17.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.17.1
-  type: image
-- source: quay.io/cilium/cilium:v1.17.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.17.2
-  type: image
-- source: quay.io/cilium/cilium:v1.17.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.17.3
-  type: image
-- source: quay.io/cilium/cilium:v1.17.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.17.4
-  type: image
-- source: quay.io/cilium/cilium:v1.17.5
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.17.5
-  type: image
-- source: quay.io/cilium/cilium:v1.17.6
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.17.6
-  type: image
-- source: quay.io/cilium/cilium:v1.18.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.18.0
-  type: image
-- source: quay.io/cilium/cilium:v1.18.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.18.1
-  type: image
-- source: quay.io/cilium/cilium:v1.18.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.18.2
-  type: image
-- source: quay.io/cilium/cilium:v1.9.12
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.9.12
-  type: image
-- source: quay.io/cilium/cilium:v1.9.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.9.4
-  type: image
-- source: quay.io/cilium/cilium:v1.9.6
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.9.6
-  type: image
-- source: quay.io/cilium/cilium:v1.9.8
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium:v1.9.8
   type: image
 - source: quay.io/cilium/cilium-envoy:v1.25.10-f71a313bd0daee41470af31ce6ea20c750fe35dd
   target: docker.io/rancher/mirrored-cilium-cilium-envoy:v1.25.10-f71a313bd0daee41470af31ce6ea20c750fe35dd
@@ -23564,90 +14228,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-cilium-cilium-envoy:v1.34.7-1757592137-1a52bb680a956879722f48c591a2ca90f7791324
   type: image
 - source: quay.io/cilium/cilium-envoy:v1.25.10-f71a313bd0daee41470af31ce6ea20c750fe35dd
-  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium-envoy:v1.25.10-f71a313bd0daee41470af31ce6ea20c750fe35dd
-  type: image
-- source: quay.io/cilium/cilium-envoy:v1.25.9-e198a2824d309024cb91fb6a984445e73033291d
-  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium-envoy:v1.25.9-e198a2824d309024cb91fb6a984445e73033291d
-  type: image
-- source: quay.io/cilium/cilium-envoy:v1.25.9-f039e2bd380b7eef2f2feea5750676bb36133699
-  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium-envoy:v1.25.9-f039e2bd380b7eef2f2feea5750676bb36133699
-  type: image
-- source: quay.io/cilium/cilium-envoy:v1.26.4-c0f770db7b6accadd2c7171af9ad00370a7d8693
-  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium-envoy:v1.26.4-c0f770db7b6accadd2c7171af9ad00370a7d8693
-  type: image
-- source: quay.io/cilium/cilium-envoy:v1.26.6-ad82c7c56e88989992fd25d8d67747de865c823b
-  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium-envoy:v1.26.6-ad82c7c56e88989992fd25d8d67747de865c823b
-  type: image
-- source: quay.io/cilium/cilium-envoy:v1.26.6-ff0d5d3f77d610040e93c7c7a430d61a0c0b90c1
-  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium-envoy:v1.26.6-ff0d5d3f77d610040e93c7c7a430d61a0c0b90c1
-  type: image
-- source: quay.io/cilium/cilium-envoy:v1.27.2-13f6142b9c02268b10d547c8b093ef16724538e3
-  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium-envoy:v1.27.2-13f6142b9c02268b10d547c8b093ef16724538e3
-  type: image
-- source: quay.io/cilium/cilium-envoy:v1.27.3-713b673cccf1af661efd75ca20532336517ddcb9
-  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium-envoy:v1.27.3-713b673cccf1af661efd75ca20532336517ddcb9
-  type: image
-- source: quay.io/cilium/cilium-envoy:v1.27.3-99c1c8f42c8de70fc8f6dd594f4a425cd38b6688
-  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium-envoy:v1.27.3-99c1c8f42c8de70fc8f6dd594f4a425cd38b6688
-  type: image
-- source: quay.io/cilium/cilium-envoy:v1.27.4-21905253931655328edaacf3cd16aeda73bbea2f
-  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium-envoy:v1.27.4-21905253931655328edaacf3cd16aeda73bbea2f
-  type: image
-- source: quay.io/cilium/cilium-envoy:v1.28.3-31ec52ec5f2e4d28a8e19a0bfb872fa48cf7a515
-  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium-envoy:v1.28.3-31ec52ec5f2e4d28a8e19a0bfb872fa48cf7a515
-  type: image
-- source: quay.io/cilium/cilium-envoy:v1.28.4-b35188ffa1bbe54d1720d2e392779f7a48e58f6b
-  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium-envoy:v1.28.4-b35188ffa1bbe54d1720d2e392779f7a48e58f6b
-  type: image
-- source: quay.io/cilium/cilium-envoy:v1.29.7-39a2a56bbd5b3a591f69dbca51d3e30ef97e0e51
-  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium-envoy:v1.29.7-39a2a56bbd5b3a591f69dbca51d3e30ef97e0e51
-  type: image
-- source: quay.io/cilium/cilium-envoy:v1.29.9-1726784081-a90146d13b4cd7d168d573396ccf2b3db5a3b047
-  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium-envoy:v1.29.9-1726784081-a90146d13b4cd7d168d573396ccf2b3db5a3b047
-  type: image
-- source: quay.io/cilium/cilium-envoy:v1.29.9-1728346947-0d05e48bfbb8c4737ec40d5781d970a550ed2bbd
-  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium-envoy:v1.29.9-1728346947-0d05e48bfbb8c4737ec40d5781d970a550ed2bbd
-  type: image
-- source: quay.io/cilium/cilium-envoy:v1.30.7-1731393961-97edc2815e2c6a174d3d12e71731d54f5d32ea16
-  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium-envoy:v1.30.7-1731393961-97edc2815e2c6a174d3d12e71731d54f5d32ea16
-  type: image
-- source: quay.io/cilium/cilium-envoy:v1.30.8-1733837904-eaae5aca0fb988583e5617170a65ac5aa51c0aa8
-  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium-envoy:v1.30.8-1733837904-eaae5aca0fb988583e5617170a65ac5aa51c0aa8
-  type: image
-- source: quay.io/cilium/cilium-envoy:v1.30.9-1737073743-40a016d11c0d863b772961ed0168eea6fe6b10a5
-  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium-envoy:v1.30.9-1737073743-40a016d11c0d863b772961ed0168eea6fe6b10a5
-  type: image
-- source: quay.io/cilium/cilium-envoy:v1.31.5-1737535524-fe8efeb16a7d233bffd05af9ea53599340d3f18e
-  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium-envoy:v1.31.5-1737535524-fe8efeb16a7d233bffd05af9ea53599340d3f18e
-  type: image
-- source: quay.io/cilium/cilium-envoy:v1.31.5-1739264036-958bef243c6c66fcfd73ca319f2eb49fff1eb2ae
-  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium-envoy:v1.31.5-1739264036-958bef243c6c66fcfd73ca319f2eb49fff1eb2ae
-  type: image
-- source: quay.io/cilium/cilium-envoy:v1.31.5-1741765102-efed3defcc70ab5b263a0fc44c93d316b846a211
-  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium-envoy:v1.31.5-1741765102-efed3defcc70ab5b263a0fc44c93d316b846a211
-  type: image
-- source: quay.io/cilium/cilium-envoy:v1.32.5-1744305768-f9ddca7dcd91f7ca25a505560e655c47d3dec2cf
-  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium-envoy:v1.32.5-1744305768-f9ddca7dcd91f7ca25a505560e655c47d3dec2cf
-  type: image
-- source: quay.io/cilium/cilium-envoy:v1.32.6-1746661844-0f602c28cb2aa57b29078195049fb257d5b5246c
-  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium-envoy:v1.32.6-1746661844-0f602c28cb2aa57b29078195049fb257d5b5246c
-  type: image
-- source: quay.io/cilium/cilium-envoy:v1.32.6-1749271279-0864395884b263913eac200ee2048fd985f8e626
-  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium-envoy:v1.32.6-1749271279-0864395884b263913eac200ee2048fd985f8e626
-  type: image
-- source: quay.io/cilium/cilium-envoy:v1.33.4-1752151664-7c2edb0b44cf95f326d628b837fcdd845102ba68
-  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium-envoy:v1.33.4-1752151664-7c2edb0b44cf95f326d628b837fcdd845102ba68
-  type: image
-- source: quay.io/cilium/cilium-envoy:v1.34.4-1753677767-266d5a01d1d55bd1d60148f991b98dac0390d363
-  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium-envoy:v1.34.4-1753677767-266d5a01d1d55bd1d60148f991b98dac0390d363
-  type: image
-- source: quay.io/cilium/cilium-envoy:v1.34.4-1754895458-68cffdfa568b6b226d70a7ef81fc65dda3b890bf
-  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium-envoy:v1.34.4-1754895458-68cffdfa568b6b226d70a7ef81fc65dda3b890bf
-  type: image
-- source: quay.io/cilium/cilium-envoy:v1.34.7-1757592137-1a52bb680a956879722f48c591a2ca90f7791324
-  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium-envoy:v1.34.7-1757592137-1a52bb680a956879722f48c591a2ca90f7791324
-  type: image
-- source: quay.io/cilium/cilium-envoy:v1.25.10-f71a313bd0daee41470af31ce6ea20c750fe35dd
   target: stgregistry.suse.com/rancher/mirrored-cilium-cilium-envoy:v1.25.10-f71a313bd0daee41470af31ce6ea20c750fe35dd
   type: image
 - source: quay.io/cilium/cilium-envoy:v1.25.9-e198a2824d309024cb91fb6a984445e73033291d
@@ -23731,90 +14311,6 @@ sync:
 - source: quay.io/cilium/cilium-envoy:v1.34.7-1757592137-1a52bb680a956879722f48c591a2ca90f7791324
   target: stgregistry.suse.com/rancher/mirrored-cilium-cilium-envoy:v1.34.7-1757592137-1a52bb680a956879722f48c591a2ca90f7791324
   type: image
-- source: quay.io/cilium/cilium-envoy:v1.25.10-f71a313bd0daee41470af31ce6ea20c750fe35dd
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium-envoy:v1.25.10-f71a313bd0daee41470af31ce6ea20c750fe35dd
-  type: image
-- source: quay.io/cilium/cilium-envoy:v1.25.9-e198a2824d309024cb91fb6a984445e73033291d
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium-envoy:v1.25.9-e198a2824d309024cb91fb6a984445e73033291d
-  type: image
-- source: quay.io/cilium/cilium-envoy:v1.25.9-f039e2bd380b7eef2f2feea5750676bb36133699
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium-envoy:v1.25.9-f039e2bd380b7eef2f2feea5750676bb36133699
-  type: image
-- source: quay.io/cilium/cilium-envoy:v1.26.4-c0f770db7b6accadd2c7171af9ad00370a7d8693
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium-envoy:v1.26.4-c0f770db7b6accadd2c7171af9ad00370a7d8693
-  type: image
-- source: quay.io/cilium/cilium-envoy:v1.26.6-ad82c7c56e88989992fd25d8d67747de865c823b
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium-envoy:v1.26.6-ad82c7c56e88989992fd25d8d67747de865c823b
-  type: image
-- source: quay.io/cilium/cilium-envoy:v1.26.6-ff0d5d3f77d610040e93c7c7a430d61a0c0b90c1
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium-envoy:v1.26.6-ff0d5d3f77d610040e93c7c7a430d61a0c0b90c1
-  type: image
-- source: quay.io/cilium/cilium-envoy:v1.27.2-13f6142b9c02268b10d547c8b093ef16724538e3
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium-envoy:v1.27.2-13f6142b9c02268b10d547c8b093ef16724538e3
-  type: image
-- source: quay.io/cilium/cilium-envoy:v1.27.3-713b673cccf1af661efd75ca20532336517ddcb9
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium-envoy:v1.27.3-713b673cccf1af661efd75ca20532336517ddcb9
-  type: image
-- source: quay.io/cilium/cilium-envoy:v1.27.3-99c1c8f42c8de70fc8f6dd594f4a425cd38b6688
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium-envoy:v1.27.3-99c1c8f42c8de70fc8f6dd594f4a425cd38b6688
-  type: image
-- source: quay.io/cilium/cilium-envoy:v1.27.4-21905253931655328edaacf3cd16aeda73bbea2f
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium-envoy:v1.27.4-21905253931655328edaacf3cd16aeda73bbea2f
-  type: image
-- source: quay.io/cilium/cilium-envoy:v1.28.3-31ec52ec5f2e4d28a8e19a0bfb872fa48cf7a515
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium-envoy:v1.28.3-31ec52ec5f2e4d28a8e19a0bfb872fa48cf7a515
-  type: image
-- source: quay.io/cilium/cilium-envoy:v1.28.4-b35188ffa1bbe54d1720d2e392779f7a48e58f6b
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium-envoy:v1.28.4-b35188ffa1bbe54d1720d2e392779f7a48e58f6b
-  type: image
-- source: quay.io/cilium/cilium-envoy:v1.29.7-39a2a56bbd5b3a591f69dbca51d3e30ef97e0e51
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium-envoy:v1.29.7-39a2a56bbd5b3a591f69dbca51d3e30ef97e0e51
-  type: image
-- source: quay.io/cilium/cilium-envoy:v1.29.9-1726784081-a90146d13b4cd7d168d573396ccf2b3db5a3b047
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium-envoy:v1.29.9-1726784081-a90146d13b4cd7d168d573396ccf2b3db5a3b047
-  type: image
-- source: quay.io/cilium/cilium-envoy:v1.29.9-1728346947-0d05e48bfbb8c4737ec40d5781d970a550ed2bbd
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium-envoy:v1.29.9-1728346947-0d05e48bfbb8c4737ec40d5781d970a550ed2bbd
-  type: image
-- source: quay.io/cilium/cilium-envoy:v1.30.7-1731393961-97edc2815e2c6a174d3d12e71731d54f5d32ea16
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium-envoy:v1.30.7-1731393961-97edc2815e2c6a174d3d12e71731d54f5d32ea16
-  type: image
-- source: quay.io/cilium/cilium-envoy:v1.30.8-1733837904-eaae5aca0fb988583e5617170a65ac5aa51c0aa8
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium-envoy:v1.30.8-1733837904-eaae5aca0fb988583e5617170a65ac5aa51c0aa8
-  type: image
-- source: quay.io/cilium/cilium-envoy:v1.30.9-1737073743-40a016d11c0d863b772961ed0168eea6fe6b10a5
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium-envoy:v1.30.9-1737073743-40a016d11c0d863b772961ed0168eea6fe6b10a5
-  type: image
-- source: quay.io/cilium/cilium-envoy:v1.31.5-1737535524-fe8efeb16a7d233bffd05af9ea53599340d3f18e
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium-envoy:v1.31.5-1737535524-fe8efeb16a7d233bffd05af9ea53599340d3f18e
-  type: image
-- source: quay.io/cilium/cilium-envoy:v1.31.5-1739264036-958bef243c6c66fcfd73ca319f2eb49fff1eb2ae
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium-envoy:v1.31.5-1739264036-958bef243c6c66fcfd73ca319f2eb49fff1eb2ae
-  type: image
-- source: quay.io/cilium/cilium-envoy:v1.31.5-1741765102-efed3defcc70ab5b263a0fc44c93d316b846a211
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium-envoy:v1.31.5-1741765102-efed3defcc70ab5b263a0fc44c93d316b846a211
-  type: image
-- source: quay.io/cilium/cilium-envoy:v1.32.5-1744305768-f9ddca7dcd91f7ca25a505560e655c47d3dec2cf
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium-envoy:v1.32.5-1744305768-f9ddca7dcd91f7ca25a505560e655c47d3dec2cf
-  type: image
-- source: quay.io/cilium/cilium-envoy:v1.32.6-1746661844-0f602c28cb2aa57b29078195049fb257d5b5246c
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium-envoy:v1.32.6-1746661844-0f602c28cb2aa57b29078195049fb257d5b5246c
-  type: image
-- source: quay.io/cilium/cilium-envoy:v1.32.6-1749271279-0864395884b263913eac200ee2048fd985f8e626
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium-envoy:v1.32.6-1749271279-0864395884b263913eac200ee2048fd985f8e626
-  type: image
-- source: quay.io/cilium/cilium-envoy:v1.33.4-1752151664-7c2edb0b44cf95f326d628b837fcdd845102ba68
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium-envoy:v1.33.4-1752151664-7c2edb0b44cf95f326d628b837fcdd845102ba68
-  type: image
-- source: quay.io/cilium/cilium-envoy:v1.34.4-1753677767-266d5a01d1d55bd1d60148f991b98dac0390d363
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium-envoy:v1.34.4-1753677767-266d5a01d1d55bd1d60148f991b98dac0390d363
-  type: image
-- source: quay.io/cilium/cilium-envoy:v1.34.4-1754895458-68cffdfa568b6b226d70a7ef81fc65dda3b890bf
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium-envoy:v1.34.4-1754895458-68cffdfa568b6b226d70a7ef81fc65dda3b890bf
-  type: image
-- source: quay.io/cilium/cilium-envoy:v1.34.7-1757592137-1a52bb680a956879722f48c591a2ca90f7791324
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium-envoy:v1.34.7-1757592137-1a52bb680a956879722f48c591a2ca90f7791324
-  type: image
 - source: quay.io/cilium/cilium-etcd-operator:v2.0.7
   target: docker.io/rancher/mirrored-cilium-cilium-etcd-operator:v2.0.7
   type: image
@@ -23822,13 +14318,7 @@ sync:
   target: registry.suse.com/rancher/mirrored-cilium-cilium-etcd-operator:v2.0.7
   type: image
 - source: quay.io/cilium/cilium-etcd-operator:v2.0.7
-  target: registry.suse.com/rancher/charts/mirrored-cilium-cilium-etcd-operator:v2.0.7
-  type: image
-- source: quay.io/cilium/cilium-etcd-operator:v2.0.7
   target: stgregistry.suse.com/rancher/mirrored-cilium-cilium-etcd-operator:v2.0.7
-  type: image
-- source: quay.io/cilium/cilium-etcd-operator:v2.0.7
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-cilium-etcd-operator:v2.0.7
   type: image
 - source: quay.io/cilium/clustermesh-apiserver:v1.12.4
   target: docker.io/rancher/mirrored-cilium-clustermesh-apiserver:v1.12.4
@@ -24041,111 +14531,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-cilium-clustermesh-apiserver:v1.18.2
   type: image
 - source: quay.io/cilium/clustermesh-apiserver:v1.12.4
-  target: registry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.12.4
-  type: image
-- source: quay.io/cilium/clustermesh-apiserver:v1.12.5
-  target: registry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.12.5
-  type: image
-- source: quay.io/cilium/clustermesh-apiserver:v1.13.0
-  target: registry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.13.0
-  type: image
-- source: quay.io/cilium/clustermesh-apiserver:v1.13.2
-  target: registry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.13.2
-  type: image
-- source: quay.io/cilium/clustermesh-apiserver:v1.13.4
-  target: registry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.13.4
-  type: image
-- source: quay.io/cilium/clustermesh-apiserver:v1.14.0
-  target: registry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.14.0
-  type: image
-- source: quay.io/cilium/clustermesh-apiserver:v1.14.1
-  target: registry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.14.1
-  type: image
-- source: quay.io/cilium/clustermesh-apiserver:v1.14.2
-  target: registry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.14.2
-  type: image
-- source: quay.io/cilium/clustermesh-apiserver:v1.14.3
-  target: registry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.14.3
-  type: image
-- source: quay.io/cilium/clustermesh-apiserver:v1.14.4
-  target: registry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.14.4
-  type: image
-- source: quay.io/cilium/clustermesh-apiserver:v1.14.5
-  target: registry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.14.5
-  type: image
-- source: quay.io/cilium/clustermesh-apiserver:v1.15.0
-  target: registry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.15.0
-  type: image
-- source: quay.io/cilium/clustermesh-apiserver:v1.15.1
-  target: registry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.15.1
-  type: image
-- source: quay.io/cilium/clustermesh-apiserver:v1.15.3
-  target: registry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.15.3
-  type: image
-- source: quay.io/cilium/clustermesh-apiserver:v1.15.4
-  target: registry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.15.4
-  type: image
-- source: quay.io/cilium/clustermesh-apiserver:v1.15.5
-  target: registry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.15.5
-  type: image
-- source: quay.io/cilium/clustermesh-apiserver:v1.15.6
-  target: registry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.15.6
-  type: image
-- source: quay.io/cilium/clustermesh-apiserver:v1.15.7
-  target: registry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.15.7
-  type: image
-- source: quay.io/cilium/clustermesh-apiserver:v1.16.0
-  target: registry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.16.0
-  type: image
-- source: quay.io/cilium/clustermesh-apiserver:v1.16.1
-  target: registry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.16.1
-  type: image
-- source: quay.io/cilium/clustermesh-apiserver:v1.16.2
-  target: registry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.16.2
-  type: image
-- source: quay.io/cilium/clustermesh-apiserver:v1.16.3
-  target: registry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.16.3
-  type: image
-- source: quay.io/cilium/clustermesh-apiserver:v1.16.4
-  target: registry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.16.4
-  type: image
-- source: quay.io/cilium/clustermesh-apiserver:v1.16.5
-  target: registry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.16.5
-  type: image
-- source: quay.io/cilium/clustermesh-apiserver:v1.16.6
-  target: registry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.16.6
-  type: image
-- source: quay.io/cilium/clustermesh-apiserver:v1.17.0
-  target: registry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.17.0
-  type: image
-- source: quay.io/cilium/clustermesh-apiserver:v1.17.1
-  target: registry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.17.1
-  type: image
-- source: quay.io/cilium/clustermesh-apiserver:v1.17.2
-  target: registry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.17.2
-  type: image
-- source: quay.io/cilium/clustermesh-apiserver:v1.17.3
-  target: registry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.17.3
-  type: image
-- source: quay.io/cilium/clustermesh-apiserver:v1.17.4
-  target: registry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.17.4
-  type: image
-- source: quay.io/cilium/clustermesh-apiserver:v1.17.5
-  target: registry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.17.5
-  type: image
-- source: quay.io/cilium/clustermesh-apiserver:v1.17.6
-  target: registry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.17.6
-  type: image
-- source: quay.io/cilium/clustermesh-apiserver:v1.18.0
-  target: registry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.18.0
-  type: image
-- source: quay.io/cilium/clustermesh-apiserver:v1.18.1
-  target: registry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.18.1
-  type: image
-- source: quay.io/cilium/clustermesh-apiserver:v1.18.2
-  target: registry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.18.2
-  type: image
-- source: quay.io/cilium/clustermesh-apiserver:v1.12.4
   target: stgregistry.suse.com/rancher/mirrored-cilium-clustermesh-apiserver:v1.12.4
   type: image
 - source: quay.io/cilium/clustermesh-apiserver:v1.12.5
@@ -24249,111 +14634,6 @@ sync:
   type: image
 - source: quay.io/cilium/clustermesh-apiserver:v1.18.2
   target: stgregistry.suse.com/rancher/mirrored-cilium-clustermesh-apiserver:v1.18.2
-  type: image
-- source: quay.io/cilium/clustermesh-apiserver:v1.12.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.12.4
-  type: image
-- source: quay.io/cilium/clustermesh-apiserver:v1.12.5
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.12.5
-  type: image
-- source: quay.io/cilium/clustermesh-apiserver:v1.13.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.13.0
-  type: image
-- source: quay.io/cilium/clustermesh-apiserver:v1.13.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.13.2
-  type: image
-- source: quay.io/cilium/clustermesh-apiserver:v1.13.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.13.4
-  type: image
-- source: quay.io/cilium/clustermesh-apiserver:v1.14.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.14.0
-  type: image
-- source: quay.io/cilium/clustermesh-apiserver:v1.14.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.14.1
-  type: image
-- source: quay.io/cilium/clustermesh-apiserver:v1.14.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.14.2
-  type: image
-- source: quay.io/cilium/clustermesh-apiserver:v1.14.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.14.3
-  type: image
-- source: quay.io/cilium/clustermesh-apiserver:v1.14.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.14.4
-  type: image
-- source: quay.io/cilium/clustermesh-apiserver:v1.14.5
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.14.5
-  type: image
-- source: quay.io/cilium/clustermesh-apiserver:v1.15.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.15.0
-  type: image
-- source: quay.io/cilium/clustermesh-apiserver:v1.15.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.15.1
-  type: image
-- source: quay.io/cilium/clustermesh-apiserver:v1.15.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.15.3
-  type: image
-- source: quay.io/cilium/clustermesh-apiserver:v1.15.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.15.4
-  type: image
-- source: quay.io/cilium/clustermesh-apiserver:v1.15.5
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.15.5
-  type: image
-- source: quay.io/cilium/clustermesh-apiserver:v1.15.6
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.15.6
-  type: image
-- source: quay.io/cilium/clustermesh-apiserver:v1.15.7
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.15.7
-  type: image
-- source: quay.io/cilium/clustermesh-apiserver:v1.16.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.16.0
-  type: image
-- source: quay.io/cilium/clustermesh-apiserver:v1.16.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.16.1
-  type: image
-- source: quay.io/cilium/clustermesh-apiserver:v1.16.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.16.2
-  type: image
-- source: quay.io/cilium/clustermesh-apiserver:v1.16.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.16.3
-  type: image
-- source: quay.io/cilium/clustermesh-apiserver:v1.16.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.16.4
-  type: image
-- source: quay.io/cilium/clustermesh-apiserver:v1.16.5
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.16.5
-  type: image
-- source: quay.io/cilium/clustermesh-apiserver:v1.16.6
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.16.6
-  type: image
-- source: quay.io/cilium/clustermesh-apiserver:v1.17.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.17.0
-  type: image
-- source: quay.io/cilium/clustermesh-apiserver:v1.17.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.17.1
-  type: image
-- source: quay.io/cilium/clustermesh-apiserver:v1.17.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.17.2
-  type: image
-- source: quay.io/cilium/clustermesh-apiserver:v1.17.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.17.3
-  type: image
-- source: quay.io/cilium/clustermesh-apiserver:v1.17.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.17.4
-  type: image
-- source: quay.io/cilium/clustermesh-apiserver:v1.17.5
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.17.5
-  type: image
-- source: quay.io/cilium/clustermesh-apiserver:v1.17.6
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.17.6
-  type: image
-- source: quay.io/cilium/clustermesh-apiserver:v1.18.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.18.0
-  type: image
-- source: quay.io/cilium/clustermesh-apiserver:v1.18.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.18.1
-  type: image
-- source: quay.io/cilium/clustermesh-apiserver:v1.18.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-clustermesh-apiserver:v1.18.2
   type: image
 - source: quay.io/cilium/hubble-relay:v1.12.4
   target: docker.io/rancher/mirrored-cilium-hubble-relay:v1.12.4
@@ -24566,111 +14846,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-cilium-hubble-relay:v1.18.2
   type: image
 - source: quay.io/cilium/hubble-relay:v1.12.4
-  target: registry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.12.4
-  type: image
-- source: quay.io/cilium/hubble-relay:v1.12.5
-  target: registry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.12.5
-  type: image
-- source: quay.io/cilium/hubble-relay:v1.13.0
-  target: registry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.13.0
-  type: image
-- source: quay.io/cilium/hubble-relay:v1.13.2
-  target: registry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.13.2
-  type: image
-- source: quay.io/cilium/hubble-relay:v1.13.4
-  target: registry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.13.4
-  type: image
-- source: quay.io/cilium/hubble-relay:v1.14.0
-  target: registry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.14.0
-  type: image
-- source: quay.io/cilium/hubble-relay:v1.14.1
-  target: registry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.14.1
-  type: image
-- source: quay.io/cilium/hubble-relay:v1.14.2
-  target: registry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.14.2
-  type: image
-- source: quay.io/cilium/hubble-relay:v1.14.3
-  target: registry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.14.3
-  type: image
-- source: quay.io/cilium/hubble-relay:v1.14.4
-  target: registry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.14.4
-  type: image
-- source: quay.io/cilium/hubble-relay:v1.14.5
-  target: registry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.14.5
-  type: image
-- source: quay.io/cilium/hubble-relay:v1.15.0
-  target: registry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.15.0
-  type: image
-- source: quay.io/cilium/hubble-relay:v1.15.1
-  target: registry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.15.1
-  type: image
-- source: quay.io/cilium/hubble-relay:v1.15.3
-  target: registry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.15.3
-  type: image
-- source: quay.io/cilium/hubble-relay:v1.15.4
-  target: registry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.15.4
-  type: image
-- source: quay.io/cilium/hubble-relay:v1.15.5
-  target: registry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.15.5
-  type: image
-- source: quay.io/cilium/hubble-relay:v1.15.6
-  target: registry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.15.6
-  type: image
-- source: quay.io/cilium/hubble-relay:v1.15.7
-  target: registry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.15.7
-  type: image
-- source: quay.io/cilium/hubble-relay:v1.16.0
-  target: registry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.16.0
-  type: image
-- source: quay.io/cilium/hubble-relay:v1.16.1
-  target: registry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.16.1
-  type: image
-- source: quay.io/cilium/hubble-relay:v1.16.2
-  target: registry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.16.2
-  type: image
-- source: quay.io/cilium/hubble-relay:v1.16.3
-  target: registry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.16.3
-  type: image
-- source: quay.io/cilium/hubble-relay:v1.16.4
-  target: registry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.16.4
-  type: image
-- source: quay.io/cilium/hubble-relay:v1.16.5
-  target: registry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.16.5
-  type: image
-- source: quay.io/cilium/hubble-relay:v1.16.6
-  target: registry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.16.6
-  type: image
-- source: quay.io/cilium/hubble-relay:v1.17.0
-  target: registry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.17.0
-  type: image
-- source: quay.io/cilium/hubble-relay:v1.17.1
-  target: registry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.17.1
-  type: image
-- source: quay.io/cilium/hubble-relay:v1.17.2
-  target: registry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.17.2
-  type: image
-- source: quay.io/cilium/hubble-relay:v1.17.3
-  target: registry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.17.3
-  type: image
-- source: quay.io/cilium/hubble-relay:v1.17.4
-  target: registry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.17.4
-  type: image
-- source: quay.io/cilium/hubble-relay:v1.17.5
-  target: registry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.17.5
-  type: image
-- source: quay.io/cilium/hubble-relay:v1.17.6
-  target: registry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.17.6
-  type: image
-- source: quay.io/cilium/hubble-relay:v1.18.0
-  target: registry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.18.0
-  type: image
-- source: quay.io/cilium/hubble-relay:v1.18.1
-  target: registry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.18.1
-  type: image
-- source: quay.io/cilium/hubble-relay:v1.18.2
-  target: registry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.18.2
-  type: image
-- source: quay.io/cilium/hubble-relay:v1.12.4
   target: stgregistry.suse.com/rancher/mirrored-cilium-hubble-relay:v1.12.4
   type: image
 - source: quay.io/cilium/hubble-relay:v1.12.5
@@ -24775,111 +14950,6 @@ sync:
 - source: quay.io/cilium/hubble-relay:v1.18.2
   target: stgregistry.suse.com/rancher/mirrored-cilium-hubble-relay:v1.18.2
   type: image
-- source: quay.io/cilium/hubble-relay:v1.12.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.12.4
-  type: image
-- source: quay.io/cilium/hubble-relay:v1.12.5
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.12.5
-  type: image
-- source: quay.io/cilium/hubble-relay:v1.13.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.13.0
-  type: image
-- source: quay.io/cilium/hubble-relay:v1.13.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.13.2
-  type: image
-- source: quay.io/cilium/hubble-relay:v1.13.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.13.4
-  type: image
-- source: quay.io/cilium/hubble-relay:v1.14.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.14.0
-  type: image
-- source: quay.io/cilium/hubble-relay:v1.14.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.14.1
-  type: image
-- source: quay.io/cilium/hubble-relay:v1.14.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.14.2
-  type: image
-- source: quay.io/cilium/hubble-relay:v1.14.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.14.3
-  type: image
-- source: quay.io/cilium/hubble-relay:v1.14.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.14.4
-  type: image
-- source: quay.io/cilium/hubble-relay:v1.14.5
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.14.5
-  type: image
-- source: quay.io/cilium/hubble-relay:v1.15.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.15.0
-  type: image
-- source: quay.io/cilium/hubble-relay:v1.15.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.15.1
-  type: image
-- source: quay.io/cilium/hubble-relay:v1.15.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.15.3
-  type: image
-- source: quay.io/cilium/hubble-relay:v1.15.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.15.4
-  type: image
-- source: quay.io/cilium/hubble-relay:v1.15.5
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.15.5
-  type: image
-- source: quay.io/cilium/hubble-relay:v1.15.6
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.15.6
-  type: image
-- source: quay.io/cilium/hubble-relay:v1.15.7
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.15.7
-  type: image
-- source: quay.io/cilium/hubble-relay:v1.16.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.16.0
-  type: image
-- source: quay.io/cilium/hubble-relay:v1.16.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.16.1
-  type: image
-- source: quay.io/cilium/hubble-relay:v1.16.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.16.2
-  type: image
-- source: quay.io/cilium/hubble-relay:v1.16.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.16.3
-  type: image
-- source: quay.io/cilium/hubble-relay:v1.16.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.16.4
-  type: image
-- source: quay.io/cilium/hubble-relay:v1.16.5
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.16.5
-  type: image
-- source: quay.io/cilium/hubble-relay:v1.16.6
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.16.6
-  type: image
-- source: quay.io/cilium/hubble-relay:v1.17.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.17.0
-  type: image
-- source: quay.io/cilium/hubble-relay:v1.17.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.17.1
-  type: image
-- source: quay.io/cilium/hubble-relay:v1.17.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.17.2
-  type: image
-- source: quay.io/cilium/hubble-relay:v1.17.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.17.3
-  type: image
-- source: quay.io/cilium/hubble-relay:v1.17.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.17.4
-  type: image
-- source: quay.io/cilium/hubble-relay:v1.17.5
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.17.5
-  type: image
-- source: quay.io/cilium/hubble-relay:v1.17.6
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.17.6
-  type: image
-- source: quay.io/cilium/hubble-relay:v1.18.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.18.0
-  type: image
-- source: quay.io/cilium/hubble-relay:v1.18.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.18.1
-  type: image
-- source: quay.io/cilium/hubble-relay:v1.18.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-hubble-relay:v1.18.2
-  type: image
 - source: quay.io/cilium/hubble-ui:v0.10.0
   target: docker.io/rancher/mirrored-cilium-hubble-ui:v0.10.0
   type: image
@@ -24941,36 +15011,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-cilium-hubble-ui:v0.9.2
   type: image
 - source: quay.io/cilium/hubble-ui:v0.10.0
-  target: registry.suse.com/rancher/charts/mirrored-cilium-hubble-ui:v0.10.0
-  type: image
-- source: quay.io/cilium/hubble-ui:v0.11.0
-  target: registry.suse.com/rancher/charts/mirrored-cilium-hubble-ui:v0.11.0
-  type: image
-- source: quay.io/cilium/hubble-ui:v0.12.0
-  target: registry.suse.com/rancher/charts/mirrored-cilium-hubble-ui:v0.12.0
-  type: image
-- source: quay.io/cilium/hubble-ui:v0.12.1
-  target: registry.suse.com/rancher/charts/mirrored-cilium-hubble-ui:v0.12.1
-  type: image
-- source: quay.io/cilium/hubble-ui:v0.12.3
-  target: registry.suse.com/rancher/charts/mirrored-cilium-hubble-ui:v0.12.3
-  type: image
-- source: quay.io/cilium/hubble-ui:v0.13.0
-  target: registry.suse.com/rancher/charts/mirrored-cilium-hubble-ui:v0.13.0
-  type: image
-- source: quay.io/cilium/hubble-ui:v0.13.1
-  target: registry.suse.com/rancher/charts/mirrored-cilium-hubble-ui:v0.13.1
-  type: image
-- source: quay.io/cilium/hubble-ui:v0.13.2
-  target: registry.suse.com/rancher/charts/mirrored-cilium-hubble-ui:v0.13.2
-  type: image
-- source: quay.io/cilium/hubble-ui:v0.13.3
-  target: registry.suse.com/rancher/charts/mirrored-cilium-hubble-ui:v0.13.3
-  type: image
-- source: quay.io/cilium/hubble-ui:v0.9.2
-  target: registry.suse.com/rancher/charts/mirrored-cilium-hubble-ui:v0.9.2
-  type: image
-- source: quay.io/cilium/hubble-ui:v0.10.0
   target: stgregistry.suse.com/rancher/mirrored-cilium-hubble-ui:v0.10.0
   type: image
 - source: quay.io/cilium/hubble-ui:v0.11.0
@@ -24999,36 +15039,6 @@ sync:
   type: image
 - source: quay.io/cilium/hubble-ui:v0.9.2
   target: stgregistry.suse.com/rancher/mirrored-cilium-hubble-ui:v0.9.2
-  type: image
-- source: quay.io/cilium/hubble-ui:v0.10.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-hubble-ui:v0.10.0
-  type: image
-- source: quay.io/cilium/hubble-ui:v0.11.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-hubble-ui:v0.11.0
-  type: image
-- source: quay.io/cilium/hubble-ui:v0.12.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-hubble-ui:v0.12.0
-  type: image
-- source: quay.io/cilium/hubble-ui:v0.12.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-hubble-ui:v0.12.1
-  type: image
-- source: quay.io/cilium/hubble-ui:v0.12.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-hubble-ui:v0.12.3
-  type: image
-- source: quay.io/cilium/hubble-ui:v0.13.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-hubble-ui:v0.13.0
-  type: image
-- source: quay.io/cilium/hubble-ui:v0.13.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-hubble-ui:v0.13.1
-  type: image
-- source: quay.io/cilium/hubble-ui:v0.13.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-hubble-ui:v0.13.2
-  type: image
-- source: quay.io/cilium/hubble-ui:v0.13.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-hubble-ui:v0.13.3
-  type: image
-- source: quay.io/cilium/hubble-ui:v0.9.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-hubble-ui:v0.9.2
   type: image
 - source: quay.io/cilium/hubble-ui-backend:v0.10.0
   target: docker.io/rancher/mirrored-cilium-hubble-ui-backend:v0.10.0
@@ -25091,36 +15101,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-cilium-hubble-ui-backend:v0.9.2
   type: image
 - source: quay.io/cilium/hubble-ui-backend:v0.10.0
-  target: registry.suse.com/rancher/charts/mirrored-cilium-hubble-ui-backend:v0.10.0
-  type: image
-- source: quay.io/cilium/hubble-ui-backend:v0.11.0
-  target: registry.suse.com/rancher/charts/mirrored-cilium-hubble-ui-backend:v0.11.0
-  type: image
-- source: quay.io/cilium/hubble-ui-backend:v0.12.0
-  target: registry.suse.com/rancher/charts/mirrored-cilium-hubble-ui-backend:v0.12.0
-  type: image
-- source: quay.io/cilium/hubble-ui-backend:v0.12.1
-  target: registry.suse.com/rancher/charts/mirrored-cilium-hubble-ui-backend:v0.12.1
-  type: image
-- source: quay.io/cilium/hubble-ui-backend:v0.12.3
-  target: registry.suse.com/rancher/charts/mirrored-cilium-hubble-ui-backend:v0.12.3
-  type: image
-- source: quay.io/cilium/hubble-ui-backend:v0.13.0
-  target: registry.suse.com/rancher/charts/mirrored-cilium-hubble-ui-backend:v0.13.0
-  type: image
-- source: quay.io/cilium/hubble-ui-backend:v0.13.1
-  target: registry.suse.com/rancher/charts/mirrored-cilium-hubble-ui-backend:v0.13.1
-  type: image
-- source: quay.io/cilium/hubble-ui-backend:v0.13.2
-  target: registry.suse.com/rancher/charts/mirrored-cilium-hubble-ui-backend:v0.13.2
-  type: image
-- source: quay.io/cilium/hubble-ui-backend:v0.13.3
-  target: registry.suse.com/rancher/charts/mirrored-cilium-hubble-ui-backend:v0.13.3
-  type: image
-- source: quay.io/cilium/hubble-ui-backend:v0.9.2
-  target: registry.suse.com/rancher/charts/mirrored-cilium-hubble-ui-backend:v0.9.2
-  type: image
-- source: quay.io/cilium/hubble-ui-backend:v0.10.0
   target: stgregistry.suse.com/rancher/mirrored-cilium-hubble-ui-backend:v0.10.0
   type: image
 - source: quay.io/cilium/hubble-ui-backend:v0.11.0
@@ -25149,36 +15129,6 @@ sync:
   type: image
 - source: quay.io/cilium/hubble-ui-backend:v0.9.2
   target: stgregistry.suse.com/rancher/mirrored-cilium-hubble-ui-backend:v0.9.2
-  type: image
-- source: quay.io/cilium/hubble-ui-backend:v0.10.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-hubble-ui-backend:v0.10.0
-  type: image
-- source: quay.io/cilium/hubble-ui-backend:v0.11.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-hubble-ui-backend:v0.11.0
-  type: image
-- source: quay.io/cilium/hubble-ui-backend:v0.12.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-hubble-ui-backend:v0.12.0
-  type: image
-- source: quay.io/cilium/hubble-ui-backend:v0.12.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-hubble-ui-backend:v0.12.1
-  type: image
-- source: quay.io/cilium/hubble-ui-backend:v0.12.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-hubble-ui-backend:v0.12.3
-  type: image
-- source: quay.io/cilium/hubble-ui-backend:v0.13.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-hubble-ui-backend:v0.13.0
-  type: image
-- source: quay.io/cilium/hubble-ui-backend:v0.13.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-hubble-ui-backend:v0.13.1
-  type: image
-- source: quay.io/cilium/hubble-ui-backend:v0.13.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-hubble-ui-backend:v0.13.2
-  type: image
-- source: quay.io/cilium/hubble-ui-backend:v0.13.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-hubble-ui-backend:v0.13.3
-  type: image
-- source: quay.io/cilium/hubble-ui-backend:v0.9.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-hubble-ui-backend:v0.9.2
   type: image
 - source: quay.io/cilium/kvstoremesh:v1.14.0
   target: docker.io/rancher/mirrored-cilium-kvstoremesh:v1.14.0
@@ -25217,24 +15167,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-cilium-kvstoremesh:v1.14.5
   type: image
 - source: quay.io/cilium/kvstoremesh:v1.14.0
-  target: registry.suse.com/rancher/charts/mirrored-cilium-kvstoremesh:v1.14.0
-  type: image
-- source: quay.io/cilium/kvstoremesh:v1.14.1
-  target: registry.suse.com/rancher/charts/mirrored-cilium-kvstoremesh:v1.14.1
-  type: image
-- source: quay.io/cilium/kvstoremesh:v1.14.2
-  target: registry.suse.com/rancher/charts/mirrored-cilium-kvstoremesh:v1.14.2
-  type: image
-- source: quay.io/cilium/kvstoremesh:v1.14.3
-  target: registry.suse.com/rancher/charts/mirrored-cilium-kvstoremesh:v1.14.3
-  type: image
-- source: quay.io/cilium/kvstoremesh:v1.14.4
-  target: registry.suse.com/rancher/charts/mirrored-cilium-kvstoremesh:v1.14.4
-  type: image
-- source: quay.io/cilium/kvstoremesh:v1.14.5
-  target: registry.suse.com/rancher/charts/mirrored-cilium-kvstoremesh:v1.14.5
-  type: image
-- source: quay.io/cilium/kvstoremesh:v1.14.0
   target: stgregistry.suse.com/rancher/mirrored-cilium-kvstoremesh:v1.14.0
   type: image
 - source: quay.io/cilium/kvstoremesh:v1.14.1
@@ -25251,24 +15183,6 @@ sync:
   type: image
 - source: quay.io/cilium/kvstoremesh:v1.14.5
   target: stgregistry.suse.com/rancher/mirrored-cilium-kvstoremesh:v1.14.5
-  type: image
-- source: quay.io/cilium/kvstoremesh:v1.14.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-kvstoremesh:v1.14.0
-  type: image
-- source: quay.io/cilium/kvstoremesh:v1.14.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-kvstoremesh:v1.14.1
-  type: image
-- source: quay.io/cilium/kvstoremesh:v1.14.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-kvstoremesh:v1.14.2
-  type: image
-- source: quay.io/cilium/kvstoremesh:v1.14.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-kvstoremesh:v1.14.3
-  type: image
-- source: quay.io/cilium/kvstoremesh:v1.14.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-kvstoremesh:v1.14.4
-  type: image
-- source: quay.io/cilium/kvstoremesh:v1.14.5
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-kvstoremesh:v1.14.5
   type: image
 - source: quay.io/cilium/operator-aws:v1.10.4
   target: docker.io/rancher/mirrored-cilium-operator-aws:v1.10.4
@@ -25565,153 +15479,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-cilium-operator-aws:v1.9.8
   type: image
 - source: quay.io/cilium/operator-aws:v1.10.4
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.10.4
-  type: image
-- source: quay.io/cilium/operator-aws:v1.10.7
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.10.7
-  type: image
-- source: quay.io/cilium/operator-aws:v1.11.0
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.11.0
-  type: image
-- source: quay.io/cilium/operator-aws:v1.11.1
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.11.1
-  type: image
-- source: quay.io/cilium/operator-aws:v1.11.2
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.11.2
-  type: image
-- source: quay.io/cilium/operator-aws:v1.11.4
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.11.4
-  type: image
-- source: quay.io/cilium/operator-aws:v1.11.5
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.11.5
-  type: image
-- source: quay.io/cilium/operator-aws:v1.12.0
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.12.0
-  type: image
-- source: quay.io/cilium/operator-aws:v1.12.1
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.12.1
-  type: image
-- source: quay.io/cilium/operator-aws:v1.12.3
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.12.3
-  type: image
-- source: quay.io/cilium/operator-aws:v1.12.4
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.12.4
-  type: image
-- source: quay.io/cilium/operator-aws:v1.12.5
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.12.5
-  type: image
-- source: quay.io/cilium/operator-aws:v1.13.0
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.13.0
-  type: image
-- source: quay.io/cilium/operator-aws:v1.13.2
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.13.2
-  type: image
-- source: quay.io/cilium/operator-aws:v1.13.4
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.13.4
-  type: image
-- source: quay.io/cilium/operator-aws:v1.14.0
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.14.0
-  type: image
-- source: quay.io/cilium/operator-aws:v1.14.1
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.14.1
-  type: image
-- source: quay.io/cilium/operator-aws:v1.14.2
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.14.2
-  type: image
-- source: quay.io/cilium/operator-aws:v1.14.3
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.14.3
-  type: image
-- source: quay.io/cilium/operator-aws:v1.14.4
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.14.4
-  type: image
-- source: quay.io/cilium/operator-aws:v1.14.5
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.14.5
-  type: image
-- source: quay.io/cilium/operator-aws:v1.15.0
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.15.0
-  type: image
-- source: quay.io/cilium/operator-aws:v1.15.1
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.15.1
-  type: image
-- source: quay.io/cilium/operator-aws:v1.15.3
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.15.3
-  type: image
-- source: quay.io/cilium/operator-aws:v1.15.4
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.15.4
-  type: image
-- source: quay.io/cilium/operator-aws:v1.15.5
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.15.5
-  type: image
-- source: quay.io/cilium/operator-aws:v1.15.6
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.15.6
-  type: image
-- source: quay.io/cilium/operator-aws:v1.15.7
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.15.7
-  type: image
-- source: quay.io/cilium/operator-aws:v1.16.0
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.16.0
-  type: image
-- source: quay.io/cilium/operator-aws:v1.16.1
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.16.1
-  type: image
-- source: quay.io/cilium/operator-aws:v1.16.2
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.16.2
-  type: image
-- source: quay.io/cilium/operator-aws:v1.16.3
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.16.3
-  type: image
-- source: quay.io/cilium/operator-aws:v1.16.4
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.16.4
-  type: image
-- source: quay.io/cilium/operator-aws:v1.16.5
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.16.5
-  type: image
-- source: quay.io/cilium/operator-aws:v1.16.6
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.16.6
-  type: image
-- source: quay.io/cilium/operator-aws:v1.17.0
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.17.0
-  type: image
-- source: quay.io/cilium/operator-aws:v1.17.1
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.17.1
-  type: image
-- source: quay.io/cilium/operator-aws:v1.17.2
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.17.2
-  type: image
-- source: quay.io/cilium/operator-aws:v1.17.3
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.17.3
-  type: image
-- source: quay.io/cilium/operator-aws:v1.17.4
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.17.4
-  type: image
-- source: quay.io/cilium/operator-aws:v1.17.5
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.17.5
-  type: image
-- source: quay.io/cilium/operator-aws:v1.17.6
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.17.6
-  type: image
-- source: quay.io/cilium/operator-aws:v1.18.0
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.18.0
-  type: image
-- source: quay.io/cilium/operator-aws:v1.18.1
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.18.1
-  type: image
-- source: quay.io/cilium/operator-aws:v1.18.2
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.18.2
-  type: image
-- source: quay.io/cilium/operator-aws:v1.9.12
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.9.12
-  type: image
-- source: quay.io/cilium/operator-aws:v1.9.4
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.9.4
-  type: image
-- source: quay.io/cilium/operator-aws:v1.9.6
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.9.6
-  type: image
-- source: quay.io/cilium/operator-aws:v1.9.8
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.9.8
-  type: image
-- source: quay.io/cilium/operator-aws:v1.10.4
   target: stgregistry.suse.com/rancher/mirrored-cilium-operator-aws:v1.10.4
   type: image
 - source: quay.io/cilium/operator-aws:v1.10.7
@@ -25857,153 +15624,6 @@ sync:
   type: image
 - source: quay.io/cilium/operator-aws:v1.9.8
   target: stgregistry.suse.com/rancher/mirrored-cilium-operator-aws:v1.9.8
-  type: image
-- source: quay.io/cilium/operator-aws:v1.10.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.10.4
-  type: image
-- source: quay.io/cilium/operator-aws:v1.10.7
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.10.7
-  type: image
-- source: quay.io/cilium/operator-aws:v1.11.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.11.0
-  type: image
-- source: quay.io/cilium/operator-aws:v1.11.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.11.1
-  type: image
-- source: quay.io/cilium/operator-aws:v1.11.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.11.2
-  type: image
-- source: quay.io/cilium/operator-aws:v1.11.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.11.4
-  type: image
-- source: quay.io/cilium/operator-aws:v1.11.5
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.11.5
-  type: image
-- source: quay.io/cilium/operator-aws:v1.12.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.12.0
-  type: image
-- source: quay.io/cilium/operator-aws:v1.12.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.12.1
-  type: image
-- source: quay.io/cilium/operator-aws:v1.12.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.12.3
-  type: image
-- source: quay.io/cilium/operator-aws:v1.12.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.12.4
-  type: image
-- source: quay.io/cilium/operator-aws:v1.12.5
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.12.5
-  type: image
-- source: quay.io/cilium/operator-aws:v1.13.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.13.0
-  type: image
-- source: quay.io/cilium/operator-aws:v1.13.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.13.2
-  type: image
-- source: quay.io/cilium/operator-aws:v1.13.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.13.4
-  type: image
-- source: quay.io/cilium/operator-aws:v1.14.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.14.0
-  type: image
-- source: quay.io/cilium/operator-aws:v1.14.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.14.1
-  type: image
-- source: quay.io/cilium/operator-aws:v1.14.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.14.2
-  type: image
-- source: quay.io/cilium/operator-aws:v1.14.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.14.3
-  type: image
-- source: quay.io/cilium/operator-aws:v1.14.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.14.4
-  type: image
-- source: quay.io/cilium/operator-aws:v1.14.5
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.14.5
-  type: image
-- source: quay.io/cilium/operator-aws:v1.15.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.15.0
-  type: image
-- source: quay.io/cilium/operator-aws:v1.15.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.15.1
-  type: image
-- source: quay.io/cilium/operator-aws:v1.15.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.15.3
-  type: image
-- source: quay.io/cilium/operator-aws:v1.15.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.15.4
-  type: image
-- source: quay.io/cilium/operator-aws:v1.15.5
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.15.5
-  type: image
-- source: quay.io/cilium/operator-aws:v1.15.6
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.15.6
-  type: image
-- source: quay.io/cilium/operator-aws:v1.15.7
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.15.7
-  type: image
-- source: quay.io/cilium/operator-aws:v1.16.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.16.0
-  type: image
-- source: quay.io/cilium/operator-aws:v1.16.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.16.1
-  type: image
-- source: quay.io/cilium/operator-aws:v1.16.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.16.2
-  type: image
-- source: quay.io/cilium/operator-aws:v1.16.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.16.3
-  type: image
-- source: quay.io/cilium/operator-aws:v1.16.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.16.4
-  type: image
-- source: quay.io/cilium/operator-aws:v1.16.5
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.16.5
-  type: image
-- source: quay.io/cilium/operator-aws:v1.16.6
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.16.6
-  type: image
-- source: quay.io/cilium/operator-aws:v1.17.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.17.0
-  type: image
-- source: quay.io/cilium/operator-aws:v1.17.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.17.1
-  type: image
-- source: quay.io/cilium/operator-aws:v1.17.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.17.2
-  type: image
-- source: quay.io/cilium/operator-aws:v1.17.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.17.3
-  type: image
-- source: quay.io/cilium/operator-aws:v1.17.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.17.4
-  type: image
-- source: quay.io/cilium/operator-aws:v1.17.5
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.17.5
-  type: image
-- source: quay.io/cilium/operator-aws:v1.17.6
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.17.6
-  type: image
-- source: quay.io/cilium/operator-aws:v1.18.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.18.0
-  type: image
-- source: quay.io/cilium/operator-aws:v1.18.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.18.1
-  type: image
-- source: quay.io/cilium/operator-aws:v1.18.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.18.2
-  type: image
-- source: quay.io/cilium/operator-aws:v1.9.12
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.9.12
-  type: image
-- source: quay.io/cilium/operator-aws:v1.9.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.9.4
-  type: image
-- source: quay.io/cilium/operator-aws:v1.9.6
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.9.6
-  type: image
-- source: quay.io/cilium/operator-aws:v1.9.8
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-aws:v1.9.8
   type: image
 - source: quay.io/cilium/operator-azure:v1.10.4
   target: docker.io/rancher/mirrored-cilium-operator-azure:v1.10.4
@@ -26300,153 +15920,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-cilium-operator-azure:v1.9.8
   type: image
 - source: quay.io/cilium/operator-azure:v1.10.4
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.10.4
-  type: image
-- source: quay.io/cilium/operator-azure:v1.10.7
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.10.7
-  type: image
-- source: quay.io/cilium/operator-azure:v1.11.0
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.11.0
-  type: image
-- source: quay.io/cilium/operator-azure:v1.11.1
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.11.1
-  type: image
-- source: quay.io/cilium/operator-azure:v1.11.2
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.11.2
-  type: image
-- source: quay.io/cilium/operator-azure:v1.11.4
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.11.4
-  type: image
-- source: quay.io/cilium/operator-azure:v1.11.5
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.11.5
-  type: image
-- source: quay.io/cilium/operator-azure:v1.12.0
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.12.0
-  type: image
-- source: quay.io/cilium/operator-azure:v1.12.1
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.12.1
-  type: image
-- source: quay.io/cilium/operator-azure:v1.12.3
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.12.3
-  type: image
-- source: quay.io/cilium/operator-azure:v1.12.4
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.12.4
-  type: image
-- source: quay.io/cilium/operator-azure:v1.12.5
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.12.5
-  type: image
-- source: quay.io/cilium/operator-azure:v1.13.0
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.13.0
-  type: image
-- source: quay.io/cilium/operator-azure:v1.13.2
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.13.2
-  type: image
-- source: quay.io/cilium/operator-azure:v1.13.4
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.13.4
-  type: image
-- source: quay.io/cilium/operator-azure:v1.14.0
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.14.0
-  type: image
-- source: quay.io/cilium/operator-azure:v1.14.1
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.14.1
-  type: image
-- source: quay.io/cilium/operator-azure:v1.14.2
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.14.2
-  type: image
-- source: quay.io/cilium/operator-azure:v1.14.3
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.14.3
-  type: image
-- source: quay.io/cilium/operator-azure:v1.14.4
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.14.4
-  type: image
-- source: quay.io/cilium/operator-azure:v1.14.5
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.14.5
-  type: image
-- source: quay.io/cilium/operator-azure:v1.15.0
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.15.0
-  type: image
-- source: quay.io/cilium/operator-azure:v1.15.1
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.15.1
-  type: image
-- source: quay.io/cilium/operator-azure:v1.15.3
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.15.3
-  type: image
-- source: quay.io/cilium/operator-azure:v1.15.4
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.15.4
-  type: image
-- source: quay.io/cilium/operator-azure:v1.15.5
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.15.5
-  type: image
-- source: quay.io/cilium/operator-azure:v1.15.6
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.15.6
-  type: image
-- source: quay.io/cilium/operator-azure:v1.15.7
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.15.7
-  type: image
-- source: quay.io/cilium/operator-azure:v1.16.0
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.16.0
-  type: image
-- source: quay.io/cilium/operator-azure:v1.16.1
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.16.1
-  type: image
-- source: quay.io/cilium/operator-azure:v1.16.2
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.16.2
-  type: image
-- source: quay.io/cilium/operator-azure:v1.16.3
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.16.3
-  type: image
-- source: quay.io/cilium/operator-azure:v1.16.4
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.16.4
-  type: image
-- source: quay.io/cilium/operator-azure:v1.16.5
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.16.5
-  type: image
-- source: quay.io/cilium/operator-azure:v1.16.6
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.16.6
-  type: image
-- source: quay.io/cilium/operator-azure:v1.17.0
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.17.0
-  type: image
-- source: quay.io/cilium/operator-azure:v1.17.1
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.17.1
-  type: image
-- source: quay.io/cilium/operator-azure:v1.17.2
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.17.2
-  type: image
-- source: quay.io/cilium/operator-azure:v1.17.3
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.17.3
-  type: image
-- source: quay.io/cilium/operator-azure:v1.17.4
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.17.4
-  type: image
-- source: quay.io/cilium/operator-azure:v1.17.5
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.17.5
-  type: image
-- source: quay.io/cilium/operator-azure:v1.17.6
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.17.6
-  type: image
-- source: quay.io/cilium/operator-azure:v1.18.0
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.18.0
-  type: image
-- source: quay.io/cilium/operator-azure:v1.18.1
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.18.1
-  type: image
-- source: quay.io/cilium/operator-azure:v1.18.2
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.18.2
-  type: image
-- source: quay.io/cilium/operator-azure:v1.9.12
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.9.12
-  type: image
-- source: quay.io/cilium/operator-azure:v1.9.4
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.9.4
-  type: image
-- source: quay.io/cilium/operator-azure:v1.9.6
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.9.6
-  type: image
-- source: quay.io/cilium/operator-azure:v1.9.8
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.9.8
-  type: image
-- source: quay.io/cilium/operator-azure:v1.10.4
   target: stgregistry.suse.com/rancher/mirrored-cilium-operator-azure:v1.10.4
   type: image
 - source: quay.io/cilium/operator-azure:v1.10.7
@@ -26592,153 +16065,6 @@ sync:
   type: image
 - source: quay.io/cilium/operator-azure:v1.9.8
   target: stgregistry.suse.com/rancher/mirrored-cilium-operator-azure:v1.9.8
-  type: image
-- source: quay.io/cilium/operator-azure:v1.10.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.10.4
-  type: image
-- source: quay.io/cilium/operator-azure:v1.10.7
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.10.7
-  type: image
-- source: quay.io/cilium/operator-azure:v1.11.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.11.0
-  type: image
-- source: quay.io/cilium/operator-azure:v1.11.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.11.1
-  type: image
-- source: quay.io/cilium/operator-azure:v1.11.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.11.2
-  type: image
-- source: quay.io/cilium/operator-azure:v1.11.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.11.4
-  type: image
-- source: quay.io/cilium/operator-azure:v1.11.5
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.11.5
-  type: image
-- source: quay.io/cilium/operator-azure:v1.12.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.12.0
-  type: image
-- source: quay.io/cilium/operator-azure:v1.12.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.12.1
-  type: image
-- source: quay.io/cilium/operator-azure:v1.12.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.12.3
-  type: image
-- source: quay.io/cilium/operator-azure:v1.12.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.12.4
-  type: image
-- source: quay.io/cilium/operator-azure:v1.12.5
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.12.5
-  type: image
-- source: quay.io/cilium/operator-azure:v1.13.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.13.0
-  type: image
-- source: quay.io/cilium/operator-azure:v1.13.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.13.2
-  type: image
-- source: quay.io/cilium/operator-azure:v1.13.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.13.4
-  type: image
-- source: quay.io/cilium/operator-azure:v1.14.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.14.0
-  type: image
-- source: quay.io/cilium/operator-azure:v1.14.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.14.1
-  type: image
-- source: quay.io/cilium/operator-azure:v1.14.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.14.2
-  type: image
-- source: quay.io/cilium/operator-azure:v1.14.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.14.3
-  type: image
-- source: quay.io/cilium/operator-azure:v1.14.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.14.4
-  type: image
-- source: quay.io/cilium/operator-azure:v1.14.5
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.14.5
-  type: image
-- source: quay.io/cilium/operator-azure:v1.15.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.15.0
-  type: image
-- source: quay.io/cilium/operator-azure:v1.15.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.15.1
-  type: image
-- source: quay.io/cilium/operator-azure:v1.15.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.15.3
-  type: image
-- source: quay.io/cilium/operator-azure:v1.15.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.15.4
-  type: image
-- source: quay.io/cilium/operator-azure:v1.15.5
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.15.5
-  type: image
-- source: quay.io/cilium/operator-azure:v1.15.6
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.15.6
-  type: image
-- source: quay.io/cilium/operator-azure:v1.15.7
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.15.7
-  type: image
-- source: quay.io/cilium/operator-azure:v1.16.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.16.0
-  type: image
-- source: quay.io/cilium/operator-azure:v1.16.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.16.1
-  type: image
-- source: quay.io/cilium/operator-azure:v1.16.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.16.2
-  type: image
-- source: quay.io/cilium/operator-azure:v1.16.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.16.3
-  type: image
-- source: quay.io/cilium/operator-azure:v1.16.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.16.4
-  type: image
-- source: quay.io/cilium/operator-azure:v1.16.5
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.16.5
-  type: image
-- source: quay.io/cilium/operator-azure:v1.16.6
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.16.6
-  type: image
-- source: quay.io/cilium/operator-azure:v1.17.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.17.0
-  type: image
-- source: quay.io/cilium/operator-azure:v1.17.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.17.1
-  type: image
-- source: quay.io/cilium/operator-azure:v1.17.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.17.2
-  type: image
-- source: quay.io/cilium/operator-azure:v1.17.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.17.3
-  type: image
-- source: quay.io/cilium/operator-azure:v1.17.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.17.4
-  type: image
-- source: quay.io/cilium/operator-azure:v1.17.5
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.17.5
-  type: image
-- source: quay.io/cilium/operator-azure:v1.17.6
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.17.6
-  type: image
-- source: quay.io/cilium/operator-azure:v1.18.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.18.0
-  type: image
-- source: quay.io/cilium/operator-azure:v1.18.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.18.1
-  type: image
-- source: quay.io/cilium/operator-azure:v1.18.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.18.2
-  type: image
-- source: quay.io/cilium/operator-azure:v1.9.12
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.9.12
-  type: image
-- source: quay.io/cilium/operator-azure:v1.9.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.9.4
-  type: image
-- source: quay.io/cilium/operator-azure:v1.9.6
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.9.6
-  type: image
-- source: quay.io/cilium/operator-azure:v1.9.8
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-azure:v1.9.8
   type: image
 - source: quay.io/cilium/operator-generic:v1.10.4
   target: docker.io/rancher/mirrored-cilium-operator-generic:v1.10.4
@@ -27035,153 +16361,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-cilium-operator-generic:v1.9.8
   type: image
 - source: quay.io/cilium/operator-generic:v1.10.4
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.10.4
-  type: image
-- source: quay.io/cilium/operator-generic:v1.10.7
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.10.7
-  type: image
-- source: quay.io/cilium/operator-generic:v1.11.0
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.11.0
-  type: image
-- source: quay.io/cilium/operator-generic:v1.11.1
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.11.1
-  type: image
-- source: quay.io/cilium/operator-generic:v1.11.2
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.11.2
-  type: image
-- source: quay.io/cilium/operator-generic:v1.11.4
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.11.4
-  type: image
-- source: quay.io/cilium/operator-generic:v1.11.5
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.11.5
-  type: image
-- source: quay.io/cilium/operator-generic:v1.12.0
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.12.0
-  type: image
-- source: quay.io/cilium/operator-generic:v1.12.1
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.12.1
-  type: image
-- source: quay.io/cilium/operator-generic:v1.12.3
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.12.3
-  type: image
-- source: quay.io/cilium/operator-generic:v1.12.4
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.12.4
-  type: image
-- source: quay.io/cilium/operator-generic:v1.12.5
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.12.5
-  type: image
-- source: quay.io/cilium/operator-generic:v1.13.0
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.13.0
-  type: image
-- source: quay.io/cilium/operator-generic:v1.13.2
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.13.2
-  type: image
-- source: quay.io/cilium/operator-generic:v1.13.4
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.13.4
-  type: image
-- source: quay.io/cilium/operator-generic:v1.14.0
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.14.0
-  type: image
-- source: quay.io/cilium/operator-generic:v1.14.1
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.14.1
-  type: image
-- source: quay.io/cilium/operator-generic:v1.14.2
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.14.2
-  type: image
-- source: quay.io/cilium/operator-generic:v1.14.3
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.14.3
-  type: image
-- source: quay.io/cilium/operator-generic:v1.14.4
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.14.4
-  type: image
-- source: quay.io/cilium/operator-generic:v1.14.5
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.14.5
-  type: image
-- source: quay.io/cilium/operator-generic:v1.15.0
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.15.0
-  type: image
-- source: quay.io/cilium/operator-generic:v1.15.1
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.15.1
-  type: image
-- source: quay.io/cilium/operator-generic:v1.15.3
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.15.3
-  type: image
-- source: quay.io/cilium/operator-generic:v1.15.4
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.15.4
-  type: image
-- source: quay.io/cilium/operator-generic:v1.15.5
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.15.5
-  type: image
-- source: quay.io/cilium/operator-generic:v1.15.6
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.15.6
-  type: image
-- source: quay.io/cilium/operator-generic:v1.15.7
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.15.7
-  type: image
-- source: quay.io/cilium/operator-generic:v1.16.0
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.16.0
-  type: image
-- source: quay.io/cilium/operator-generic:v1.16.1
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.16.1
-  type: image
-- source: quay.io/cilium/operator-generic:v1.16.2
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.16.2
-  type: image
-- source: quay.io/cilium/operator-generic:v1.16.3
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.16.3
-  type: image
-- source: quay.io/cilium/operator-generic:v1.16.4
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.16.4
-  type: image
-- source: quay.io/cilium/operator-generic:v1.16.5
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.16.5
-  type: image
-- source: quay.io/cilium/operator-generic:v1.16.6
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.16.6
-  type: image
-- source: quay.io/cilium/operator-generic:v1.17.0
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.17.0
-  type: image
-- source: quay.io/cilium/operator-generic:v1.17.1
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.17.1
-  type: image
-- source: quay.io/cilium/operator-generic:v1.17.2
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.17.2
-  type: image
-- source: quay.io/cilium/operator-generic:v1.17.3
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.17.3
-  type: image
-- source: quay.io/cilium/operator-generic:v1.17.4
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.17.4
-  type: image
-- source: quay.io/cilium/operator-generic:v1.17.5
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.17.5
-  type: image
-- source: quay.io/cilium/operator-generic:v1.17.6
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.17.6
-  type: image
-- source: quay.io/cilium/operator-generic:v1.18.0
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.18.0
-  type: image
-- source: quay.io/cilium/operator-generic:v1.18.1
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.18.1
-  type: image
-- source: quay.io/cilium/operator-generic:v1.18.2
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.18.2
-  type: image
-- source: quay.io/cilium/operator-generic:v1.9.12
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.9.12
-  type: image
-- source: quay.io/cilium/operator-generic:v1.9.4
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.9.4
-  type: image
-- source: quay.io/cilium/operator-generic:v1.9.6
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.9.6
-  type: image
-- source: quay.io/cilium/operator-generic:v1.9.8
-  target: registry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.9.8
-  type: image
-- source: quay.io/cilium/operator-generic:v1.10.4
   target: stgregistry.suse.com/rancher/mirrored-cilium-operator-generic:v1.10.4
   type: image
 - source: quay.io/cilium/operator-generic:v1.10.7
@@ -27328,153 +16507,6 @@ sync:
 - source: quay.io/cilium/operator-generic:v1.9.8
   target: stgregistry.suse.com/rancher/mirrored-cilium-operator-generic:v1.9.8
   type: image
-- source: quay.io/cilium/operator-generic:v1.10.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.10.4
-  type: image
-- source: quay.io/cilium/operator-generic:v1.10.7
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.10.7
-  type: image
-- source: quay.io/cilium/operator-generic:v1.11.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.11.0
-  type: image
-- source: quay.io/cilium/operator-generic:v1.11.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.11.1
-  type: image
-- source: quay.io/cilium/operator-generic:v1.11.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.11.2
-  type: image
-- source: quay.io/cilium/operator-generic:v1.11.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.11.4
-  type: image
-- source: quay.io/cilium/operator-generic:v1.11.5
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.11.5
-  type: image
-- source: quay.io/cilium/operator-generic:v1.12.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.12.0
-  type: image
-- source: quay.io/cilium/operator-generic:v1.12.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.12.1
-  type: image
-- source: quay.io/cilium/operator-generic:v1.12.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.12.3
-  type: image
-- source: quay.io/cilium/operator-generic:v1.12.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.12.4
-  type: image
-- source: quay.io/cilium/operator-generic:v1.12.5
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.12.5
-  type: image
-- source: quay.io/cilium/operator-generic:v1.13.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.13.0
-  type: image
-- source: quay.io/cilium/operator-generic:v1.13.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.13.2
-  type: image
-- source: quay.io/cilium/operator-generic:v1.13.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.13.4
-  type: image
-- source: quay.io/cilium/operator-generic:v1.14.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.14.0
-  type: image
-- source: quay.io/cilium/operator-generic:v1.14.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.14.1
-  type: image
-- source: quay.io/cilium/operator-generic:v1.14.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.14.2
-  type: image
-- source: quay.io/cilium/operator-generic:v1.14.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.14.3
-  type: image
-- source: quay.io/cilium/operator-generic:v1.14.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.14.4
-  type: image
-- source: quay.io/cilium/operator-generic:v1.14.5
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.14.5
-  type: image
-- source: quay.io/cilium/operator-generic:v1.15.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.15.0
-  type: image
-- source: quay.io/cilium/operator-generic:v1.15.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.15.1
-  type: image
-- source: quay.io/cilium/operator-generic:v1.15.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.15.3
-  type: image
-- source: quay.io/cilium/operator-generic:v1.15.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.15.4
-  type: image
-- source: quay.io/cilium/operator-generic:v1.15.5
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.15.5
-  type: image
-- source: quay.io/cilium/operator-generic:v1.15.6
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.15.6
-  type: image
-- source: quay.io/cilium/operator-generic:v1.15.7
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.15.7
-  type: image
-- source: quay.io/cilium/operator-generic:v1.16.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.16.0
-  type: image
-- source: quay.io/cilium/operator-generic:v1.16.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.16.1
-  type: image
-- source: quay.io/cilium/operator-generic:v1.16.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.16.2
-  type: image
-- source: quay.io/cilium/operator-generic:v1.16.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.16.3
-  type: image
-- source: quay.io/cilium/operator-generic:v1.16.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.16.4
-  type: image
-- source: quay.io/cilium/operator-generic:v1.16.5
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.16.5
-  type: image
-- source: quay.io/cilium/operator-generic:v1.16.6
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.16.6
-  type: image
-- source: quay.io/cilium/operator-generic:v1.17.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.17.0
-  type: image
-- source: quay.io/cilium/operator-generic:v1.17.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.17.1
-  type: image
-- source: quay.io/cilium/operator-generic:v1.17.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.17.2
-  type: image
-- source: quay.io/cilium/operator-generic:v1.17.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.17.3
-  type: image
-- source: quay.io/cilium/operator-generic:v1.17.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.17.4
-  type: image
-- source: quay.io/cilium/operator-generic:v1.17.5
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.17.5
-  type: image
-- source: quay.io/cilium/operator-generic:v1.17.6
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.17.6
-  type: image
-- source: quay.io/cilium/operator-generic:v1.18.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.18.0
-  type: image
-- source: quay.io/cilium/operator-generic:v1.18.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.18.1
-  type: image
-- source: quay.io/cilium/operator-generic:v1.18.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.18.2
-  type: image
-- source: quay.io/cilium/operator-generic:v1.9.12
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.9.12
-  type: image
-- source: quay.io/cilium/operator-generic:v1.9.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.9.4
-  type: image
-- source: quay.io/cilium/operator-generic:v1.9.6
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.9.6
-  type: image
-- source: quay.io/cilium/operator-generic:v1.9.8
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-operator-generic:v1.9.8
-  type: image
 - source: quay.io/cilium/startup-script:5e928f628f9fc644a1d2651d6cd6aecbde0e7acd
   target: docker.io/rancher/mirrored-cilium-startup-script:5e928f628f9fc644a1d2651d6cd6aecbde0e7acd
   type: image
@@ -27494,15 +16526,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-cilium-startup-script:d69851597ea019af980891a4628fb36b7880ec26
   type: image
 - source: quay.io/cilium/startup-script:5e928f628f9fc644a1d2651d6cd6aecbde0e7acd
-  target: registry.suse.com/rancher/charts/mirrored-cilium-startup-script:5e928f628f9fc644a1d2651d6cd6aecbde0e7acd
-  type: image
-- source: quay.io/cilium/startup-script:62bfbe88c17778aad7bef9fa57ff9e2d4a9ba0d8
-  target: registry.suse.com/rancher/charts/mirrored-cilium-startup-script:62bfbe88c17778aad7bef9fa57ff9e2d4a9ba0d8
-  type: image
-- source: quay.io/cilium/startup-script:d69851597ea019af980891a4628fb36b7880ec26
-  target: registry.suse.com/rancher/charts/mirrored-cilium-startup-script:d69851597ea019af980891a4628fb36b7880ec26
-  type: image
-- source: quay.io/cilium/startup-script:5e928f628f9fc644a1d2651d6cd6aecbde0e7acd
   target: stgregistry.suse.com/rancher/mirrored-cilium-startup-script:5e928f628f9fc644a1d2651d6cd6aecbde0e7acd
   type: image
 - source: quay.io/cilium/startup-script:62bfbe88c17778aad7bef9fa57ff9e2d4a9ba0d8
@@ -27510,15 +16533,6 @@ sync:
   type: image
 - source: quay.io/cilium/startup-script:d69851597ea019af980891a4628fb36b7880ec26
   target: stgregistry.suse.com/rancher/mirrored-cilium-startup-script:d69851597ea019af980891a4628fb36b7880ec26
-  type: image
-- source: quay.io/cilium/startup-script:5e928f628f9fc644a1d2651d6cd6aecbde0e7acd
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-startup-script:5e928f628f9fc644a1d2651d6cd6aecbde0e7acd
-  type: image
-- source: quay.io/cilium/startup-script:62bfbe88c17778aad7bef9fa57ff9e2d4a9ba0d8
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-startup-script:62bfbe88c17778aad7bef9fa57ff9e2d4a9ba0d8
-  type: image
-- source: quay.io/cilium/startup-script:d69851597ea019af980891a4628fb36b7880ec26
-  target: stgregistry.suse.com/rancher/charts/mirrored-cilium-startup-script:d69851597ea019af980891a4628fb36b7880ec26
   type: image
 - source: quay.io/coreos/etcd:v3.5.0
   target: docker.io/rancher/mirrored-coreos-etcd:v3.5.0
@@ -27671,81 +16685,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-coreos-etcd:v3.6.4
   type: image
 - source: quay.io/coreos/etcd:v3.5.0
-  target: registry.suse.com/rancher/charts/mirrored-coreos-etcd:v3.5.0
-  type: image
-- source: quay.io/coreos/etcd:v3.5.10
-  target: registry.suse.com/rancher/charts/mirrored-coreos-etcd:v3.5.10
-  type: image
-- source: quay.io/coreos/etcd:v3.5.11
-  target: registry.suse.com/rancher/charts/mirrored-coreos-etcd:v3.5.11
-  type: image
-- source: quay.io/coreos/etcd:v3.5.12
-  target: registry.suse.com/rancher/charts/mirrored-coreos-etcd:v3.5.12
-  type: image
-- source: quay.io/coreos/etcd:v3.5.13
-  target: registry.suse.com/rancher/charts/mirrored-coreos-etcd:v3.5.13
-  type: image
-- source: quay.io/coreos/etcd:v3.5.14
-  target: registry.suse.com/rancher/charts/mirrored-coreos-etcd:v3.5.14
-  type: image
-- source: quay.io/coreos/etcd:v3.5.15
-  target: registry.suse.com/rancher/charts/mirrored-coreos-etcd:v3.5.15
-  type: image
-- source: quay.io/coreos/etcd:v3.5.16
-  target: registry.suse.com/rancher/charts/mirrored-coreos-etcd:v3.5.16
-  type: image
-- source: quay.io/coreos/etcd:v3.5.17
-  target: registry.suse.com/rancher/charts/mirrored-coreos-etcd:v3.5.17
-  type: image
-- source: quay.io/coreos/etcd:v3.5.18
-  target: registry.suse.com/rancher/charts/mirrored-coreos-etcd:v3.5.18
-  type: image
-- source: quay.io/coreos/etcd:v3.5.19
-  target: registry.suse.com/rancher/charts/mirrored-coreos-etcd:v3.5.19
-  type: image
-- source: quay.io/coreos/etcd:v3.5.2
-  target: registry.suse.com/rancher/charts/mirrored-coreos-etcd:v3.5.2
-  type: image
-- source: quay.io/coreos/etcd:v3.5.20
-  target: registry.suse.com/rancher/charts/mirrored-coreos-etcd:v3.5.20
-  type: image
-- source: quay.io/coreos/etcd:v3.5.21
-  target: registry.suse.com/rancher/charts/mirrored-coreos-etcd:v3.5.21
-  type: image
-- source: quay.io/coreos/etcd:v3.5.22
-  target: registry.suse.com/rancher/charts/mirrored-coreos-etcd:v3.5.22
-  type: image
-- source: quay.io/coreos/etcd:v3.5.3
-  target: registry.suse.com/rancher/charts/mirrored-coreos-etcd:v3.5.3
-  type: image
-- source: quay.io/coreos/etcd:v3.5.4
-  target: registry.suse.com/rancher/charts/mirrored-coreos-etcd:v3.5.4
-  type: image
-- source: quay.io/coreos/etcd:v3.5.6
-  target: registry.suse.com/rancher/charts/mirrored-coreos-etcd:v3.5.6
-  type: image
-- source: quay.io/coreos/etcd:v3.5.7
-  target: registry.suse.com/rancher/charts/mirrored-coreos-etcd:v3.5.7
-  type: image
-- source: quay.io/coreos/etcd:v3.5.9
-  target: registry.suse.com/rancher/charts/mirrored-coreos-etcd:v3.5.9
-  type: image
-- source: quay.io/coreos/etcd:v3.6.0
-  target: registry.suse.com/rancher/charts/mirrored-coreos-etcd:v3.6.0
-  type: image
-- source: quay.io/coreos/etcd:v3.6.1
-  target: registry.suse.com/rancher/charts/mirrored-coreos-etcd:v3.6.1
-  type: image
-- source: quay.io/coreos/etcd:v3.6.2
-  target: registry.suse.com/rancher/charts/mirrored-coreos-etcd:v3.6.2
-  type: image
-- source: quay.io/coreos/etcd:v3.6.3
-  target: registry.suse.com/rancher/charts/mirrored-coreos-etcd:v3.6.3
-  type: image
-- source: quay.io/coreos/etcd:v3.6.4
-  target: registry.suse.com/rancher/charts/mirrored-coreos-etcd:v3.6.4
-  type: image
-- source: quay.io/coreos/etcd:v3.5.0
   target: stgregistry.suse.com/rancher/mirrored-coreos-etcd:v3.5.0
   type: image
 - source: quay.io/coreos/etcd:v3.5.10
@@ -27820,81 +16759,6 @@ sync:
 - source: quay.io/coreos/etcd:v3.6.4
   target: stgregistry.suse.com/rancher/mirrored-coreos-etcd:v3.6.4
   type: image
-- source: quay.io/coreos/etcd:v3.5.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-coreos-etcd:v3.5.0
-  type: image
-- source: quay.io/coreos/etcd:v3.5.10
-  target: stgregistry.suse.com/rancher/charts/mirrored-coreos-etcd:v3.5.10
-  type: image
-- source: quay.io/coreos/etcd:v3.5.11
-  target: stgregistry.suse.com/rancher/charts/mirrored-coreos-etcd:v3.5.11
-  type: image
-- source: quay.io/coreos/etcd:v3.5.12
-  target: stgregistry.suse.com/rancher/charts/mirrored-coreos-etcd:v3.5.12
-  type: image
-- source: quay.io/coreos/etcd:v3.5.13
-  target: stgregistry.suse.com/rancher/charts/mirrored-coreos-etcd:v3.5.13
-  type: image
-- source: quay.io/coreos/etcd:v3.5.14
-  target: stgregistry.suse.com/rancher/charts/mirrored-coreos-etcd:v3.5.14
-  type: image
-- source: quay.io/coreos/etcd:v3.5.15
-  target: stgregistry.suse.com/rancher/charts/mirrored-coreos-etcd:v3.5.15
-  type: image
-- source: quay.io/coreos/etcd:v3.5.16
-  target: stgregistry.suse.com/rancher/charts/mirrored-coreos-etcd:v3.5.16
-  type: image
-- source: quay.io/coreos/etcd:v3.5.17
-  target: stgregistry.suse.com/rancher/charts/mirrored-coreos-etcd:v3.5.17
-  type: image
-- source: quay.io/coreos/etcd:v3.5.18
-  target: stgregistry.suse.com/rancher/charts/mirrored-coreos-etcd:v3.5.18
-  type: image
-- source: quay.io/coreos/etcd:v3.5.19
-  target: stgregistry.suse.com/rancher/charts/mirrored-coreos-etcd:v3.5.19
-  type: image
-- source: quay.io/coreos/etcd:v3.5.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-coreos-etcd:v3.5.2
-  type: image
-- source: quay.io/coreos/etcd:v3.5.20
-  target: stgregistry.suse.com/rancher/charts/mirrored-coreos-etcd:v3.5.20
-  type: image
-- source: quay.io/coreos/etcd:v3.5.21
-  target: stgregistry.suse.com/rancher/charts/mirrored-coreos-etcd:v3.5.21
-  type: image
-- source: quay.io/coreos/etcd:v3.5.22
-  target: stgregistry.suse.com/rancher/charts/mirrored-coreos-etcd:v3.5.22
-  type: image
-- source: quay.io/coreos/etcd:v3.5.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-coreos-etcd:v3.5.3
-  type: image
-- source: quay.io/coreos/etcd:v3.5.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-coreos-etcd:v3.5.4
-  type: image
-- source: quay.io/coreos/etcd:v3.5.6
-  target: stgregistry.suse.com/rancher/charts/mirrored-coreos-etcd:v3.5.6
-  type: image
-- source: quay.io/coreos/etcd:v3.5.7
-  target: stgregistry.suse.com/rancher/charts/mirrored-coreos-etcd:v3.5.7
-  type: image
-- source: quay.io/coreos/etcd:v3.5.9
-  target: stgregistry.suse.com/rancher/charts/mirrored-coreos-etcd:v3.5.9
-  type: image
-- source: quay.io/coreos/etcd:v3.6.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-coreos-etcd:v3.6.0
-  type: image
-- source: quay.io/coreos/etcd:v3.6.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-coreos-etcd:v3.6.1
-  type: image
-- source: quay.io/coreos/etcd:v3.6.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-coreos-etcd:v3.6.2
-  type: image
-- source: quay.io/coreos/etcd:v3.6.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-coreos-etcd:v3.6.3
-  type: image
-- source: quay.io/coreos/etcd:v3.6.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-coreos-etcd:v3.6.4
-  type: image
 - source: quay.io/coreos/flannel:v0.13.0
   target: docker.io/rancher/mirrored-coreos-flannel:v0.13.0
   type: image
@@ -27920,18 +16784,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-coreos-flannel:v0.15.1
   type: image
 - source: quay.io/coreos/flannel:v0.13.0
-  target: registry.suse.com/rancher/charts/mirrored-coreos-flannel:v0.13.0
-  type: image
-- source: quay.io/coreos/flannel:v0.14.0
-  target: registry.suse.com/rancher/charts/mirrored-coreos-flannel:v0.14.0
-  type: image
-- source: quay.io/coreos/flannel:v0.15.0
-  target: registry.suse.com/rancher/charts/mirrored-coreos-flannel:v0.15.0
-  type: image
-- source: quay.io/coreos/flannel:v0.15.1
-  target: registry.suse.com/rancher/charts/mirrored-coreos-flannel:v0.15.1
-  type: image
-- source: quay.io/coreos/flannel:v0.13.0
   target: stgregistry.suse.com/rancher/mirrored-coreos-flannel:v0.13.0
   type: image
 - source: quay.io/coreos/flannel:v0.14.0
@@ -27943,18 +16795,6 @@ sync:
 - source: quay.io/coreos/flannel:v0.15.1
   target: stgregistry.suse.com/rancher/mirrored-coreos-flannel:v0.15.1
   type: image
-- source: quay.io/coreos/flannel:v0.13.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-coreos-flannel:v0.13.0
-  type: image
-- source: quay.io/coreos/flannel:v0.14.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-coreos-flannel:v0.14.0
-  type: image
-- source: quay.io/coreos/flannel:v0.15.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-coreos-flannel:v0.15.0
-  type: image
-- source: quay.io/coreos/flannel:v0.15.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-coreos-flannel:v0.15.1
-  type: image
 - source: quay.io/jetstack/cert-manager-controller:v0.8.1
   target: docker.io/rancher/mirrored-jetstack-cert-manager-controller:v0.8.1
   type: image
@@ -27962,13 +16802,7 @@ sync:
   target: registry.suse.com/rancher/mirrored-jetstack-cert-manager-controller:v0.8.1
   type: image
 - source: quay.io/jetstack/cert-manager-controller:v0.8.1
-  target: registry.suse.com/rancher/charts/mirrored-jetstack-cert-manager-controller:v0.8.1
-  type: image
-- source: quay.io/jetstack/cert-manager-controller:v0.8.1
   target: stgregistry.suse.com/rancher/mirrored-jetstack-cert-manager-controller:v0.8.1
-  type: image
-- source: quay.io/jetstack/cert-manager-controller:v0.8.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-jetstack-cert-manager-controller:v0.8.1
   type: image
 - source: quay.io/kiali/kiali:v1.22.1
   target: docker.io/rancher/kiali-kiali:v1.22.1
@@ -28001,21 +16835,6 @@ sync:
   target: registry.suse.com/rancher/kiali-kiali:v1.29.0
   type: image
 - source: quay.io/kiali/kiali:v1.22.1
-  target: registry.suse.com/rancher/charts/kiali-kiali:v1.22.1
-  type: image
-- source: quay.io/kiali/kiali:v1.23.0
-  target: registry.suse.com/rancher/charts/kiali-kiali:v1.23.0
-  type: image
-- source: quay.io/kiali/kiali:v1.24.0
-  target: registry.suse.com/rancher/charts/kiali-kiali:v1.24.0
-  type: image
-- source: quay.io/kiali/kiali:v1.28.0
-  target: registry.suse.com/rancher/charts/kiali-kiali:v1.28.0
-  type: image
-- source: quay.io/kiali/kiali:v1.29.0
-  target: registry.suse.com/rancher/charts/kiali-kiali:v1.29.0
-  type: image
-- source: quay.io/kiali/kiali:v1.22.1
   target: stgregistry.suse.com/rancher/kiali-kiali:v1.22.1
   type: image
 - source: quay.io/kiali/kiali:v1.23.0
@@ -28029,21 +16848,6 @@ sync:
   type: image
 - source: quay.io/kiali/kiali:v1.29.0
   target: stgregistry.suse.com/rancher/kiali-kiali:v1.29.0
-  type: image
-- source: quay.io/kiali/kiali:v1.22.1
-  target: stgregistry.suse.com/rancher/charts/kiali-kiali:v1.22.1
-  type: image
-- source: quay.io/kiali/kiali:v1.23.0
-  target: stgregistry.suse.com/rancher/charts/kiali-kiali:v1.23.0
-  type: image
-- source: quay.io/kiali/kiali:v1.24.0
-  target: stgregistry.suse.com/rancher/charts/kiali-kiali:v1.24.0
-  type: image
-- source: quay.io/kiali/kiali:v1.28.0
-  target: stgregistry.suse.com/rancher/charts/kiali-kiali:v1.28.0
-  type: image
-- source: quay.io/kiali/kiali:v1.29.0
-  target: stgregistry.suse.com/rancher/charts/kiali-kiali:v1.29.0
   type: image
 - source: quay.io/kiali/kiali:v1.17
   target: docker.io/rancher/mirrored-kiali-kiali:v1.17
@@ -28214,90 +17018,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-kiali-kiali:v2.7.1
   type: image
 - source: quay.io/kiali/kiali:v1.17
-  target: registry.suse.com/rancher/charts/mirrored-kiali-kiali:v1.17
-  type: image
-- source: quay.io/kiali/kiali:v1.29.0
-  target: registry.suse.com/rancher/charts/mirrored-kiali-kiali:v1.29.0
-  type: image
-- source: quay.io/kiali/kiali:v1.32.0
-  target: registry.suse.com/rancher/charts/mirrored-kiali-kiali:v1.32.0
-  type: image
-- source: quay.io/kiali/kiali:v1.34.1
-  target: registry.suse.com/rancher/charts/mirrored-kiali-kiali:v1.34.1
-  type: image
-- source: quay.io/kiali/kiali:v1.35.0
-  target: registry.suse.com/rancher/charts/mirrored-kiali-kiali:v1.35.0
-  type: image
-- source: quay.io/kiali/kiali:v1.40.1
-  target: registry.suse.com/rancher/charts/mirrored-kiali-kiali:v1.40.1
-  type: image
-- source: quay.io/kiali/kiali:v1.41.0
-  target: registry.suse.com/rancher/charts/mirrored-kiali-kiali:v1.41.0
-  type: image
-- source: quay.io/kiali/kiali:v1.44.0
-  target: registry.suse.com/rancher/charts/mirrored-kiali-kiali:v1.44.0
-  type: image
-- source: quay.io/kiali/kiali:v1.50.0
-  target: registry.suse.com/rancher/charts/mirrored-kiali-kiali:v1.50.0
-  type: image
-- source: quay.io/kiali/kiali:v1.52.0
-  target: registry.suse.com/rancher/charts/mirrored-kiali-kiali:v1.52.0
-  type: image
-- source: quay.io/kiali/kiali:v1.55.0
-  target: registry.suse.com/rancher/charts/mirrored-kiali-kiali:v1.55.0
-  type: image
-- source: quay.io/kiali/kiali:v1.57.3
-  target: registry.suse.com/rancher/charts/mirrored-kiali-kiali:v1.57.3
-  type: image
-- source: quay.io/kiali/kiali:v1.59.0
-  target: registry.suse.com/rancher/charts/mirrored-kiali-kiali:v1.59.0
-  type: image
-- source: quay.io/kiali/kiali:v1.63.2
-  target: registry.suse.com/rancher/charts/mirrored-kiali-kiali:v1.63.2
-  type: image
-- source: quay.io/kiali/kiali:v1.66.0
-  target: registry.suse.com/rancher/charts/mirrored-kiali-kiali:v1.66.0
-  type: image
-- source: quay.io/kiali/kiali:v1.67.0
-  target: registry.suse.com/rancher/charts/mirrored-kiali-kiali:v1.67.0
-  type: image
-- source: quay.io/kiali/kiali:v1.72.0
-  target: registry.suse.com/rancher/charts/mirrored-kiali-kiali:v1.72.0
-  type: image
-- source: quay.io/kiali/kiali:v1.74.0
-  target: registry.suse.com/rancher/charts/mirrored-kiali-kiali:v1.74.0
-  type: image
-- source: quay.io/kiali/kiali:v1.75.0
-  target: registry.suse.com/rancher/charts/mirrored-kiali-kiali:v1.75.0
-  type: image
-- source: quay.io/kiali/kiali:v1.76.0
-  target: registry.suse.com/rancher/charts/mirrored-kiali-kiali:v1.76.0
-  type: image
-- source: quay.io/kiali/kiali:v1.78.0
-  target: registry.suse.com/rancher/charts/mirrored-kiali-kiali:v1.78.0
-  type: image
-- source: quay.io/kiali/kiali:v1.79.0
-  target: registry.suse.com/rancher/charts/mirrored-kiali-kiali:v1.79.0
-  type: image
-- source: quay.io/kiali/kiali:v1.85.0
-  target: registry.suse.com/rancher/charts/mirrored-kiali-kiali:v1.85.0
-  type: image
-- source: quay.io/kiali/kiali:v1.86.0
-  target: registry.suse.com/rancher/charts/mirrored-kiali-kiali:v1.86.0
-  type: image
-- source: quay.io/kiali/kiali:v1.89.3
-  target: registry.suse.com/rancher/charts/mirrored-kiali-kiali:v1.89.3
-  type: image
-- source: quay.io/kiali/kiali:v2.1.0
-  target: registry.suse.com/rancher/charts/mirrored-kiali-kiali:v2.1.0
-  type: image
-- source: quay.io/kiali/kiali:v2.12.0
-  target: registry.suse.com/rancher/charts/mirrored-kiali-kiali:v2.12.0
-  type: image
-- source: quay.io/kiali/kiali:v2.7.1
-  target: registry.suse.com/rancher/charts/mirrored-kiali-kiali:v2.7.1
-  type: image
-- source: quay.io/kiali/kiali:v1.17
   target: stgregistry.suse.com/rancher/mirrored-kiali-kiali:v1.17
   type: image
 - source: quay.io/kiali/kiali:v1.29.0
@@ -28381,90 +17101,6 @@ sync:
 - source: quay.io/kiali/kiali:v2.7.1
   target: stgregistry.suse.com/rancher/mirrored-kiali-kiali:v2.7.1
   type: image
-- source: quay.io/kiali/kiali:v1.17
-  target: stgregistry.suse.com/rancher/charts/mirrored-kiali-kiali:v1.17
-  type: image
-- source: quay.io/kiali/kiali:v1.29.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-kiali-kiali:v1.29.0
-  type: image
-- source: quay.io/kiali/kiali:v1.32.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-kiali-kiali:v1.32.0
-  type: image
-- source: quay.io/kiali/kiali:v1.34.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-kiali-kiali:v1.34.1
-  type: image
-- source: quay.io/kiali/kiali:v1.35.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-kiali-kiali:v1.35.0
-  type: image
-- source: quay.io/kiali/kiali:v1.40.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-kiali-kiali:v1.40.1
-  type: image
-- source: quay.io/kiali/kiali:v1.41.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-kiali-kiali:v1.41.0
-  type: image
-- source: quay.io/kiali/kiali:v1.44.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-kiali-kiali:v1.44.0
-  type: image
-- source: quay.io/kiali/kiali:v1.50.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-kiali-kiali:v1.50.0
-  type: image
-- source: quay.io/kiali/kiali:v1.52.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-kiali-kiali:v1.52.0
-  type: image
-- source: quay.io/kiali/kiali:v1.55.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-kiali-kiali:v1.55.0
-  type: image
-- source: quay.io/kiali/kiali:v1.57.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-kiali-kiali:v1.57.3
-  type: image
-- source: quay.io/kiali/kiali:v1.59.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-kiali-kiali:v1.59.0
-  type: image
-- source: quay.io/kiali/kiali:v1.63.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-kiali-kiali:v1.63.2
-  type: image
-- source: quay.io/kiali/kiali:v1.66.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-kiali-kiali:v1.66.0
-  type: image
-- source: quay.io/kiali/kiali:v1.67.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-kiali-kiali:v1.67.0
-  type: image
-- source: quay.io/kiali/kiali:v1.72.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-kiali-kiali:v1.72.0
-  type: image
-- source: quay.io/kiali/kiali:v1.74.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-kiali-kiali:v1.74.0
-  type: image
-- source: quay.io/kiali/kiali:v1.75.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-kiali-kiali:v1.75.0
-  type: image
-- source: quay.io/kiali/kiali:v1.76.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-kiali-kiali:v1.76.0
-  type: image
-- source: quay.io/kiali/kiali:v1.78.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-kiali-kiali:v1.78.0
-  type: image
-- source: quay.io/kiali/kiali:v1.79.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-kiali-kiali:v1.79.0
-  type: image
-- source: quay.io/kiali/kiali:v1.85.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-kiali-kiali:v1.85.0
-  type: image
-- source: quay.io/kiali/kiali:v1.86.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-kiali-kiali:v1.86.0
-  type: image
-- source: quay.io/kiali/kiali:v1.89.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-kiali-kiali:v1.89.3
-  type: image
-- source: quay.io/kiali/kiali:v2.1.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-kiali-kiali:v2.1.0
-  type: image
-- source: quay.io/kiali/kiali:v2.12.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-kiali-kiali:v2.12.0
-  type: image
-- source: quay.io/kiali/kiali:v2.7.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-kiali-kiali:v2.7.1
-  type: image
 - source: quay.io/kiwigrid/k8s-sidecar:1.10.7
   target: docker.io/rancher/mirrored-kiwigrid-k8s-sidecar:1.10.7
   type: image
@@ -28526,36 +17162,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-kiwigrid-k8s-sidecar:1.30.0
   type: image
 - source: quay.io/kiwigrid/k8s-sidecar:1.10.7
-  target: registry.suse.com/rancher/charts/mirrored-kiwigrid-k8s-sidecar:1.10.7
-  type: image
-- source: quay.io/kiwigrid/k8s-sidecar:1.12.2
-  target: registry.suse.com/rancher/charts/mirrored-kiwigrid-k8s-sidecar:1.12.2
-  type: image
-- source: quay.io/kiwigrid/k8s-sidecar:1.12.3
-  target: registry.suse.com/rancher/charts/mirrored-kiwigrid-k8s-sidecar:1.12.3
-  type: image
-- source: quay.io/kiwigrid/k8s-sidecar:1.15.6
-  target: registry.suse.com/rancher/charts/mirrored-kiwigrid-k8s-sidecar:1.15.6
-  type: image
-- source: quay.io/kiwigrid/k8s-sidecar:1.15.9
-  target: registry.suse.com/rancher/charts/mirrored-kiwigrid-k8s-sidecar:1.15.9
-  type: image
-- source: quay.io/kiwigrid/k8s-sidecar:1.19.2
-  target: registry.suse.com/rancher/charts/mirrored-kiwigrid-k8s-sidecar:1.19.2
-  type: image
-- source: quay.io/kiwigrid/k8s-sidecar:1.24.6
-  target: registry.suse.com/rancher/charts/mirrored-kiwigrid-k8s-sidecar:1.24.6
-  type: image
-- source: quay.io/kiwigrid/k8s-sidecar:1.26.1
-  target: registry.suse.com/rancher/charts/mirrored-kiwigrid-k8s-sidecar:1.26.1
-  type: image
-- source: quay.io/kiwigrid/k8s-sidecar:1.28.0
-  target: registry.suse.com/rancher/charts/mirrored-kiwigrid-k8s-sidecar:1.28.0
-  type: image
-- source: quay.io/kiwigrid/k8s-sidecar:1.30.0
-  target: registry.suse.com/rancher/charts/mirrored-kiwigrid-k8s-sidecar:1.30.0
-  type: image
-- source: quay.io/kiwigrid/k8s-sidecar:1.10.7
   target: stgregistry.suse.com/rancher/mirrored-kiwigrid-k8s-sidecar:1.10.7
   type: image
 - source: quay.io/kiwigrid/k8s-sidecar:1.12.2
@@ -28585,36 +17191,6 @@ sync:
 - source: quay.io/kiwigrid/k8s-sidecar:1.30.0
   target: stgregistry.suse.com/rancher/mirrored-kiwigrid-k8s-sidecar:1.30.0
   type: image
-- source: quay.io/kiwigrid/k8s-sidecar:1.10.7
-  target: stgregistry.suse.com/rancher/charts/mirrored-kiwigrid-k8s-sidecar:1.10.7
-  type: image
-- source: quay.io/kiwigrid/k8s-sidecar:1.12.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-kiwigrid-k8s-sidecar:1.12.2
-  type: image
-- source: quay.io/kiwigrid/k8s-sidecar:1.12.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-kiwigrid-k8s-sidecar:1.12.3
-  type: image
-- source: quay.io/kiwigrid/k8s-sidecar:1.15.6
-  target: stgregistry.suse.com/rancher/charts/mirrored-kiwigrid-k8s-sidecar:1.15.6
-  type: image
-- source: quay.io/kiwigrid/k8s-sidecar:1.15.9
-  target: stgregistry.suse.com/rancher/charts/mirrored-kiwigrid-k8s-sidecar:1.15.9
-  type: image
-- source: quay.io/kiwigrid/k8s-sidecar:1.19.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-kiwigrid-k8s-sidecar:1.19.2
-  type: image
-- source: quay.io/kiwigrid/k8s-sidecar:1.24.6
-  target: stgregistry.suse.com/rancher/charts/mirrored-kiwigrid-k8s-sidecar:1.24.6
-  type: image
-- source: quay.io/kiwigrid/k8s-sidecar:1.26.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-kiwigrid-k8s-sidecar:1.26.1
-  type: image
-- source: quay.io/kiwigrid/k8s-sidecar:1.28.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-kiwigrid-k8s-sidecar:1.28.0
-  type: image
-- source: quay.io/kiwigrid/k8s-sidecar:1.30.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-kiwigrid-k8s-sidecar:1.30.0
-  type: image
 - source: quay.io/minio/minio:RELEASE.2022-03-24T00-43-44Z
   target: docker.io/rancher/mirrored-minio-minio:RELEASE.2022-03-24T00-43-44Z
   type: image
@@ -28622,13 +17198,7 @@ sync:
   target: registry.suse.com/rancher/mirrored-minio-minio:RELEASE.2022-03-24T00-43-44Z
   type: image
 - source: quay.io/minio/minio:RELEASE.2022-03-24T00-43-44Z
-  target: registry.suse.com/rancher/charts/mirrored-minio-minio:RELEASE.2022-03-24T00-43-44Z
-  type: image
-- source: quay.io/minio/minio:RELEASE.2022-03-24T00-43-44Z
   target: stgregistry.suse.com/rancher/mirrored-minio-minio:RELEASE.2022-03-24T00-43-44Z
-  type: image
-- source: quay.io/minio/minio:RELEASE.2022-03-24T00-43-44Z
-  target: stgregistry.suse.com/rancher/charts/mirrored-minio-minio:RELEASE.2022-03-24T00-43-44Z
   type: image
 - source: quay.io/prometheus-operator/admission-webhook:v0.72.0
   target: docker.io/rancher/mirrored-prometheus-operator-admission-webhook:v0.72.0
@@ -28667,24 +17237,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-prometheus-operator-admission-webhook:v0.85.0
   type: image
 - source: quay.io/prometheus-operator/admission-webhook:v0.72.0
-  target: registry.suse.com/rancher/charts/mirrored-prometheus-operator-admission-webhook:v0.72.0
-  type: image
-- source: quay.io/prometheus-operator/admission-webhook:v0.75.1
-  target: registry.suse.com/rancher/charts/mirrored-prometheus-operator-admission-webhook:v0.75.1
-  type: image
-- source: quay.io/prometheus-operator/admission-webhook:v0.77.2
-  target: registry.suse.com/rancher/charts/mirrored-prometheus-operator-admission-webhook:v0.77.2
-  type: image
-- source: quay.io/prometheus-operator/admission-webhook:v0.79.0
-  target: registry.suse.com/rancher/charts/mirrored-prometheus-operator-admission-webhook:v0.79.0
-  type: image
-- source: quay.io/prometheus-operator/admission-webhook:v0.80.1
-  target: registry.suse.com/rancher/charts/mirrored-prometheus-operator-admission-webhook:v0.80.1
-  type: image
-- source: quay.io/prometheus-operator/admission-webhook:v0.85.0
-  target: registry.suse.com/rancher/charts/mirrored-prometheus-operator-admission-webhook:v0.85.0
-  type: image
-- source: quay.io/prometheus-operator/admission-webhook:v0.72.0
   target: stgregistry.suse.com/rancher/mirrored-prometheus-operator-admission-webhook:v0.72.0
   type: image
 - source: quay.io/prometheus-operator/admission-webhook:v0.75.1
@@ -28702,24 +17254,6 @@ sync:
 - source: quay.io/prometheus-operator/admission-webhook:v0.85.0
   target: stgregistry.suse.com/rancher/mirrored-prometheus-operator-admission-webhook:v0.85.0
   type: image
-- source: quay.io/prometheus-operator/admission-webhook:v0.72.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-operator-admission-webhook:v0.72.0
-  type: image
-- source: quay.io/prometheus-operator/admission-webhook:v0.75.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-operator-admission-webhook:v0.75.1
-  type: image
-- source: quay.io/prometheus-operator/admission-webhook:v0.77.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-operator-admission-webhook:v0.77.2
-  type: image
-- source: quay.io/prometheus-operator/admission-webhook:v0.79.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-operator-admission-webhook:v0.79.0
-  type: image
-- source: quay.io/prometheus-operator/admission-webhook:v0.80.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-operator-admission-webhook:v0.80.1
-  type: image
-- source: quay.io/prometheus-operator/admission-webhook:v0.85.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-operator-admission-webhook:v0.85.0
-  type: image
 - source: quay.io/prometheus-operator/prometheus-config-reloader:v0.43.0
   target: docker.io/rancher/coreos-prometheus-config-reloader:v0.43.0
   type: image
@@ -28727,13 +17261,7 @@ sync:
   target: registry.suse.com/rancher/coreos-prometheus-config-reloader:v0.43.0
   type: image
 - source: quay.io/prometheus-operator/prometheus-config-reloader:v0.43.0
-  target: registry.suse.com/rancher/charts/coreos-prometheus-config-reloader:v0.43.0
-  type: image
-- source: quay.io/prometheus-operator/prometheus-config-reloader:v0.43.0
   target: stgregistry.suse.com/rancher/coreos-prometheus-config-reloader:v0.43.0
-  type: image
-- source: quay.io/prometheus-operator/prometheus-config-reloader:v0.43.0
-  target: stgregistry.suse.com/rancher/charts/coreos-prometheus-config-reloader:v0.43.0
   type: image
 - source: quay.io/prometheus-operator/prometheus-config-reloader:v0.46.0
   target: docker.io/rancher/mirrored-prometheus-operator-prometheus-config-reloader:v0.46.0
@@ -28814,45 +17342,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-prometheus-operator-prometheus-config-reloader:v0.85.0
   type: image
 - source: quay.io/prometheus-operator/prometheus-config-reloader:v0.46.0
-  target: registry.suse.com/rancher/charts/mirrored-prometheus-operator-prometheus-config-reloader:v0.46.0
-  type: image
-- source: quay.io/prometheus-operator/prometheus-config-reloader:v0.48.0
-  target: registry.suse.com/rancher/charts/mirrored-prometheus-operator-prometheus-config-reloader:v0.48.0
-  type: image
-- source: quay.io/prometheus-operator/prometheus-config-reloader:v0.50.0
-  target: registry.suse.com/rancher/charts/mirrored-prometheus-operator-prometheus-config-reloader:v0.50.0
-  type: image
-- source: quay.io/prometheus-operator/prometheus-config-reloader:v0.59.1
-  target: registry.suse.com/rancher/charts/mirrored-prometheus-operator-prometheus-config-reloader:v0.59.1
-  type: image
-- source: quay.io/prometheus-operator/prometheus-config-reloader:v0.65.1
-  target: registry.suse.com/rancher/charts/mirrored-prometheus-operator-prometheus-config-reloader:v0.65.1
-  type: image
-- source: quay.io/prometheus-operator/prometheus-config-reloader:v0.70.0
-  target: registry.suse.com/rancher/charts/mirrored-prometheus-operator-prometheus-config-reloader:v0.70.0
-  type: image
-- source: quay.io/prometheus-operator/prometheus-config-reloader:v0.72.0
-  target: registry.suse.com/rancher/charts/mirrored-prometheus-operator-prometheus-config-reloader:v0.72.0
-  type: image
-- source: quay.io/prometheus-operator/prometheus-config-reloader:v0.75.1
-  target: registry.suse.com/rancher/charts/mirrored-prometheus-operator-prometheus-config-reloader:v0.75.1
-  type: image
-- source: quay.io/prometheus-operator/prometheus-config-reloader:v0.77.2
-  target: registry.suse.com/rancher/charts/mirrored-prometheus-operator-prometheus-config-reloader:v0.77.2
-  type: image
-- source: quay.io/prometheus-operator/prometheus-config-reloader:v0.79.0
-  target: registry.suse.com/rancher/charts/mirrored-prometheus-operator-prometheus-config-reloader:v0.79.0
-  type: image
-- source: quay.io/prometheus-operator/prometheus-config-reloader:v0.79.2
-  target: registry.suse.com/rancher/charts/mirrored-prometheus-operator-prometheus-config-reloader:v0.79.2
-  type: image
-- source: quay.io/prometheus-operator/prometheus-config-reloader:v0.80.1
-  target: registry.suse.com/rancher/charts/mirrored-prometheus-operator-prometheus-config-reloader:v0.80.1
-  type: image
-- source: quay.io/prometheus-operator/prometheus-config-reloader:v0.85.0
-  target: registry.suse.com/rancher/charts/mirrored-prometheus-operator-prometheus-config-reloader:v0.85.0
-  type: image
-- source: quay.io/prometheus-operator/prometheus-config-reloader:v0.46.0
   target: stgregistry.suse.com/rancher/mirrored-prometheus-operator-prometheus-config-reloader:v0.46.0
   type: image
 - source: quay.io/prometheus-operator/prometheus-config-reloader:v0.48.0
@@ -28891,45 +17380,6 @@ sync:
 - source: quay.io/prometheus-operator/prometheus-config-reloader:v0.85.0
   target: stgregistry.suse.com/rancher/mirrored-prometheus-operator-prometheus-config-reloader:v0.85.0
   type: image
-- source: quay.io/prometheus-operator/prometheus-config-reloader:v0.46.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-operator-prometheus-config-reloader:v0.46.0
-  type: image
-- source: quay.io/prometheus-operator/prometheus-config-reloader:v0.48.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-operator-prometheus-config-reloader:v0.48.0
-  type: image
-- source: quay.io/prometheus-operator/prometheus-config-reloader:v0.50.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-operator-prometheus-config-reloader:v0.50.0
-  type: image
-- source: quay.io/prometheus-operator/prometheus-config-reloader:v0.59.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-operator-prometheus-config-reloader:v0.59.1
-  type: image
-- source: quay.io/prometheus-operator/prometheus-config-reloader:v0.65.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-operator-prometheus-config-reloader:v0.65.1
-  type: image
-- source: quay.io/prometheus-operator/prometheus-config-reloader:v0.70.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-operator-prometheus-config-reloader:v0.70.0
-  type: image
-- source: quay.io/prometheus-operator/prometheus-config-reloader:v0.72.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-operator-prometheus-config-reloader:v0.72.0
-  type: image
-- source: quay.io/prometheus-operator/prometheus-config-reloader:v0.75.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-operator-prometheus-config-reloader:v0.75.1
-  type: image
-- source: quay.io/prometheus-operator/prometheus-config-reloader:v0.77.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-operator-prometheus-config-reloader:v0.77.2
-  type: image
-- source: quay.io/prometheus-operator/prometheus-config-reloader:v0.79.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-operator-prometheus-config-reloader:v0.79.0
-  type: image
-- source: quay.io/prometheus-operator/prometheus-config-reloader:v0.79.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-operator-prometheus-config-reloader:v0.79.2
-  type: image
-- source: quay.io/prometheus-operator/prometheus-config-reloader:v0.80.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-operator-prometheus-config-reloader:v0.80.1
-  type: image
-- source: quay.io/prometheus-operator/prometheus-config-reloader:v0.85.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-operator-prometheus-config-reloader:v0.85.0
-  type: image
 - source: quay.io/prometheus-operator/prometheus-operator:v0.43.0
   target: docker.io/rancher/coreos-prometheus-operator:v0.43.0
   type: image
@@ -28937,13 +17387,7 @@ sync:
   target: registry.suse.com/rancher/coreos-prometheus-operator:v0.43.0
   type: image
 - source: quay.io/prometheus-operator/prometheus-operator:v0.43.0
-  target: registry.suse.com/rancher/charts/coreos-prometheus-operator:v0.43.0
-  type: image
-- source: quay.io/prometheus-operator/prometheus-operator:v0.43.0
   target: stgregistry.suse.com/rancher/coreos-prometheus-operator:v0.43.0
-  type: image
-- source: quay.io/prometheus-operator/prometheus-operator:v0.43.0
-  target: stgregistry.suse.com/rancher/charts/coreos-prometheus-operator:v0.43.0
   type: image
 - source: quay.io/prometheus-operator/prometheus-operator:v0.46.0
   target: docker.io/rancher/mirrored-prometheus-operator-prometheus-operator:v0.46.0
@@ -29024,45 +17468,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-prometheus-operator-prometheus-operator:v0.85.0
   type: image
 - source: quay.io/prometheus-operator/prometheus-operator:v0.46.0
-  target: registry.suse.com/rancher/charts/mirrored-prometheus-operator-prometheus-operator:v0.46.0
-  type: image
-- source: quay.io/prometheus-operator/prometheus-operator:v0.48.0
-  target: registry.suse.com/rancher/charts/mirrored-prometheus-operator-prometheus-operator:v0.48.0
-  type: image
-- source: quay.io/prometheus-operator/prometheus-operator:v0.50.0
-  target: registry.suse.com/rancher/charts/mirrored-prometheus-operator-prometheus-operator:v0.50.0
-  type: image
-- source: quay.io/prometheus-operator/prometheus-operator:v0.59.1
-  target: registry.suse.com/rancher/charts/mirrored-prometheus-operator-prometheus-operator:v0.59.1
-  type: image
-- source: quay.io/prometheus-operator/prometheus-operator:v0.65.1
-  target: registry.suse.com/rancher/charts/mirrored-prometheus-operator-prometheus-operator:v0.65.1
-  type: image
-- source: quay.io/prometheus-operator/prometheus-operator:v0.70.0
-  target: registry.suse.com/rancher/charts/mirrored-prometheus-operator-prometheus-operator:v0.70.0
-  type: image
-- source: quay.io/prometheus-operator/prometheus-operator:v0.72.0
-  target: registry.suse.com/rancher/charts/mirrored-prometheus-operator-prometheus-operator:v0.72.0
-  type: image
-- source: quay.io/prometheus-operator/prometheus-operator:v0.75.1
-  target: registry.suse.com/rancher/charts/mirrored-prometheus-operator-prometheus-operator:v0.75.1
-  type: image
-- source: quay.io/prometheus-operator/prometheus-operator:v0.77.2
-  target: registry.suse.com/rancher/charts/mirrored-prometheus-operator-prometheus-operator:v0.77.2
-  type: image
-- source: quay.io/prometheus-operator/prometheus-operator:v0.79.0
-  target: registry.suse.com/rancher/charts/mirrored-prometheus-operator-prometheus-operator:v0.79.0
-  type: image
-- source: quay.io/prometheus-operator/prometheus-operator:v0.79.2
-  target: registry.suse.com/rancher/charts/mirrored-prometheus-operator-prometheus-operator:v0.79.2
-  type: image
-- source: quay.io/prometheus-operator/prometheus-operator:v0.80.1
-  target: registry.suse.com/rancher/charts/mirrored-prometheus-operator-prometheus-operator:v0.80.1
-  type: image
-- source: quay.io/prometheus-operator/prometheus-operator:v0.85.0
-  target: registry.suse.com/rancher/charts/mirrored-prometheus-operator-prometheus-operator:v0.85.0
-  type: image
-- source: quay.io/prometheus-operator/prometheus-operator:v0.46.0
   target: stgregistry.suse.com/rancher/mirrored-prometheus-operator-prometheus-operator:v0.46.0
   type: image
 - source: quay.io/prometheus-operator/prometheus-operator:v0.48.0
@@ -29100,45 +17505,6 @@ sync:
   type: image
 - source: quay.io/prometheus-operator/prometheus-operator:v0.85.0
   target: stgregistry.suse.com/rancher/mirrored-prometheus-operator-prometheus-operator:v0.85.0
-  type: image
-- source: quay.io/prometheus-operator/prometheus-operator:v0.46.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-operator-prometheus-operator:v0.46.0
-  type: image
-- source: quay.io/prometheus-operator/prometheus-operator:v0.48.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-operator-prometheus-operator:v0.48.0
-  type: image
-- source: quay.io/prometheus-operator/prometheus-operator:v0.50.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-operator-prometheus-operator:v0.50.0
-  type: image
-- source: quay.io/prometheus-operator/prometheus-operator:v0.59.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-operator-prometheus-operator:v0.59.1
-  type: image
-- source: quay.io/prometheus-operator/prometheus-operator:v0.65.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-operator-prometheus-operator:v0.65.1
-  type: image
-- source: quay.io/prometheus-operator/prometheus-operator:v0.70.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-operator-prometheus-operator:v0.70.0
-  type: image
-- source: quay.io/prometheus-operator/prometheus-operator:v0.72.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-operator-prometheus-operator:v0.72.0
-  type: image
-- source: quay.io/prometheus-operator/prometheus-operator:v0.75.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-operator-prometheus-operator:v0.75.1
-  type: image
-- source: quay.io/prometheus-operator/prometheus-operator:v0.77.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-operator-prometheus-operator:v0.77.2
-  type: image
-- source: quay.io/prometheus-operator/prometheus-operator:v0.79.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-operator-prometheus-operator:v0.79.0
-  type: image
-- source: quay.io/prometheus-operator/prometheus-operator:v0.79.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-operator-prometheus-operator:v0.79.2
-  type: image
-- source: quay.io/prometheus-operator/prometheus-operator:v0.80.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-operator-prometheus-operator:v0.80.1
-  type: image
-- source: quay.io/prometheus-operator/prometheus-operator:v0.85.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-operator-prometheus-operator:v0.85.0
   type: image
 - source: quay.io/prometheus/alertmanager:v0.22.0
   target: docker.io/rancher/mirrored-prometheus-alertmanager:v0.22.0
@@ -29183,27 +17549,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-prometheus-alertmanager:v0.28.1
   type: image
 - source: quay.io/prometheus/alertmanager:v0.22.0
-  target: registry.suse.com/rancher/charts/mirrored-prometheus-alertmanager:v0.22.0
-  type: image
-- source: quay.io/prometheus/alertmanager:v0.22.2
-  target: registry.suse.com/rancher/charts/mirrored-prometheus-alertmanager:v0.22.2
-  type: image
-- source: quay.io/prometheus/alertmanager:v0.24.0
-  target: registry.suse.com/rancher/charts/mirrored-prometheus-alertmanager:v0.24.0
-  type: image
-- source: quay.io/prometheus/alertmanager:v0.25.0
-  target: registry.suse.com/rancher/charts/mirrored-prometheus-alertmanager:v0.25.0
-  type: image
-- source: quay.io/prometheus/alertmanager:v0.26.0
-  target: registry.suse.com/rancher/charts/mirrored-prometheus-alertmanager:v0.26.0
-  type: image
-- source: quay.io/prometheus/alertmanager:v0.27.0
-  target: registry.suse.com/rancher/charts/mirrored-prometheus-alertmanager:v0.27.0
-  type: image
-- source: quay.io/prometheus/alertmanager:v0.28.1
-  target: registry.suse.com/rancher/charts/mirrored-prometheus-alertmanager:v0.28.1
-  type: image
-- source: quay.io/prometheus/alertmanager:v0.22.0
   target: stgregistry.suse.com/rancher/mirrored-prometheus-alertmanager:v0.22.0
   type: image
 - source: quay.io/prometheus/alertmanager:v0.22.2
@@ -29223,27 +17568,6 @@ sync:
   type: image
 - source: quay.io/prometheus/alertmanager:v0.28.1
   target: stgregistry.suse.com/rancher/mirrored-prometheus-alertmanager:v0.28.1
-  type: image
-- source: quay.io/prometheus/alertmanager:v0.22.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-alertmanager:v0.22.0
-  type: image
-- source: quay.io/prometheus/alertmanager:v0.22.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-alertmanager:v0.22.2
-  type: image
-- source: quay.io/prometheus/alertmanager:v0.24.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-alertmanager:v0.24.0
-  type: image
-- source: quay.io/prometheus/alertmanager:v0.25.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-alertmanager:v0.25.0
-  type: image
-- source: quay.io/prometheus/alertmanager:v0.26.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-alertmanager:v0.26.0
-  type: image
-- source: quay.io/prometheus/alertmanager:v0.27.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-alertmanager:v0.27.0
-  type: image
-- source: quay.io/prometheus/alertmanager:v0.28.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-alertmanager:v0.28.1
   type: image
 - source: quay.io/prometheus/node-exporter:v1.1.2
   target: docker.io/rancher/mirrored-prometheus-node-exporter:v1.1.2
@@ -29288,27 +17612,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-prometheus-node-exporter:v1.9.1
   type: image
 - source: quay.io/prometheus/node-exporter:v1.1.2
-  target: registry.suse.com/rancher/charts/mirrored-prometheus-node-exporter:v1.1.2
-  type: image
-- source: quay.io/prometheus/node-exporter:v1.2.2
-  target: registry.suse.com/rancher/charts/mirrored-prometheus-node-exporter:v1.2.2
-  type: image
-- source: quay.io/prometheus/node-exporter:v1.3.1
-  target: registry.suse.com/rancher/charts/mirrored-prometheus-node-exporter:v1.3.1
-  type: image
-- source: quay.io/prometheus/node-exporter:v1.7.0
-  target: registry.suse.com/rancher/charts/mirrored-prometheus-node-exporter:v1.7.0
-  type: image
-- source: quay.io/prometheus/node-exporter:v1.8.2
-  target: registry.suse.com/rancher/charts/mirrored-prometheus-node-exporter:v1.8.2
-  type: image
-- source: quay.io/prometheus/node-exporter:v1.9.0
-  target: registry.suse.com/rancher/charts/mirrored-prometheus-node-exporter:v1.9.0
-  type: image
-- source: quay.io/prometheus/node-exporter:v1.9.1
-  target: registry.suse.com/rancher/charts/mirrored-prometheus-node-exporter:v1.9.1
-  type: image
-- source: quay.io/prometheus/node-exporter:v1.1.2
   target: stgregistry.suse.com/rancher/mirrored-prometheus-node-exporter:v1.1.2
   type: image
 - source: quay.io/prometheus/node-exporter:v1.2.2
@@ -29329,27 +17632,6 @@ sync:
 - source: quay.io/prometheus/node-exporter:v1.9.1
   target: stgregistry.suse.com/rancher/mirrored-prometheus-node-exporter:v1.9.1
   type: image
-- source: quay.io/prometheus/node-exporter:v1.1.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-node-exporter:v1.1.2
-  type: image
-- source: quay.io/prometheus/node-exporter:v1.2.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-node-exporter:v1.2.2
-  type: image
-- source: quay.io/prometheus/node-exporter:v1.3.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-node-exporter:v1.3.1
-  type: image
-- source: quay.io/prometheus/node-exporter:v1.7.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-node-exporter:v1.7.0
-  type: image
-- source: quay.io/prometheus/node-exporter:v1.8.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-node-exporter:v1.8.2
-  type: image
-- source: quay.io/prometheus/node-exporter:v1.9.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-node-exporter:v1.9.0
-  type: image
-- source: quay.io/prometheus/node-exporter:v1.9.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-node-exporter:v1.9.1
-  type: image
 - source: quay.io/prometheus/prometheus:v2.18.2
   target: docker.io/rancher/mirrored-prom-prometheus:v2.18.2
   type: image
@@ -29357,13 +17639,7 @@ sync:
   target: registry.suse.com/rancher/mirrored-prom-prometheus:v2.18.2
   type: image
 - source: quay.io/prometheus/prometheus:v2.18.2
-  target: registry.suse.com/rancher/charts/mirrored-prom-prometheus:v2.18.2
-  type: image
-- source: quay.io/prometheus/prometheus:v2.18.2
   target: stgregistry.suse.com/rancher/mirrored-prom-prometheus:v2.18.2
-  type: image
-- source: quay.io/prometheus/prometheus:v2.18.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-prom-prometheus:v2.18.2
   type: image
 - source: quay.io/prometheus/prometheus:v2.24.0
   target: docker.io/rancher/mirrored-prometheus-prometheus:v2.24.0
@@ -29426,36 +17702,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-prometheus-prometheus:v2.55.0
   type: image
 - source: quay.io/prometheus/prometheus:v2.24.0
-  target: registry.suse.com/rancher/charts/mirrored-prometheus-prometheus:v2.24.0
-  type: image
-- source: quay.io/prometheus/prometheus:v2.27.1
-  target: registry.suse.com/rancher/charts/mirrored-prometheus-prometheus:v2.27.1
-  type: image
-- source: quay.io/prometheus/prometheus:v2.28.1
-  target: registry.suse.com/rancher/charts/mirrored-prometheus-prometheus:v2.28.1
-  type: image
-- source: quay.io/prometheus/prometheus:v2.38.0
-  target: registry.suse.com/rancher/charts/mirrored-prometheus-prometheus:v2.38.0
-  type: image
-- source: quay.io/prometheus/prometheus:v2.42.0
-  target: registry.suse.com/rancher/charts/mirrored-prometheus-prometheus:v2.42.0
-  type: image
-- source: quay.io/prometheus/prometheus:v2.45.0
-  target: registry.suse.com/rancher/charts/mirrored-prometheus-prometheus:v2.45.0
-  type: image
-- source: quay.io/prometheus/prometheus:v2.48.1
-  target: registry.suse.com/rancher/charts/mirrored-prometheus-prometheus:v2.48.1
-  type: image
-- source: quay.io/prometheus/prometheus:v2.50.1
-  target: registry.suse.com/rancher/charts/mirrored-prometheus-prometheus:v2.50.1
-  type: image
-- source: quay.io/prometheus/prometheus:v2.53.1
-  target: registry.suse.com/rancher/charts/mirrored-prometheus-prometheus:v2.53.1
-  type: image
-- source: quay.io/prometheus/prometheus:v2.55.0
-  target: registry.suse.com/rancher/charts/mirrored-prometheus-prometheus:v2.55.0
-  type: image
-- source: quay.io/prometheus/prometheus:v2.24.0
   target: stgregistry.suse.com/rancher/mirrored-prometheus-prometheus:v2.24.0
   type: image
 - source: quay.io/prometheus/prometheus:v2.27.1
@@ -29484,36 +17730,6 @@ sync:
   type: image
 - source: quay.io/prometheus/prometheus:v2.55.0
   target: stgregistry.suse.com/rancher/mirrored-prometheus-prometheus:v2.55.0
-  type: image
-- source: quay.io/prometheus/prometheus:v2.24.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-prometheus:v2.24.0
-  type: image
-- source: quay.io/prometheus/prometheus:v2.27.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-prometheus:v2.27.1
-  type: image
-- source: quay.io/prometheus/prometheus:v2.28.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-prometheus:v2.28.1
-  type: image
-- source: quay.io/prometheus/prometheus:v2.38.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-prometheus:v2.38.0
-  type: image
-- source: quay.io/prometheus/prometheus:v2.42.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-prometheus:v2.42.0
-  type: image
-- source: quay.io/prometheus/prometheus:v2.45.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-prometheus:v2.45.0
-  type: image
-- source: quay.io/prometheus/prometheus:v2.48.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-prometheus:v2.48.1
-  type: image
-- source: quay.io/prometheus/prometheus:v2.50.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-prometheus:v2.50.1
-  type: image
-- source: quay.io/prometheus/prometheus:v2.53.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-prometheus:v2.53.1
-  type: image
-- source: quay.io/prometheus/prometheus:v2.55.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-prometheus:v2.55.0
   type: image
 - source: quay.io/prometheus/prometheus:v2.19.2
   target: docker.io/rancher/prom-prometheus:v2.19.2
@@ -29546,21 +17762,6 @@ sync:
   target: registry.suse.com/rancher/prom-prometheus:v3.5.0
   type: image
 - source: quay.io/prometheus/prometheus:v2.19.2
-  target: registry.suse.com/rancher/charts/prom-prometheus:v2.19.2
-  type: image
-- source: quay.io/prometheus/prometheus:v2.22.0
-  target: registry.suse.com/rancher/charts/prom-prometheus:v2.22.0
-  type: image
-- source: quay.io/prometheus/prometheus:v2.55.1
-  target: registry.suse.com/rancher/charts/prom-prometheus:v2.55.1
-  type: image
-- source: quay.io/prometheus/prometheus:v3.2.1
-  target: registry.suse.com/rancher/charts/prom-prometheus:v3.2.1
-  type: image
-- source: quay.io/prometheus/prometheus:v3.5.0
-  target: registry.suse.com/rancher/charts/prom-prometheus:v3.5.0
-  type: image
-- source: quay.io/prometheus/prometheus:v2.19.2
   target: stgregistry.suse.com/rancher/prom-prometheus:v2.19.2
   type: image
 - source: quay.io/prometheus/prometheus:v2.22.0
@@ -29575,21 +17776,6 @@ sync:
 - source: quay.io/prometheus/prometheus:v3.5.0
   target: stgregistry.suse.com/rancher/prom-prometheus:v3.5.0
   type: image
-- source: quay.io/prometheus/prometheus:v2.19.2
-  target: stgregistry.suse.com/rancher/charts/prom-prometheus:v2.19.2
-  type: image
-- source: quay.io/prometheus/prometheus:v2.22.0
-  target: stgregistry.suse.com/rancher/charts/prom-prometheus:v2.22.0
-  type: image
-- source: quay.io/prometheus/prometheus:v2.55.1
-  target: stgregistry.suse.com/rancher/charts/prom-prometheus:v2.55.1
-  type: image
-- source: quay.io/prometheus/prometheus:v3.2.1
-  target: stgregistry.suse.com/rancher/charts/prom-prometheus:v3.2.1
-  type: image
-- source: quay.io/prometheus/prometheus:v3.5.0
-  target: stgregistry.suse.com/rancher/charts/prom-prometheus:v3.5.0
-  type: image
 - source: quay.io/s3gw/s3gw:v0.14.0
   target: docker.io/rancher/mirrored-s3gw-s3gw:v0.14.0
   type: image
@@ -29597,13 +17783,7 @@ sync:
   target: registry.suse.com/rancher/mirrored-s3gw-s3gw:v0.14.0
   type: image
 - source: quay.io/s3gw/s3gw:v0.14.0
-  target: registry.suse.com/rancher/charts/mirrored-s3gw-s3gw:v0.14.0
-  type: image
-- source: quay.io/s3gw/s3gw:v0.14.0
   target: stgregistry.suse.com/rancher/mirrored-s3gw-s3gw:v0.14.0
-  type: image
-- source: quay.io/s3gw/s3gw:v0.14.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-s3gw-s3gw:v0.14.0
   type: image
 - source: quay.io/skopeo/stable:v1.10.0
   target: docker.io/rancher/mirrored-skopeo-skopeo:v1.10.0
@@ -29618,22 +17798,10 @@ sync:
   target: registry.suse.com/rancher/mirrored-skopeo-skopeo:v1.13.2
   type: image
 - source: quay.io/skopeo/stable:v1.10.0
-  target: registry.suse.com/rancher/charts/mirrored-skopeo-skopeo:v1.10.0
-  type: image
-- source: quay.io/skopeo/stable:v1.13.2
-  target: registry.suse.com/rancher/charts/mirrored-skopeo-skopeo:v1.13.2
-  type: image
-- source: quay.io/skopeo/stable:v1.10.0
   target: stgregistry.suse.com/rancher/mirrored-skopeo-skopeo:v1.10.0
   type: image
 - source: quay.io/skopeo/stable:v1.13.2
   target: stgregistry.suse.com/rancher/mirrored-skopeo-skopeo:v1.13.2
-  type: image
-- source: quay.io/skopeo/stable:v1.10.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-skopeo-skopeo:v1.10.0
-  type: image
-- source: quay.io/skopeo/stable:v1.13.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-skopeo-skopeo:v1.13.2
   type: image
 - source: quay.io/thanos/thanos:v0.17.2
   target: docker.io/rancher/mirrored-thanos-thanos:v0.17.2
@@ -29678,27 +17846,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-thanos-thanos:v0.37.2
   type: image
 - source: quay.io/thanos/thanos:v0.17.2
-  target: registry.suse.com/rancher/charts/mirrored-thanos-thanos:v0.17.2
-  type: image
-- source: quay.io/thanos/thanos:v0.28.0
-  target: registry.suse.com/rancher/charts/mirrored-thanos-thanos:v0.28.0
-  type: image
-- source: quay.io/thanos/thanos:v0.30.2
-  target: registry.suse.com/rancher/charts/mirrored-thanos-thanos:v0.30.2
-  type: image
-- source: quay.io/thanos/thanos:v0.34.1
-  target: registry.suse.com/rancher/charts/mirrored-thanos-thanos:v0.34.1
-  type: image
-- source: quay.io/thanos/thanos:v0.35.1
-  target: registry.suse.com/rancher/charts/mirrored-thanos-thanos:v0.35.1
-  type: image
-- source: quay.io/thanos/thanos:v0.36.1
-  target: registry.suse.com/rancher/charts/mirrored-thanos-thanos:v0.36.1
-  type: image
-- source: quay.io/thanos/thanos:v0.37.2
-  target: registry.suse.com/rancher/charts/mirrored-thanos-thanos:v0.37.2
-  type: image
-- source: quay.io/thanos/thanos:v0.17.2
   target: stgregistry.suse.com/rancher/mirrored-thanos-thanos:v0.17.2
   type: image
 - source: quay.io/thanos/thanos:v0.28.0
@@ -29718,27 +17865,6 @@ sync:
   type: image
 - source: quay.io/thanos/thanos:v0.37.2
   target: stgregistry.suse.com/rancher/mirrored-thanos-thanos:v0.37.2
-  type: image
-- source: quay.io/thanos/thanos:v0.17.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-thanos-thanos:v0.17.2
-  type: image
-- source: quay.io/thanos/thanos:v0.28.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-thanos-thanos:v0.28.0
-  type: image
-- source: quay.io/thanos/thanos:v0.30.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-thanos-thanos:v0.30.2
-  type: image
-- source: quay.io/thanos/thanos:v0.34.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-thanos-thanos:v0.34.1
-  type: image
-- source: quay.io/thanos/thanos:v0.35.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-thanos-thanos:v0.35.1
-  type: image
-- source: quay.io/thanos/thanos:v0.36.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-thanos-thanos:v0.36.1
-  type: image
-- source: quay.io/thanos/thanos:v0.37.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-thanos-thanos:v0.37.2
   type: image
 - source: quay.io/tigera/operator:v1.15.1
   target: docker.io/rancher/mirrored-calico-operator:v1.15.1
@@ -29987,129 +18113,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-calico-operator:v1.38.6
   type: image
 - source: quay.io/tigera/operator:v1.15.1
-  target: registry.suse.com/rancher/charts/mirrored-calico-operator:v1.15.1
-  type: image
-- source: quay.io/tigera/operator:v1.17.2
-  target: registry.suse.com/rancher/charts/mirrored-calico-operator:v1.17.2
-  type: image
-- source: quay.io/tigera/operator:v1.17.4
-  target: registry.suse.com/rancher/charts/mirrored-calico-operator:v1.17.4
-  type: image
-- source: quay.io/tigera/operator:v1.17.6
-  target: registry.suse.com/rancher/charts/mirrored-calico-operator:v1.17.6
-  type: image
-- source: quay.io/tigera/operator:v1.20.3
-  target: registry.suse.com/rancher/charts/mirrored-calico-operator:v1.20.3
-  type: image
-- source: quay.io/tigera/operator:v1.20.4
-  target: registry.suse.com/rancher/charts/mirrored-calico-operator:v1.20.4
-  type: image
-- source: quay.io/tigera/operator:v1.23.3
-  target: registry.suse.com/rancher/charts/mirrored-calico-operator:v1.23.3
-  type: image
-- source: quay.io/tigera/operator:v1.23.5
-  target: registry.suse.com/rancher/charts/mirrored-calico-operator:v1.23.5
-  type: image
-- source: quay.io/tigera/operator:v1.23.6
-  target: registry.suse.com/rancher/charts/mirrored-calico-operator:v1.23.6
-  type: image
-- source: quay.io/tigera/operator:v1.23.7
-  target: registry.suse.com/rancher/charts/mirrored-calico-operator:v1.23.7
-  type: image
-- source: quay.io/tigera/operator:v1.25.0
-  target: registry.suse.com/rancher/charts/mirrored-calico-operator:v1.25.0
-  type: image
-- source: quay.io/tigera/operator:v1.25.13
-  target: registry.suse.com/rancher/charts/mirrored-calico-operator:v1.25.13
-  type: image
-- source: quay.io/tigera/operator:v1.25.3
-  target: registry.suse.com/rancher/charts/mirrored-calico-operator:v1.25.3
-  type: image
-- source: quay.io/tigera/operator:v1.25.4
-  target: registry.suse.com/rancher/charts/mirrored-calico-operator:v1.25.4
-  type: image
-- source: quay.io/tigera/operator:v1.25.8
-  target: registry.suse.com/rancher/charts/mirrored-calico-operator:v1.25.8
-  type: image
-- source: quay.io/tigera/operator:v1.27.0
-  target: registry.suse.com/rancher/charts/mirrored-calico-operator:v1.27.0
-  type: image
-- source: quay.io/tigera/operator:v1.27.1
-  target: registry.suse.com/rancher/charts/mirrored-calico-operator:v1.27.1
-  type: image
-- source: quay.io/tigera/operator:v1.27.12
-  target: registry.suse.com/rancher/charts/mirrored-calico-operator:v1.27.12
-  type: image
-- source: quay.io/tigera/operator:v1.28.1
-  target: registry.suse.com/rancher/charts/mirrored-calico-operator:v1.28.1
-  type: image
-- source: quay.io/tigera/operator:v1.28.5
-  target: registry.suse.com/rancher/charts/mirrored-calico-operator:v1.28.5
-  type: image
-- source: quay.io/tigera/operator:v1.29.0
-  target: registry.suse.com/rancher/charts/mirrored-calico-operator:v1.29.0
-  type: image
-- source: quay.io/tigera/operator:v1.29.6
-  target: registry.suse.com/rancher/charts/mirrored-calico-operator:v1.29.6
-  type: image
-- source: quay.io/tigera/operator:v1.30.4
-  target: registry.suse.com/rancher/charts/mirrored-calico-operator:v1.30.4
-  type: image
-- source: quay.io/tigera/operator:v1.30.5
-  target: registry.suse.com/rancher/charts/mirrored-calico-operator:v1.30.5
-  type: image
-- source: quay.io/tigera/operator:v1.30.7
-  target: registry.suse.com/rancher/charts/mirrored-calico-operator:v1.30.7
-  type: image
-- source: quay.io/tigera/operator:v1.31.0
-  target: registry.suse.com/rancher/charts/mirrored-calico-operator:v1.31.0
-  type: image
-- source: quay.io/tigera/operator:v1.31.1
-  target: registry.suse.com/rancher/charts/mirrored-calico-operator:v1.31.1
-  type: image
-- source: quay.io/tigera/operator:v1.32.3
-  target: registry.suse.com/rancher/charts/mirrored-calico-operator:v1.32.3
-  type: image
-- source: quay.io/tigera/operator:v1.32.5
-  target: registry.suse.com/rancher/charts/mirrored-calico-operator:v1.32.5
-  type: image
-- source: quay.io/tigera/operator:v1.32.7
-  target: registry.suse.com/rancher/charts/mirrored-calico-operator:v1.32.7
-  type: image
-- source: quay.io/tigera/operator:v1.34.0
-  target: registry.suse.com/rancher/charts/mirrored-calico-operator:v1.34.0
-  type: image
-- source: quay.io/tigera/operator:v1.34.3
-  target: registry.suse.com/rancher/charts/mirrored-calico-operator:v1.34.3
-  type: image
-- source: quay.io/tigera/operator:v1.34.5
-  target: registry.suse.com/rancher/charts/mirrored-calico-operator:v1.34.5
-  type: image
-- source: quay.io/tigera/operator:v1.36.0
-  target: registry.suse.com/rancher/charts/mirrored-calico-operator:v1.36.0
-  type: image
-- source: quay.io/tigera/operator:v1.36.2
-  target: registry.suse.com/rancher/charts/mirrored-calico-operator:v1.36.2
-  type: image
-- source: quay.io/tigera/operator:v1.36.5
-  target: registry.suse.com/rancher/charts/mirrored-calico-operator:v1.36.5
-  type: image
-- source: quay.io/tigera/operator:v1.36.7
-  target: registry.suse.com/rancher/charts/mirrored-calico-operator:v1.36.7
-  type: image
-- source: quay.io/tigera/operator:v1.38.0
-  target: registry.suse.com/rancher/charts/mirrored-calico-operator:v1.38.0
-  type: image
-- source: quay.io/tigera/operator:v1.38.1
-  target: registry.suse.com/rancher/charts/mirrored-calico-operator:v1.38.1
-  type: image
-- source: quay.io/tigera/operator:v1.38.3
-  target: registry.suse.com/rancher/charts/mirrored-calico-operator:v1.38.3
-  type: image
-- source: quay.io/tigera/operator:v1.38.6
-  target: registry.suse.com/rancher/charts/mirrored-calico-operator:v1.38.6
-  type: image
-- source: quay.io/tigera/operator:v1.15.1
   target: stgregistry.suse.com/rancher/mirrored-calico-operator:v1.15.1
   type: image
 - source: quay.io/tigera/operator:v1.17.2
@@ -30232,129 +18235,6 @@ sync:
 - source: quay.io/tigera/operator:v1.38.6
   target: stgregistry.suse.com/rancher/mirrored-calico-operator:v1.38.6
   type: image
-- source: quay.io/tigera/operator:v1.15.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-operator:v1.15.1
-  type: image
-- source: quay.io/tigera/operator:v1.17.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-operator:v1.17.2
-  type: image
-- source: quay.io/tigera/operator:v1.17.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-operator:v1.17.4
-  type: image
-- source: quay.io/tigera/operator:v1.17.6
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-operator:v1.17.6
-  type: image
-- source: quay.io/tigera/operator:v1.20.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-operator:v1.20.3
-  type: image
-- source: quay.io/tigera/operator:v1.20.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-operator:v1.20.4
-  type: image
-- source: quay.io/tigera/operator:v1.23.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-operator:v1.23.3
-  type: image
-- source: quay.io/tigera/operator:v1.23.5
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-operator:v1.23.5
-  type: image
-- source: quay.io/tigera/operator:v1.23.6
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-operator:v1.23.6
-  type: image
-- source: quay.io/tigera/operator:v1.23.7
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-operator:v1.23.7
-  type: image
-- source: quay.io/tigera/operator:v1.25.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-operator:v1.25.0
-  type: image
-- source: quay.io/tigera/operator:v1.25.13
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-operator:v1.25.13
-  type: image
-- source: quay.io/tigera/operator:v1.25.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-operator:v1.25.3
-  type: image
-- source: quay.io/tigera/operator:v1.25.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-operator:v1.25.4
-  type: image
-- source: quay.io/tigera/operator:v1.25.8
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-operator:v1.25.8
-  type: image
-- source: quay.io/tigera/operator:v1.27.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-operator:v1.27.0
-  type: image
-- source: quay.io/tigera/operator:v1.27.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-operator:v1.27.1
-  type: image
-- source: quay.io/tigera/operator:v1.27.12
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-operator:v1.27.12
-  type: image
-- source: quay.io/tigera/operator:v1.28.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-operator:v1.28.1
-  type: image
-- source: quay.io/tigera/operator:v1.28.5
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-operator:v1.28.5
-  type: image
-- source: quay.io/tigera/operator:v1.29.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-operator:v1.29.0
-  type: image
-- source: quay.io/tigera/operator:v1.29.6
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-operator:v1.29.6
-  type: image
-- source: quay.io/tigera/operator:v1.30.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-operator:v1.30.4
-  type: image
-- source: quay.io/tigera/operator:v1.30.5
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-operator:v1.30.5
-  type: image
-- source: quay.io/tigera/operator:v1.30.7
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-operator:v1.30.7
-  type: image
-- source: quay.io/tigera/operator:v1.31.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-operator:v1.31.0
-  type: image
-- source: quay.io/tigera/operator:v1.31.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-operator:v1.31.1
-  type: image
-- source: quay.io/tigera/operator:v1.32.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-operator:v1.32.3
-  type: image
-- source: quay.io/tigera/operator:v1.32.5
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-operator:v1.32.5
-  type: image
-- source: quay.io/tigera/operator:v1.32.7
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-operator:v1.32.7
-  type: image
-- source: quay.io/tigera/operator:v1.34.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-operator:v1.34.0
-  type: image
-- source: quay.io/tigera/operator:v1.34.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-operator:v1.34.3
-  type: image
-- source: quay.io/tigera/operator:v1.34.5
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-operator:v1.34.5
-  type: image
-- source: quay.io/tigera/operator:v1.36.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-operator:v1.36.0
-  type: image
-- source: quay.io/tigera/operator:v1.36.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-operator:v1.36.2
-  type: image
-- source: quay.io/tigera/operator:v1.36.5
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-operator:v1.36.5
-  type: image
-- source: quay.io/tigera/operator:v1.36.7
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-operator:v1.36.7
-  type: image
-- source: quay.io/tigera/operator:v1.38.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-operator:v1.38.0
-  type: image
-- source: quay.io/tigera/operator:v1.38.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-operator:v1.38.1
-  type: image
-- source: quay.io/tigera/operator:v1.38.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-operator:v1.38.3
-  type: image
-- source: quay.io/tigera/operator:v1.38.6
-  target: stgregistry.suse.com/rancher/charts/mirrored-calico-operator:v1.38.6
-  type: image
 - source: rancher/cluster-proportional-autoscaler:1.7.1
   target: docker.io/rancher/mirrored-cluster-proportional-autoscaler:1.7.1
   type: image
@@ -30368,22 +18248,10 @@ sync:
   target: registry.suse.com/rancher/mirrored-cluster-proportional-autoscaler:1.8.1
   type: image
 - source: rancher/cluster-proportional-autoscaler:1.7.1
-  target: registry.suse.com/rancher/charts/mirrored-cluster-proportional-autoscaler:1.7.1
-  type: image
-- source: rancher/cluster-proportional-autoscaler:1.8.1
-  target: registry.suse.com/rancher/charts/mirrored-cluster-proportional-autoscaler:1.8.1
-  type: image
-- source: rancher/cluster-proportional-autoscaler:1.7.1
   target: stgregistry.suse.com/rancher/mirrored-cluster-proportional-autoscaler:1.7.1
   type: image
 - source: rancher/cluster-proportional-autoscaler:1.8.1
   target: stgregistry.suse.com/rancher/mirrored-cluster-proportional-autoscaler:1.8.1
-  type: image
-- source: rancher/cluster-proportional-autoscaler:1.7.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-cluster-proportional-autoscaler:1.7.1
-  type: image
-- source: rancher/cluster-proportional-autoscaler:1.8.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-cluster-proportional-autoscaler:1.8.1
   type: image
 - source: rancher/coreos-etcd:v3.3.15-rancher1
   target: docker.io/rancher/mirrored-coreos-etcd:v3.3.15-rancher1
@@ -30422,24 +18290,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-coreos-etcd:v3.4.3-rancher1
   type: image
 - source: rancher/coreos-etcd:v3.3.15-rancher1
-  target: registry.suse.com/rancher/charts/mirrored-coreos-etcd:v3.3.15-rancher1
-  type: image
-- source: rancher/coreos-etcd:v3.4.13-rancher1
-  target: registry.suse.com/rancher/charts/mirrored-coreos-etcd:v3.4.13-rancher1
-  type: image
-- source: rancher/coreos-etcd:v3.4.14-rancher1
-  target: registry.suse.com/rancher/charts/mirrored-coreos-etcd:v3.4.14-rancher1
-  type: image
-- source: rancher/coreos-etcd:v3.4.15-rancher1
-  target: registry.suse.com/rancher/charts/mirrored-coreos-etcd:v3.4.15-rancher1
-  type: image
-- source: rancher/coreos-etcd:v3.4.16-rancher1
-  target: registry.suse.com/rancher/charts/mirrored-coreos-etcd:v3.4.16-rancher1
-  type: image
-- source: rancher/coreos-etcd:v3.4.3-rancher1
-  target: registry.suse.com/rancher/charts/mirrored-coreos-etcd:v3.4.3-rancher1
-  type: image
-- source: rancher/coreos-etcd:v3.3.15-rancher1
   target: stgregistry.suse.com/rancher/mirrored-coreos-etcd:v3.3.15-rancher1
   type: image
 - source: rancher/coreos-etcd:v3.4.13-rancher1
@@ -30457,24 +18307,6 @@ sync:
 - source: rancher/coreos-etcd:v3.4.3-rancher1
   target: stgregistry.suse.com/rancher/mirrored-coreos-etcd:v3.4.3-rancher1
   type: image
-- source: rancher/coreos-etcd:v3.3.15-rancher1
-  target: stgregistry.suse.com/rancher/charts/mirrored-coreos-etcd:v3.3.15-rancher1
-  type: image
-- source: rancher/coreos-etcd:v3.4.13-rancher1
-  target: stgregistry.suse.com/rancher/charts/mirrored-coreos-etcd:v3.4.13-rancher1
-  type: image
-- source: rancher/coreos-etcd:v3.4.14-rancher1
-  target: stgregistry.suse.com/rancher/charts/mirrored-coreos-etcd:v3.4.14-rancher1
-  type: image
-- source: rancher/coreos-etcd:v3.4.15-rancher1
-  target: stgregistry.suse.com/rancher/charts/mirrored-coreos-etcd:v3.4.15-rancher1
-  type: image
-- source: rancher/coreos-etcd:v3.4.16-rancher1
-  target: stgregistry.suse.com/rancher/charts/mirrored-coreos-etcd:v3.4.16-rancher1
-  type: image
-- source: rancher/coreos-etcd:v3.4.3-rancher1
-  target: stgregistry.suse.com/rancher/charts/mirrored-coreos-etcd:v3.4.3-rancher1
-  type: image
 - source: rancher/coreos-flannel:v0.12.0
   target: docker.io/rancher/mirrored-coreos-flannel:v0.12.0
   type: image
@@ -30482,13 +18314,7 @@ sync:
   target: registry.suse.com/rancher/mirrored-coreos-flannel:v0.12.0
   type: image
 - source: rancher/coreos-flannel:v0.12.0
-  target: registry.suse.com/rancher/charts/mirrored-coreos-flannel:v0.12.0
-  type: image
-- source: rancher/coreos-flannel:v0.12.0
   target: stgregistry.suse.com/rancher/mirrored-coreos-flannel:v0.12.0
-  type: image
-- source: rancher/coreos-flannel:v0.12.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-coreos-flannel:v0.12.0
   type: image
 - source: rancher/metrics-server:v0.3.4
   target: docker.io/rancher/mirrored-metrics-server:v0.3.4
@@ -30503,22 +18329,10 @@ sync:
   target: registry.suse.com/rancher/mirrored-metrics-server:v0.3.6
   type: image
 - source: rancher/metrics-server:v0.3.4
-  target: registry.suse.com/rancher/charts/mirrored-metrics-server:v0.3.4
-  type: image
-- source: rancher/metrics-server:v0.3.6
-  target: registry.suse.com/rancher/charts/mirrored-metrics-server:v0.3.6
-  type: image
-- source: rancher/metrics-server:v0.3.4
   target: stgregistry.suse.com/rancher/mirrored-metrics-server:v0.3.4
   type: image
 - source: rancher/metrics-server:v0.3.6
   target: stgregistry.suse.com/rancher/mirrored-metrics-server:v0.3.6
-  type: image
-- source: rancher/metrics-server:v0.3.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-metrics-server:v0.3.4
-  type: image
-- source: rancher/metrics-server:v0.3.6
-  target: stgregistry.suse.com/rancher/charts/mirrored-metrics-server:v0.3.6
   type: image
 - source: rancher/nginx-ingress-controller-defaultbackend:1.5-rancher1
   target: docker.io/rancher/mirrored-nginx-ingress-controller-defaultbackend:1.5-rancher1
@@ -30533,22 +18347,10 @@ sync:
   target: registry.suse.com/rancher/mirrored-nginx-ingress-controller-defaultbackend:1.5-rancher2
   type: image
 - source: rancher/nginx-ingress-controller-defaultbackend:1.5-rancher1
-  target: registry.suse.com/rancher/charts/mirrored-nginx-ingress-controller-defaultbackend:1.5-rancher1
-  type: image
-- source: rancher/nginx-ingress-controller-defaultbackend:1.5-rancher2
-  target: registry.suse.com/rancher/charts/mirrored-nginx-ingress-controller-defaultbackend:1.5-rancher2
-  type: image
-- source: rancher/nginx-ingress-controller-defaultbackend:1.5-rancher1
   target: stgregistry.suse.com/rancher/mirrored-nginx-ingress-controller-defaultbackend:1.5-rancher1
   type: image
 - source: rancher/nginx-ingress-controller-defaultbackend:1.5-rancher2
   target: stgregistry.suse.com/rancher/mirrored-nginx-ingress-controller-defaultbackend:1.5-rancher2
-  type: image
-- source: rancher/nginx-ingress-controller-defaultbackend:1.5-rancher1
-  target: stgregistry.suse.com/rancher/charts/mirrored-nginx-ingress-controller-defaultbackend:1.5-rancher1
-  type: image
-- source: rancher/nginx-ingress-controller-defaultbackend:1.5-rancher2
-  target: stgregistry.suse.com/rancher/charts/mirrored-nginx-ingress-controller-defaultbackend:1.5-rancher2
   type: image
 - source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.30.0
   target: docker.io/rancher/mirrored-cloud-provider-vsphere:v1.30.0
@@ -30611,36 +18413,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-cloud-provider-vsphere:v1.34.0
   type: image
 - source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.30.0
-  target: registry.suse.com/rancher/charts/mirrored-cloud-provider-vsphere:v1.30.0
-  type: image
-- source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.30.1
-  target: registry.suse.com/rancher/charts/mirrored-cloud-provider-vsphere:v1.30.1
-  type: image
-- source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.30.2
-  target: registry.suse.com/rancher/charts/mirrored-cloud-provider-vsphere:v1.30.2
-  type: image
-- source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.31.0
-  target: registry.suse.com/rancher/charts/mirrored-cloud-provider-vsphere:v1.31.0
-  type: image
-- source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.31.1
-  target: registry.suse.com/rancher/charts/mirrored-cloud-provider-vsphere:v1.31.1
-  type: image
-- source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.32.0
-  target: registry.suse.com/rancher/charts/mirrored-cloud-provider-vsphere:v1.32.0
-  type: image
-- source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.32.1
-  target: registry.suse.com/rancher/charts/mirrored-cloud-provider-vsphere:v1.32.1
-  type: image
-- source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.32.2
-  target: registry.suse.com/rancher/charts/mirrored-cloud-provider-vsphere:v1.32.2
-  type: image
-- source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.33.0
-  target: registry.suse.com/rancher/charts/mirrored-cloud-provider-vsphere:v1.33.0
-  type: image
-- source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.34.0
-  target: registry.suse.com/rancher/charts/mirrored-cloud-provider-vsphere:v1.34.0
-  type: image
-- source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.30.0
   target: stgregistry.suse.com/rancher/mirrored-cloud-provider-vsphere:v1.30.0
   type: image
 - source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.30.1
@@ -30669,36 +18441,6 @@ sync:
   type: image
 - source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.34.0
   target: stgregistry.suse.com/rancher/mirrored-cloud-provider-vsphere:v1.34.0
-  type: image
-- source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.30.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-cloud-provider-vsphere:v1.30.0
-  type: image
-- source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.30.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-cloud-provider-vsphere:v1.30.1
-  type: image
-- source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.30.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-cloud-provider-vsphere:v1.30.2
-  type: image
-- source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.31.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-cloud-provider-vsphere:v1.31.0
-  type: image
-- source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.31.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-cloud-provider-vsphere:v1.31.1
-  type: image
-- source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.32.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-cloud-provider-vsphere:v1.32.0
-  type: image
-- source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.32.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-cloud-provider-vsphere:v1.32.1
-  type: image
-- source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.32.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-cloud-provider-vsphere:v1.32.2
-  type: image
-- source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.33.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-cloud-provider-vsphere:v1.33.0
-  type: image
-- source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.34.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-cloud-provider-vsphere:v1.34.0
   type: image
 - source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.30.0
   target: docker.io/rancher/mirrored-cloud-pv-vsphere-cloud-provider-vsphere:v1.30.0
@@ -30761,36 +18503,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-cloud-pv-vsphere-cloud-provider-vsphere:v1.34.0
   type: image
 - source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.30.0
-  target: registry.suse.com/rancher/charts/mirrored-cloud-pv-vsphere-cloud-provider-vsphere:v1.30.0
-  type: image
-- source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.30.1
-  target: registry.suse.com/rancher/charts/mirrored-cloud-pv-vsphere-cloud-provider-vsphere:v1.30.1
-  type: image
-- source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.30.2
-  target: registry.suse.com/rancher/charts/mirrored-cloud-pv-vsphere-cloud-provider-vsphere:v1.30.2
-  type: image
-- source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.31.0
-  target: registry.suse.com/rancher/charts/mirrored-cloud-pv-vsphere-cloud-provider-vsphere:v1.31.0
-  type: image
-- source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.31.1
-  target: registry.suse.com/rancher/charts/mirrored-cloud-pv-vsphere-cloud-provider-vsphere:v1.31.1
-  type: image
-- source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.32.0
-  target: registry.suse.com/rancher/charts/mirrored-cloud-pv-vsphere-cloud-provider-vsphere:v1.32.0
-  type: image
-- source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.32.1
-  target: registry.suse.com/rancher/charts/mirrored-cloud-pv-vsphere-cloud-provider-vsphere:v1.32.1
-  type: image
-- source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.32.2
-  target: registry.suse.com/rancher/charts/mirrored-cloud-pv-vsphere-cloud-provider-vsphere:v1.32.2
-  type: image
-- source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.33.0
-  target: registry.suse.com/rancher/charts/mirrored-cloud-pv-vsphere-cloud-provider-vsphere:v1.33.0
-  type: image
-- source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.34.0
-  target: registry.suse.com/rancher/charts/mirrored-cloud-pv-vsphere-cloud-provider-vsphere:v1.34.0
-  type: image
-- source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.30.0
   target: stgregistry.suse.com/rancher/mirrored-cloud-pv-vsphere-cloud-provider-vsphere:v1.30.0
   type: image
 - source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.30.1
@@ -30819,36 +18531,6 @@ sync:
   type: image
 - source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.34.0
   target: stgregistry.suse.com/rancher/mirrored-cloud-pv-vsphere-cloud-provider-vsphere:v1.34.0
-  type: image
-- source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.30.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-cloud-pv-vsphere-cloud-provider-vsphere:v1.30.0
-  type: image
-- source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.30.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-cloud-pv-vsphere-cloud-provider-vsphere:v1.30.1
-  type: image
-- source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.30.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-cloud-pv-vsphere-cloud-provider-vsphere:v1.30.2
-  type: image
-- source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.31.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-cloud-pv-vsphere-cloud-provider-vsphere:v1.31.0
-  type: image
-- source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.31.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-cloud-pv-vsphere-cloud-provider-vsphere:v1.31.1
-  type: image
-- source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.32.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-cloud-pv-vsphere-cloud-provider-vsphere:v1.32.0
-  type: image
-- source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.32.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-cloud-pv-vsphere-cloud-provider-vsphere:v1.32.1
-  type: image
-- source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.32.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-cloud-pv-vsphere-cloud-provider-vsphere:v1.32.2
-  type: image
-- source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.33.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-cloud-pv-vsphere-cloud-provider-vsphere:v1.33.0
-  type: image
-- source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.34.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-cloud-pv-vsphere-cloud-provider-vsphere:v1.34.0
   type: image
 - source: registry.k8s.io/cluster-api/cluster-api-controller:v1.10.2
   target: docker.io/rancher/mirrored-cluster-api-controller:v1.10.2
@@ -30917,39 +18599,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-cluster-api-controller:v1.9.5
   type: image
 - source: registry.k8s.io/cluster-api/cluster-api-controller:v1.10.2
-  target: registry.suse.com/rancher/charts/mirrored-cluster-api-controller:v1.10.2
-  type: image
-- source: registry.k8s.io/cluster-api/cluster-api-controller:v1.10.6
-  target: registry.suse.com/rancher/charts/mirrored-cluster-api-controller:v1.10.6
-  type: image
-- source: registry.k8s.io/cluster-api/cluster-api-controller:v1.11.1
-  target: registry.suse.com/rancher/charts/mirrored-cluster-api-controller:v1.11.1
-  type: image
-- source: registry.k8s.io/cluster-api/cluster-api-controller:v1.4.4
-  target: registry.suse.com/rancher/charts/mirrored-cluster-api-controller:v1.4.4
-  type: image
-- source: registry.k8s.io/cluster-api/cluster-api-controller:v1.5.5
-  target: registry.suse.com/rancher/charts/mirrored-cluster-api-controller:v1.5.5
-  type: image
-- source: registry.k8s.io/cluster-api/cluster-api-controller:v1.6.4
-  target: registry.suse.com/rancher/charts/mirrored-cluster-api-controller:v1.6.4
-  type: image
-- source: registry.k8s.io/cluster-api/cluster-api-controller:v1.7.2
-  target: registry.suse.com/rancher/charts/mirrored-cluster-api-controller:v1.7.2
-  type: image
-- source: registry.k8s.io/cluster-api/cluster-api-controller:v1.7.3
-  target: registry.suse.com/rancher/charts/mirrored-cluster-api-controller:v1.7.3
-  type: image
-- source: registry.k8s.io/cluster-api/cluster-api-controller:v1.8.3
-  target: registry.suse.com/rancher/charts/mirrored-cluster-api-controller:v1.8.3
-  type: image
-- source: registry.k8s.io/cluster-api/cluster-api-controller:v1.9.4
-  target: registry.suse.com/rancher/charts/mirrored-cluster-api-controller:v1.9.4
-  type: image
-- source: registry.k8s.io/cluster-api/cluster-api-controller:v1.9.5
-  target: registry.suse.com/rancher/charts/mirrored-cluster-api-controller:v1.9.5
-  type: image
-- source: registry.k8s.io/cluster-api/cluster-api-controller:v1.10.2
   target: stgregistry.suse.com/rancher/mirrored-cluster-api-controller:v1.10.2
   type: image
 - source: registry.k8s.io/cluster-api/cluster-api-controller:v1.10.6
@@ -30982,39 +18631,6 @@ sync:
 - source: registry.k8s.io/cluster-api/cluster-api-controller:v1.9.5
   target: stgregistry.suse.com/rancher/mirrored-cluster-api-controller:v1.9.5
   type: image
-- source: registry.k8s.io/cluster-api/cluster-api-controller:v1.10.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-cluster-api-controller:v1.10.2
-  type: image
-- source: registry.k8s.io/cluster-api/cluster-api-controller:v1.10.6
-  target: stgregistry.suse.com/rancher/charts/mirrored-cluster-api-controller:v1.10.6
-  type: image
-- source: registry.k8s.io/cluster-api/cluster-api-controller:v1.11.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-cluster-api-controller:v1.11.1
-  type: image
-- source: registry.k8s.io/cluster-api/cluster-api-controller:v1.4.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-cluster-api-controller:v1.4.4
-  type: image
-- source: registry.k8s.io/cluster-api/cluster-api-controller:v1.5.5
-  target: stgregistry.suse.com/rancher/charts/mirrored-cluster-api-controller:v1.5.5
-  type: image
-- source: registry.k8s.io/cluster-api/cluster-api-controller:v1.6.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-cluster-api-controller:v1.6.4
-  type: image
-- source: registry.k8s.io/cluster-api/cluster-api-controller:v1.7.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-cluster-api-controller:v1.7.2
-  type: image
-- source: registry.k8s.io/cluster-api/cluster-api-controller:v1.7.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-cluster-api-controller:v1.7.3
-  type: image
-- source: registry.k8s.io/cluster-api/cluster-api-controller:v1.8.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-cluster-api-controller:v1.8.3
-  type: image
-- source: registry.k8s.io/cluster-api/cluster-api-controller:v1.9.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-cluster-api-controller:v1.9.4
-  type: image
-- source: registry.k8s.io/cluster-api/cluster-api-controller:v1.9.5
-  target: stgregistry.suse.com/rancher/charts/mirrored-cluster-api-controller:v1.9.5
-  type: image
 - source: registry.k8s.io/cpa/cluster-proportional-autoscaler:1.8.3
   target: docker.io/rancher/mirrored-cluster-proportional-autoscaler:1.8.3
   type: image
@@ -31046,21 +18662,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-cluster-proportional-autoscaler:v1.9.0
   type: image
 - source: registry.k8s.io/cpa/cluster-proportional-autoscaler:1.8.3
-  target: registry.suse.com/rancher/charts/mirrored-cluster-proportional-autoscaler:1.8.3
-  type: image
-- source: registry.k8s.io/cpa/cluster-proportional-autoscaler:1.8.5
-  target: registry.suse.com/rancher/charts/mirrored-cluster-proportional-autoscaler:1.8.5
-  type: image
-- source: registry.k8s.io/cpa/cluster-proportional-autoscaler:1.8.6
-  target: registry.suse.com/rancher/charts/mirrored-cluster-proportional-autoscaler:1.8.6
-  type: image
-- source: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.8.9
-  target: registry.suse.com/rancher/charts/mirrored-cluster-proportional-autoscaler:v1.8.9
-  type: image
-- source: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.9.0
-  target: registry.suse.com/rancher/charts/mirrored-cluster-proportional-autoscaler:v1.9.0
-  type: image
-- source: registry.k8s.io/cpa/cluster-proportional-autoscaler:1.8.3
   target: stgregistry.suse.com/rancher/mirrored-cluster-proportional-autoscaler:1.8.3
   type: image
 - source: registry.k8s.io/cpa/cluster-proportional-autoscaler:1.8.5
@@ -31074,21 +18675,6 @@ sync:
   type: image
 - source: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.9.0
   target: stgregistry.suse.com/rancher/mirrored-cluster-proportional-autoscaler:v1.9.0
-  type: image
-- source: registry.k8s.io/cpa/cluster-proportional-autoscaler:1.8.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-cluster-proportional-autoscaler:1.8.3
-  type: image
-- source: registry.k8s.io/cpa/cluster-proportional-autoscaler:1.8.5
-  target: stgregistry.suse.com/rancher/charts/mirrored-cluster-proportional-autoscaler:1.8.5
-  type: image
-- source: registry.k8s.io/cpa/cluster-proportional-autoscaler:1.8.6
-  target: stgregistry.suse.com/rancher/charts/mirrored-cluster-proportional-autoscaler:1.8.6
-  type: image
-- source: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.8.9
-  target: stgregistry.suse.com/rancher/charts/mirrored-cluster-proportional-autoscaler:v1.8.9
-  type: image
-- source: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.9.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-cluster-proportional-autoscaler:v1.9.0
   type: image
 - source: registry.k8s.io/csi-vsphere/driver:v3.3.1
   target: docker.io/rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v3.3.1
@@ -31109,15 +18695,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v3.5.0
   type: image
 - source: registry.k8s.io/csi-vsphere/driver:v3.3.1
-  target: registry.suse.com/rancher/charts/mirrored-cloud-provider-vsphere-csi-release-driver:v3.3.1
-  type: image
-- source: registry.k8s.io/csi-vsphere/driver:v3.4.0
-  target: registry.suse.com/rancher/charts/mirrored-cloud-provider-vsphere-csi-release-driver:v3.4.0
-  type: image
-- source: registry.k8s.io/csi-vsphere/driver:v3.5.0
-  target: registry.suse.com/rancher/charts/mirrored-cloud-provider-vsphere-csi-release-driver:v3.5.0
-  type: image
-- source: registry.k8s.io/csi-vsphere/driver:v3.3.1
   target: stgregistry.suse.com/rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v3.3.1
   type: image
 - source: registry.k8s.io/csi-vsphere/driver:v3.4.0
@@ -31125,15 +18702,6 @@ sync:
   type: image
 - source: registry.k8s.io/csi-vsphere/driver:v3.5.0
   target: stgregistry.suse.com/rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v3.5.0
-  type: image
-- source: registry.k8s.io/csi-vsphere/driver:v3.3.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-cloud-provider-vsphere-csi-release-driver:v3.3.1
-  type: image
-- source: registry.k8s.io/csi-vsphere/driver:v3.4.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-cloud-provider-vsphere-csi-release-driver:v3.4.0
-  type: image
-- source: registry.k8s.io/csi-vsphere/driver:v3.5.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-cloud-provider-vsphere-csi-release-driver:v3.5.0
   type: image
 - source: registry.k8s.io/csi-vsphere/syncer:v3.3.1
   target: docker.io/rancher/mirrored-cloud-provider-vsphere-csi-release-syncer:v3.3.1
@@ -31154,15 +18722,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-cloud-provider-vsphere-csi-release-syncer:v3.5.0
   type: image
 - source: registry.k8s.io/csi-vsphere/syncer:v3.3.1
-  target: registry.suse.com/rancher/charts/mirrored-cloud-provider-vsphere-csi-release-syncer:v3.3.1
-  type: image
-- source: registry.k8s.io/csi-vsphere/syncer:v3.4.0
-  target: registry.suse.com/rancher/charts/mirrored-cloud-provider-vsphere-csi-release-syncer:v3.4.0
-  type: image
-- source: registry.k8s.io/csi-vsphere/syncer:v3.5.0
-  target: registry.suse.com/rancher/charts/mirrored-cloud-provider-vsphere-csi-release-syncer:v3.5.0
-  type: image
-- source: registry.k8s.io/csi-vsphere/syncer:v3.3.1
   target: stgregistry.suse.com/rancher/mirrored-cloud-provider-vsphere-csi-release-syncer:v3.3.1
   type: image
 - source: registry.k8s.io/csi-vsphere/syncer:v3.4.0
@@ -31170,15 +18729,6 @@ sync:
   type: image
 - source: registry.k8s.io/csi-vsphere/syncer:v3.5.0
   target: stgregistry.suse.com/rancher/mirrored-cloud-provider-vsphere-csi-release-syncer:v3.5.0
-  type: image
-- source: registry.k8s.io/csi-vsphere/syncer:v3.3.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-cloud-provider-vsphere-csi-release-syncer:v3.3.1
-  type: image
-- source: registry.k8s.io/csi-vsphere/syncer:v3.4.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-cloud-provider-vsphere-csi-release-syncer:v3.4.0
-  type: image
-- source: registry.k8s.io/csi-vsphere/syncer:v3.5.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-cloud-provider-vsphere-csi-release-syncer:v3.5.0
   type: image
 - source: registry.k8s.io/dns/k8s-dns-dnsmasq-nanny:1.17.3
   target: docker.io/rancher/mirrored-k8s-dns-dnsmasq-nanny:1.17.3
@@ -31223,27 +18773,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-k8s-dns-dnsmasq-nanny:1.23.0
   type: image
 - source: registry.k8s.io/dns/k8s-dns-dnsmasq-nanny:1.17.3
-  target: registry.suse.com/rancher/charts/mirrored-k8s-dns-dnsmasq-nanny:1.17.3
-  type: image
-- source: registry.k8s.io/dns/k8s-dns-dnsmasq-nanny:1.17.4
-  target: registry.suse.com/rancher/charts/mirrored-k8s-dns-dnsmasq-nanny:1.17.4
-  type: image
-- source: registry.k8s.io/dns/k8s-dns-dnsmasq-nanny:1.21.1
-  target: registry.suse.com/rancher/charts/mirrored-k8s-dns-dnsmasq-nanny:1.21.1
-  type: image
-- source: registry.k8s.io/dns/k8s-dns-dnsmasq-nanny:1.22.20
-  target: registry.suse.com/rancher/charts/mirrored-k8s-dns-dnsmasq-nanny:1.22.20
-  type: image
-- source: registry.k8s.io/dns/k8s-dns-dnsmasq-nanny:1.22.28
-  target: registry.suse.com/rancher/charts/mirrored-k8s-dns-dnsmasq-nanny:1.22.28
-  type: image
-- source: registry.k8s.io/dns/k8s-dns-dnsmasq-nanny:1.22.8
-  target: registry.suse.com/rancher/charts/mirrored-k8s-dns-dnsmasq-nanny:1.22.8
-  type: image
-- source: registry.k8s.io/dns/k8s-dns-dnsmasq-nanny:1.23.0
-  target: registry.suse.com/rancher/charts/mirrored-k8s-dns-dnsmasq-nanny:1.23.0
-  type: image
-- source: registry.k8s.io/dns/k8s-dns-dnsmasq-nanny:1.17.3
   target: stgregistry.suse.com/rancher/mirrored-k8s-dns-dnsmasq-nanny:1.17.3
   type: image
 - source: registry.k8s.io/dns/k8s-dns-dnsmasq-nanny:1.17.4
@@ -31263,27 +18792,6 @@ sync:
   type: image
 - source: registry.k8s.io/dns/k8s-dns-dnsmasq-nanny:1.23.0
   target: stgregistry.suse.com/rancher/mirrored-k8s-dns-dnsmasq-nanny:1.23.0
-  type: image
-- source: registry.k8s.io/dns/k8s-dns-dnsmasq-nanny:1.17.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-k8s-dns-dnsmasq-nanny:1.17.3
-  type: image
-- source: registry.k8s.io/dns/k8s-dns-dnsmasq-nanny:1.17.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-k8s-dns-dnsmasq-nanny:1.17.4
-  type: image
-- source: registry.k8s.io/dns/k8s-dns-dnsmasq-nanny:1.21.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-k8s-dns-dnsmasq-nanny:1.21.1
-  type: image
-- source: registry.k8s.io/dns/k8s-dns-dnsmasq-nanny:1.22.20
-  target: stgregistry.suse.com/rancher/charts/mirrored-k8s-dns-dnsmasq-nanny:1.22.20
-  type: image
-- source: registry.k8s.io/dns/k8s-dns-dnsmasq-nanny:1.22.28
-  target: stgregistry.suse.com/rancher/charts/mirrored-k8s-dns-dnsmasq-nanny:1.22.28
-  type: image
-- source: registry.k8s.io/dns/k8s-dns-dnsmasq-nanny:1.22.8
-  target: stgregistry.suse.com/rancher/charts/mirrored-k8s-dns-dnsmasq-nanny:1.22.8
-  type: image
-- source: registry.k8s.io/dns/k8s-dns-dnsmasq-nanny:1.23.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-k8s-dns-dnsmasq-nanny:1.23.0
   type: image
 - source: registry.k8s.io/dns/k8s-dns-kube-dns:1.17.3
   target: docker.io/rancher/mirrored-k8s-dns-kube-dns:1.17.3
@@ -31328,27 +18836,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-k8s-dns-kube-dns:1.23.0
   type: image
 - source: registry.k8s.io/dns/k8s-dns-kube-dns:1.17.3
-  target: registry.suse.com/rancher/charts/mirrored-k8s-dns-kube-dns:1.17.3
-  type: image
-- source: registry.k8s.io/dns/k8s-dns-kube-dns:1.17.4
-  target: registry.suse.com/rancher/charts/mirrored-k8s-dns-kube-dns:1.17.4
-  type: image
-- source: registry.k8s.io/dns/k8s-dns-kube-dns:1.21.1
-  target: registry.suse.com/rancher/charts/mirrored-k8s-dns-kube-dns:1.21.1
-  type: image
-- source: registry.k8s.io/dns/k8s-dns-kube-dns:1.22.20
-  target: registry.suse.com/rancher/charts/mirrored-k8s-dns-kube-dns:1.22.20
-  type: image
-- source: registry.k8s.io/dns/k8s-dns-kube-dns:1.22.28
-  target: registry.suse.com/rancher/charts/mirrored-k8s-dns-kube-dns:1.22.28
-  type: image
-- source: registry.k8s.io/dns/k8s-dns-kube-dns:1.22.8
-  target: registry.suse.com/rancher/charts/mirrored-k8s-dns-kube-dns:1.22.8
-  type: image
-- source: registry.k8s.io/dns/k8s-dns-kube-dns:1.23.0
-  target: registry.suse.com/rancher/charts/mirrored-k8s-dns-kube-dns:1.23.0
-  type: image
-- source: registry.k8s.io/dns/k8s-dns-kube-dns:1.17.3
   target: stgregistry.suse.com/rancher/mirrored-k8s-dns-kube-dns:1.17.3
   type: image
 - source: registry.k8s.io/dns/k8s-dns-kube-dns:1.17.4
@@ -31368,27 +18855,6 @@ sync:
   type: image
 - source: registry.k8s.io/dns/k8s-dns-kube-dns:1.23.0
   target: stgregistry.suse.com/rancher/mirrored-k8s-dns-kube-dns:1.23.0
-  type: image
-- source: registry.k8s.io/dns/k8s-dns-kube-dns:1.17.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-k8s-dns-kube-dns:1.17.3
-  type: image
-- source: registry.k8s.io/dns/k8s-dns-kube-dns:1.17.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-k8s-dns-kube-dns:1.17.4
-  type: image
-- source: registry.k8s.io/dns/k8s-dns-kube-dns:1.21.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-k8s-dns-kube-dns:1.21.1
-  type: image
-- source: registry.k8s.io/dns/k8s-dns-kube-dns:1.22.20
-  target: stgregistry.suse.com/rancher/charts/mirrored-k8s-dns-kube-dns:1.22.20
-  type: image
-- source: registry.k8s.io/dns/k8s-dns-kube-dns:1.22.28
-  target: stgregistry.suse.com/rancher/charts/mirrored-k8s-dns-kube-dns:1.22.28
-  type: image
-- source: registry.k8s.io/dns/k8s-dns-kube-dns:1.22.8
-  target: stgregistry.suse.com/rancher/charts/mirrored-k8s-dns-kube-dns:1.22.8
-  type: image
-- source: registry.k8s.io/dns/k8s-dns-kube-dns:1.23.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-k8s-dns-kube-dns:1.23.0
   type: image
 - source: registry.k8s.io/dns/k8s-dns-node-cache:1.17.3
   target: docker.io/rancher/mirrored-k8s-dns-node-cache:1.17.3
@@ -31439,30 +18905,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-k8s-dns-node-cache:1.23.0
   type: image
 - source: registry.k8s.io/dns/k8s-dns-node-cache:1.17.3
-  target: registry.suse.com/rancher/charts/mirrored-k8s-dns-node-cache:1.17.3
-  type: image
-- source: registry.k8s.io/dns/k8s-dns-node-cache:1.17.4
-  target: registry.suse.com/rancher/charts/mirrored-k8s-dns-node-cache:1.17.4
-  type: image
-- source: registry.k8s.io/dns/k8s-dns-node-cache:1.18.0
-  target: registry.suse.com/rancher/charts/mirrored-k8s-dns-node-cache:1.18.0
-  type: image
-- source: registry.k8s.io/dns/k8s-dns-node-cache:1.21.1
-  target: registry.suse.com/rancher/charts/mirrored-k8s-dns-node-cache:1.21.1
-  type: image
-- source: registry.k8s.io/dns/k8s-dns-node-cache:1.22.10
-  target: registry.suse.com/rancher/charts/mirrored-k8s-dns-node-cache:1.22.10
-  type: image
-- source: registry.k8s.io/dns/k8s-dns-node-cache:1.22.20
-  target: registry.suse.com/rancher/charts/mirrored-k8s-dns-node-cache:1.22.20
-  type: image
-- source: registry.k8s.io/dns/k8s-dns-node-cache:1.22.28
-  target: registry.suse.com/rancher/charts/mirrored-k8s-dns-node-cache:1.22.28
-  type: image
-- source: registry.k8s.io/dns/k8s-dns-node-cache:1.23.0
-  target: registry.suse.com/rancher/charts/mirrored-k8s-dns-node-cache:1.23.0
-  type: image
-- source: registry.k8s.io/dns/k8s-dns-node-cache:1.17.3
   target: stgregistry.suse.com/rancher/mirrored-k8s-dns-node-cache:1.17.3
   type: image
 - source: registry.k8s.io/dns/k8s-dns-node-cache:1.17.4
@@ -31485,30 +18927,6 @@ sync:
   type: image
 - source: registry.k8s.io/dns/k8s-dns-node-cache:1.23.0
   target: stgregistry.suse.com/rancher/mirrored-k8s-dns-node-cache:1.23.0
-  type: image
-- source: registry.k8s.io/dns/k8s-dns-node-cache:1.17.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-k8s-dns-node-cache:1.17.3
-  type: image
-- source: registry.k8s.io/dns/k8s-dns-node-cache:1.17.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-k8s-dns-node-cache:1.17.4
-  type: image
-- source: registry.k8s.io/dns/k8s-dns-node-cache:1.18.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-k8s-dns-node-cache:1.18.0
-  type: image
-- source: registry.k8s.io/dns/k8s-dns-node-cache:1.21.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-k8s-dns-node-cache:1.21.1
-  type: image
-- source: registry.k8s.io/dns/k8s-dns-node-cache:1.22.10
-  target: stgregistry.suse.com/rancher/charts/mirrored-k8s-dns-node-cache:1.22.10
-  type: image
-- source: registry.k8s.io/dns/k8s-dns-node-cache:1.22.20
-  target: stgregistry.suse.com/rancher/charts/mirrored-k8s-dns-node-cache:1.22.20
-  type: image
-- source: registry.k8s.io/dns/k8s-dns-node-cache:1.22.28
-  target: stgregistry.suse.com/rancher/charts/mirrored-k8s-dns-node-cache:1.22.28
-  type: image
-- source: registry.k8s.io/dns/k8s-dns-node-cache:1.23.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-k8s-dns-node-cache:1.23.0
   type: image
 - source: registry.k8s.io/dns/k8s-dns-sidecar:1.17.3
   target: docker.io/rancher/mirrored-k8s-dns-sidecar:1.17.3
@@ -31553,27 +18971,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-k8s-dns-sidecar:1.23.0
   type: image
 - source: registry.k8s.io/dns/k8s-dns-sidecar:1.17.3
-  target: registry.suse.com/rancher/charts/mirrored-k8s-dns-sidecar:1.17.3
-  type: image
-- source: registry.k8s.io/dns/k8s-dns-sidecar:1.17.4
-  target: registry.suse.com/rancher/charts/mirrored-k8s-dns-sidecar:1.17.4
-  type: image
-- source: registry.k8s.io/dns/k8s-dns-sidecar:1.21.1
-  target: registry.suse.com/rancher/charts/mirrored-k8s-dns-sidecar:1.21.1
-  type: image
-- source: registry.k8s.io/dns/k8s-dns-sidecar:1.22.20
-  target: registry.suse.com/rancher/charts/mirrored-k8s-dns-sidecar:1.22.20
-  type: image
-- source: registry.k8s.io/dns/k8s-dns-sidecar:1.22.28
-  target: registry.suse.com/rancher/charts/mirrored-k8s-dns-sidecar:1.22.28
-  type: image
-- source: registry.k8s.io/dns/k8s-dns-sidecar:1.22.8
-  target: registry.suse.com/rancher/charts/mirrored-k8s-dns-sidecar:1.22.8
-  type: image
-- source: registry.k8s.io/dns/k8s-dns-sidecar:1.23.0
-  target: registry.suse.com/rancher/charts/mirrored-k8s-dns-sidecar:1.23.0
-  type: image
-- source: registry.k8s.io/dns/k8s-dns-sidecar:1.17.3
   target: stgregistry.suse.com/rancher/mirrored-k8s-dns-sidecar:1.17.3
   type: image
 - source: registry.k8s.io/dns/k8s-dns-sidecar:1.17.4
@@ -31594,27 +18991,6 @@ sync:
 - source: registry.k8s.io/dns/k8s-dns-sidecar:1.23.0
   target: stgregistry.suse.com/rancher/mirrored-k8s-dns-sidecar:1.23.0
   type: image
-- source: registry.k8s.io/dns/k8s-dns-sidecar:1.17.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-k8s-dns-sidecar:1.17.3
-  type: image
-- source: registry.k8s.io/dns/k8s-dns-sidecar:1.17.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-k8s-dns-sidecar:1.17.4
-  type: image
-- source: registry.k8s.io/dns/k8s-dns-sidecar:1.21.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-k8s-dns-sidecar:1.21.1
-  type: image
-- source: registry.k8s.io/dns/k8s-dns-sidecar:1.22.20
-  target: stgregistry.suse.com/rancher/charts/mirrored-k8s-dns-sidecar:1.22.20
-  type: image
-- source: registry.k8s.io/dns/k8s-dns-sidecar:1.22.28
-  target: stgregistry.suse.com/rancher/charts/mirrored-k8s-dns-sidecar:1.22.28
-  type: image
-- source: registry.k8s.io/dns/k8s-dns-sidecar:1.22.8
-  target: stgregistry.suse.com/rancher/charts/mirrored-k8s-dns-sidecar:1.22.8
-  type: image
-- source: registry.k8s.io/dns/k8s-dns-sidecar:1.23.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-k8s-dns-sidecar:1.23.0
-  type: image
 - source: registry.k8s.io/git-sync/git-sync:v3.5.0
   target: docker.io/rancher/mirrored-git-sync:v3.5.0
   type: image
@@ -31622,13 +18998,7 @@ sync:
   target: registry.suse.com/rancher/mirrored-git-sync:v3.5.0
   type: image
 - source: registry.k8s.io/git-sync/git-sync:v3.5.0
-  target: registry.suse.com/rancher/charts/mirrored-git-sync:v3.5.0
-  type: image
-- source: registry.k8s.io/git-sync/git-sync:v3.5.0
   target: stgregistry.suse.com/rancher/mirrored-git-sync:v3.5.0
-  type: image
-- source: registry.k8s.io/git-sync/git-sync:v3.5.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-git-sync:v3.5.0
   type: image
 - source: registry.k8s.io/gmsa-webhook/k8s-gmsa-webhook:v0.13.0
   target: docker.io/rancher/mirrored-gmsa-webhook-k8s-gmsa-webhook:v0.13.0
@@ -31643,22 +19013,10 @@ sync:
   target: registry.suse.com/rancher/mirrored-gmsa-webhook-k8s-gmsa-webhook:v0.7.0
   type: image
 - source: registry.k8s.io/gmsa-webhook/k8s-gmsa-webhook:v0.13.0
-  target: registry.suse.com/rancher/charts/mirrored-gmsa-webhook-k8s-gmsa-webhook:v0.13.0
-  type: image
-- source: registry.k8s.io/gmsa-webhook/k8s-gmsa-webhook:v0.7.0
-  target: registry.suse.com/rancher/charts/mirrored-gmsa-webhook-k8s-gmsa-webhook:v0.7.0
-  type: image
-- source: registry.k8s.io/gmsa-webhook/k8s-gmsa-webhook:v0.13.0
   target: stgregistry.suse.com/rancher/mirrored-gmsa-webhook-k8s-gmsa-webhook:v0.13.0
   type: image
 - source: registry.k8s.io/gmsa-webhook/k8s-gmsa-webhook:v0.7.0
   target: stgregistry.suse.com/rancher/mirrored-gmsa-webhook-k8s-gmsa-webhook:v0.7.0
-  type: image
-- source: registry.k8s.io/gmsa-webhook/k8s-gmsa-webhook:v0.13.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-gmsa-webhook-k8s-gmsa-webhook:v0.13.0
-  type: image
-- source: registry.k8s.io/gmsa-webhook/k8s-gmsa-webhook:v0.7.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-gmsa-webhook-k8s-gmsa-webhook:v0.7.0
   type: image
 - source: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.0
   target: docker.io/rancher/mirrored-ingress-nginx-kube-webhook-certgen:v1.0
@@ -31787,69 +19145,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-ingress-nginx-kube-webhook-certgen:v20231226-1a7112e06
   type: image
 - source: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.0
-  target: registry.suse.com/rancher/charts/mirrored-ingress-nginx-kube-webhook-certgen:v1.0
-  type: image
-- source: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.1.1
-  target: registry.suse.com/rancher/charts/mirrored-ingress-nginx-kube-webhook-certgen:v1.1.1
-  type: image
-- source: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.2.0
-  target: registry.suse.com/rancher/charts/mirrored-ingress-nginx-kube-webhook-certgen:v1.2.0
-  type: image
-- source: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.3.0
-  target: registry.suse.com/rancher/charts/mirrored-ingress-nginx-kube-webhook-certgen:v1.3.0
-  type: image
-- source: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.4.0
-  target: registry.suse.com/rancher/charts/mirrored-ingress-nginx-kube-webhook-certgen:v1.4.0
-  type: image
-- source: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.4.1
-  target: registry.suse.com/rancher/charts/mirrored-ingress-nginx-kube-webhook-certgen:v1.4.1
-  type: image
-- source: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.4.3
-  target: registry.suse.com/rancher/charts/mirrored-ingress-nginx-kube-webhook-certgen:v1.4.3
-  type: image
-- source: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.4.4
-  target: registry.suse.com/rancher/charts/mirrored-ingress-nginx-kube-webhook-certgen:v1.4.4
-  type: image
-- source: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.5.0
-  target: registry.suse.com/rancher/charts/mirrored-ingress-nginx-kube-webhook-certgen:v1.5.0
-  type: image
-- source: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.5.1
-  target: registry.suse.com/rancher/charts/mirrored-ingress-nginx-kube-webhook-certgen:v1.5.1
-  type: image
-- source: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.5.2
-  target: registry.suse.com/rancher/charts/mirrored-ingress-nginx-kube-webhook-certgen:v1.5.2
-  type: image
-- source: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.5.3
-  target: registry.suse.com/rancher/charts/mirrored-ingress-nginx-kube-webhook-certgen:v1.5.3
-  type: image
-- source: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.5.4
-  target: registry.suse.com/rancher/charts/mirrored-ingress-nginx-kube-webhook-certgen:v1.5.4
-  type: image
-- source: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.6.0
-  target: registry.suse.com/rancher/charts/mirrored-ingress-nginx-kube-webhook-certgen:v1.6.0
-  type: image
-- source: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.6.1
-  target: registry.suse.com/rancher/charts/mirrored-ingress-nginx-kube-webhook-certgen:v1.6.1
-  type: image
-- source: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.6.2
-  target: registry.suse.com/rancher/charts/mirrored-ingress-nginx-kube-webhook-certgen:v1.6.2
-  type: image
-- source: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.6.3
-  target: registry.suse.com/rancher/charts/mirrored-ingress-nginx-kube-webhook-certgen:v1.6.3
-  type: image
-- source: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v20221220-controller-v1.5.1-58-g787ea74b6
-  target: registry.suse.com/rancher/charts/mirrored-ingress-nginx-kube-webhook-certgen:v20221220-controller-v1.5.1-58-g787ea74b6
-  type: image
-- source: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v20230312-helm-chart-4.5.2-28-g66a760794
-  target: registry.suse.com/rancher/charts/mirrored-ingress-nginx-kube-webhook-certgen:v20230312-helm-chart-4.5.2-28-g66a760794
-  type: image
-- source: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v20231011-8b53cabe0
-  target: registry.suse.com/rancher/charts/mirrored-ingress-nginx-kube-webhook-certgen:v20231011-8b53cabe0
-  type: image
-- source: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v20231226-1a7112e06
-  target: registry.suse.com/rancher/charts/mirrored-ingress-nginx-kube-webhook-certgen:v20231226-1a7112e06
-  type: image
-- source: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.0
   target: stgregistry.suse.com/rancher/mirrored-ingress-nginx-kube-webhook-certgen:v1.0
   type: image
 - source: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.1.1
@@ -31912,69 +19207,6 @@ sync:
 - source: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v20231226-1a7112e06
   target: stgregistry.suse.com/rancher/mirrored-ingress-nginx-kube-webhook-certgen:v20231226-1a7112e06
   type: image
-- source: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-ingress-nginx-kube-webhook-certgen:v1.0
-  type: image
-- source: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.1.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-ingress-nginx-kube-webhook-certgen:v1.1.1
-  type: image
-- source: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.2.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-ingress-nginx-kube-webhook-certgen:v1.2.0
-  type: image
-- source: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.3.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-ingress-nginx-kube-webhook-certgen:v1.3.0
-  type: image
-- source: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.4.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-ingress-nginx-kube-webhook-certgen:v1.4.0
-  type: image
-- source: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.4.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-ingress-nginx-kube-webhook-certgen:v1.4.1
-  type: image
-- source: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.4.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-ingress-nginx-kube-webhook-certgen:v1.4.3
-  type: image
-- source: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.4.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-ingress-nginx-kube-webhook-certgen:v1.4.4
-  type: image
-- source: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.5.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-ingress-nginx-kube-webhook-certgen:v1.5.0
-  type: image
-- source: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.5.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-ingress-nginx-kube-webhook-certgen:v1.5.1
-  type: image
-- source: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.5.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-ingress-nginx-kube-webhook-certgen:v1.5.2
-  type: image
-- source: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.5.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-ingress-nginx-kube-webhook-certgen:v1.5.3
-  type: image
-- source: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.5.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-ingress-nginx-kube-webhook-certgen:v1.5.4
-  type: image
-- source: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.6.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-ingress-nginx-kube-webhook-certgen:v1.6.0
-  type: image
-- source: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.6.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-ingress-nginx-kube-webhook-certgen:v1.6.1
-  type: image
-- source: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.6.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-ingress-nginx-kube-webhook-certgen:v1.6.2
-  type: image
-- source: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.6.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-ingress-nginx-kube-webhook-certgen:v1.6.3
-  type: image
-- source: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v20221220-controller-v1.5.1-58-g787ea74b6
-  target: stgregistry.suse.com/rancher/charts/mirrored-ingress-nginx-kube-webhook-certgen:v20221220-controller-v1.5.1-58-g787ea74b6
-  type: image
-- source: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v20230312-helm-chart-4.5.2-28-g66a760794
-  target: stgregistry.suse.com/rancher/charts/mirrored-ingress-nginx-kube-webhook-certgen:v20230312-helm-chart-4.5.2-28-g66a760794
-  type: image
-- source: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v20231011-8b53cabe0
-  target: stgregistry.suse.com/rancher/charts/mirrored-ingress-nginx-kube-webhook-certgen:v20231011-8b53cabe0
-  type: image
-- source: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v20231226-1a7112e06
-  target: stgregistry.suse.com/rancher/charts/mirrored-ingress-nginx-kube-webhook-certgen:v20231226-1a7112e06
-  type: image
 - source: registry.k8s.io/kube-state-metrics/kube-state-metrics:v1.9.8
   target: docker.io/rancher/mirrored-kube-state-metrics-kube-state-metrics:v1.9.8
   type: image
@@ -32036,36 +19268,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-kube-state-metrics-kube-state-metrics:v2.6.0
   type: image
 - source: registry.k8s.io/kube-state-metrics/kube-state-metrics:v1.9.8
-  target: registry.suse.com/rancher/charts/mirrored-kube-state-metrics-kube-state-metrics:v1.9.8
-  type: image
-- source: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.0.0
-  target: registry.suse.com/rancher/charts/mirrored-kube-state-metrics-kube-state-metrics:v2.0.0
-  type: image
-- source: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.10.1
-  target: registry.suse.com/rancher/charts/mirrored-kube-state-metrics-kube-state-metrics:v2.10.1
-  type: image
-- source: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.12.0
-  target: registry.suse.com/rancher/charts/mirrored-kube-state-metrics-kube-state-metrics:v2.12.0
-  type: image
-- source: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.13.0
-  target: registry.suse.com/rancher/charts/mirrored-kube-state-metrics-kube-state-metrics:v2.13.0
-  type: image
-- source: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.14.0
-  target: registry.suse.com/rancher/charts/mirrored-kube-state-metrics-kube-state-metrics:v2.14.0
-  type: image
-- source: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.15.0
-  target: registry.suse.com/rancher/charts/mirrored-kube-state-metrics-kube-state-metrics:v2.15.0
-  type: image
-- source: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.17.0
-  target: registry.suse.com/rancher/charts/mirrored-kube-state-metrics-kube-state-metrics:v2.17.0
-  type: image
-- source: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.2.0
-  target: registry.suse.com/rancher/charts/mirrored-kube-state-metrics-kube-state-metrics:v2.2.0
-  type: image
-- source: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.6.0
-  target: registry.suse.com/rancher/charts/mirrored-kube-state-metrics-kube-state-metrics:v2.6.0
-  type: image
-- source: registry.k8s.io/kube-state-metrics/kube-state-metrics:v1.9.8
   target: stgregistry.suse.com/rancher/mirrored-kube-state-metrics-kube-state-metrics:v1.9.8
   type: image
 - source: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.0.0
@@ -32095,36 +19297,6 @@ sync:
 - source: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.6.0
   target: stgregistry.suse.com/rancher/mirrored-kube-state-metrics-kube-state-metrics:v2.6.0
   type: image
-- source: registry.k8s.io/kube-state-metrics/kube-state-metrics:v1.9.8
-  target: stgregistry.suse.com/rancher/charts/mirrored-kube-state-metrics-kube-state-metrics:v1.9.8
-  type: image
-- source: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.0.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-kube-state-metrics-kube-state-metrics:v2.0.0
-  type: image
-- source: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.10.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-kube-state-metrics-kube-state-metrics:v2.10.1
-  type: image
-- source: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.12.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-kube-state-metrics-kube-state-metrics:v2.12.0
-  type: image
-- source: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.13.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-kube-state-metrics-kube-state-metrics:v2.13.0
-  type: image
-- source: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.14.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-kube-state-metrics-kube-state-metrics:v2.14.0
-  type: image
-- source: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.15.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-kube-state-metrics-kube-state-metrics:v2.15.0
-  type: image
-- source: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.17.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-kube-state-metrics-kube-state-metrics:v2.17.0
-  type: image
-- source: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.2.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-kube-state-metrics-kube-state-metrics:v2.2.0
-  type: image
-- source: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.6.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-kube-state-metrics-kube-state-metrics:v2.6.0
-  type: image
 - source: registry.k8s.io/metrics-server/metrics-server:v0.4.1
   target: docker.io/rancher/metrics-server:v0.4.1
   type: image
@@ -32132,13 +19304,7 @@ sync:
   target: registry.suse.com/rancher/metrics-server:v0.4.1
   type: image
 - source: registry.k8s.io/metrics-server/metrics-server:v0.4.1
-  target: registry.suse.com/rancher/charts/metrics-server:v0.4.1
-  type: image
-- source: registry.k8s.io/metrics-server/metrics-server:v0.4.1
   target: stgregistry.suse.com/rancher/metrics-server:v0.4.1
-  type: image
-- source: registry.k8s.io/metrics-server/metrics-server:v0.4.1
-  target: stgregistry.suse.com/rancher/charts/metrics-server:v0.4.1
   type: image
 - source: registry.k8s.io/metrics-server/metrics-server:v0.4.1
   target: docker.io/rancher/mirrored-metrics-server:v0.4.1
@@ -32219,45 +19385,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-metrics-server:v0.8.0
   type: image
 - source: registry.k8s.io/metrics-server/metrics-server:v0.4.1
-  target: registry.suse.com/rancher/charts/mirrored-metrics-server:v0.4.1
-  type: image
-- source: registry.k8s.io/metrics-server/metrics-server:v0.4.4
-  target: registry.suse.com/rancher/charts/mirrored-metrics-server:v0.4.4
-  type: image
-- source: registry.k8s.io/metrics-server/metrics-server:v0.5.0
-  target: registry.suse.com/rancher/charts/mirrored-metrics-server:v0.5.0
-  type: image
-- source: registry.k8s.io/metrics-server/metrics-server:v0.5.1
-  target: registry.suse.com/rancher/charts/mirrored-metrics-server:v0.5.1
-  type: image
-- source: registry.k8s.io/metrics-server/metrics-server:v0.5.2
-  target: registry.suse.com/rancher/charts/mirrored-metrics-server:v0.5.2
-  type: image
-- source: registry.k8s.io/metrics-server/metrics-server:v0.6.1
-  target: registry.suse.com/rancher/charts/mirrored-metrics-server:v0.6.1
-  type: image
-- source: registry.k8s.io/metrics-server/metrics-server:v0.6.2
-  target: registry.suse.com/rancher/charts/mirrored-metrics-server:v0.6.2
-  type: image
-- source: registry.k8s.io/metrics-server/metrics-server:v0.6.3
-  target: registry.suse.com/rancher/charts/mirrored-metrics-server:v0.6.3
-  type: image
-- source: registry.k8s.io/metrics-server/metrics-server:v0.6.4
-  target: registry.suse.com/rancher/charts/mirrored-metrics-server:v0.6.4
-  type: image
-- source: registry.k8s.io/metrics-server/metrics-server:v0.7.0
-  target: registry.suse.com/rancher/charts/mirrored-metrics-server:v0.7.0
-  type: image
-- source: registry.k8s.io/metrics-server/metrics-server:v0.7.1
-  target: registry.suse.com/rancher/charts/mirrored-metrics-server:v0.7.1
-  type: image
-- source: registry.k8s.io/metrics-server/metrics-server:v0.7.2
-  target: registry.suse.com/rancher/charts/mirrored-metrics-server:v0.7.2
-  type: image
-- source: registry.k8s.io/metrics-server/metrics-server:v0.8.0
-  target: registry.suse.com/rancher/charts/mirrored-metrics-server:v0.8.0
-  type: image
-- source: registry.k8s.io/metrics-server/metrics-server:v0.4.1
   target: stgregistry.suse.com/rancher/mirrored-metrics-server:v0.4.1
   type: image
 - source: registry.k8s.io/metrics-server/metrics-server:v0.4.4
@@ -32295,45 +19422,6 @@ sync:
   type: image
 - source: registry.k8s.io/metrics-server/metrics-server:v0.8.0
   target: stgregistry.suse.com/rancher/mirrored-metrics-server:v0.8.0
-  type: image
-- source: registry.k8s.io/metrics-server/metrics-server:v0.4.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-metrics-server:v0.4.1
-  type: image
-- source: registry.k8s.io/metrics-server/metrics-server:v0.4.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-metrics-server:v0.4.4
-  type: image
-- source: registry.k8s.io/metrics-server/metrics-server:v0.5.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-metrics-server:v0.5.0
-  type: image
-- source: registry.k8s.io/metrics-server/metrics-server:v0.5.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-metrics-server:v0.5.1
-  type: image
-- source: registry.k8s.io/metrics-server/metrics-server:v0.5.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-metrics-server:v0.5.2
-  type: image
-- source: registry.k8s.io/metrics-server/metrics-server:v0.6.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-metrics-server:v0.6.1
-  type: image
-- source: registry.k8s.io/metrics-server/metrics-server:v0.6.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-metrics-server:v0.6.2
-  type: image
-- source: registry.k8s.io/metrics-server/metrics-server:v0.6.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-metrics-server:v0.6.3
-  type: image
-- source: registry.k8s.io/metrics-server/metrics-server:v0.6.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-metrics-server:v0.6.4
-  type: image
-- source: registry.k8s.io/metrics-server/metrics-server:v0.7.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-metrics-server:v0.7.0
-  type: image
-- source: registry.k8s.io/metrics-server/metrics-server:v0.7.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-metrics-server:v0.7.1
-  type: image
-- source: registry.k8s.io/metrics-server/metrics-server:v0.7.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-metrics-server:v0.7.2
-  type: image
-- source: registry.k8s.io/metrics-server/metrics-server:v0.8.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-metrics-server:v0.8.0
   type: image
 - source: registry.k8s.io/pause:3.10
   target: docker.io/rancher/mirrored-pause:3.10
@@ -32378,27 +19466,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-pause:3.9
   type: image
 - source: registry.k8s.io/pause:3.10
-  target: registry.suse.com/rancher/charts/mirrored-pause:3.10
-  type: image
-- source: registry.k8s.io/pause:3.4.1
-  target: registry.suse.com/rancher/charts/mirrored-pause:3.4.1
-  type: image
-- source: registry.k8s.io/pause:3.5
-  target: registry.suse.com/rancher/charts/mirrored-pause:3.5
-  type: image
-- source: registry.k8s.io/pause:3.6
-  target: registry.suse.com/rancher/charts/mirrored-pause:3.6
-  type: image
-- source: registry.k8s.io/pause:3.7
-  target: registry.suse.com/rancher/charts/mirrored-pause:3.7
-  type: image
-- source: registry.k8s.io/pause:3.8
-  target: registry.suse.com/rancher/charts/mirrored-pause:3.8
-  type: image
-- source: registry.k8s.io/pause:3.9
-  target: registry.suse.com/rancher/charts/mirrored-pause:3.9
-  type: image
-- source: registry.k8s.io/pause:3.10
   target: stgregistry.suse.com/rancher/mirrored-pause:3.10
   type: image
 - source: registry.k8s.io/pause:3.4.1
@@ -32418,27 +19485,6 @@ sync:
   type: image
 - source: registry.k8s.io/pause:3.9
   target: stgregistry.suse.com/rancher/mirrored-pause:3.9
-  type: image
-- source: registry.k8s.io/pause:3.10
-  target: stgregistry.suse.com/rancher/charts/mirrored-pause:3.10
-  type: image
-- source: registry.k8s.io/pause:3.4.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-pause:3.4.1
-  type: image
-- source: registry.k8s.io/pause:3.5
-  target: stgregistry.suse.com/rancher/charts/mirrored-pause:3.5
-  type: image
-- source: registry.k8s.io/pause:3.6
-  target: stgregistry.suse.com/rancher/charts/mirrored-pause:3.6
-  type: image
-- source: registry.k8s.io/pause:3.7
-  target: stgregistry.suse.com/rancher/charts/mirrored-pause:3.7
-  type: image
-- source: registry.k8s.io/pause:3.8
-  target: stgregistry.suse.com/rancher/charts/mirrored-pause:3.8
-  type: image
-- source: registry.k8s.io/pause:3.9
-  target: stgregistry.suse.com/rancher/charts/mirrored-pause:3.9
   type: image
 - source: registry.k8s.io/prometheus-adapter/prometheus-adapter:v0.10.0
   target: docker.io/rancher/mirrored-prometheus-adapter-prometheus-adapter:v0.10.0
@@ -32465,18 +19511,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-prometheus-adapter-prometheus-adapter:v0.9.0
   type: image
 - source: registry.k8s.io/prometheus-adapter/prometheus-adapter:v0.10.0
-  target: registry.suse.com/rancher/charts/mirrored-prometheus-adapter-prometheus-adapter:v0.10.0
-  type: image
-- source: registry.k8s.io/prometheus-adapter/prometheus-adapter:v0.11.2
-  target: registry.suse.com/rancher/charts/mirrored-prometheus-adapter-prometheus-adapter:v0.11.2
-  type: image
-- source: registry.k8s.io/prometheus-adapter/prometheus-adapter:v0.12.0
-  target: registry.suse.com/rancher/charts/mirrored-prometheus-adapter-prometheus-adapter:v0.12.0
-  type: image
-- source: registry.k8s.io/prometheus-adapter/prometheus-adapter:v0.9.0
-  target: registry.suse.com/rancher/charts/mirrored-prometheus-adapter-prometheus-adapter:v0.9.0
-  type: image
-- source: registry.k8s.io/prometheus-adapter/prometheus-adapter:v0.10.0
   target: stgregistry.suse.com/rancher/mirrored-prometheus-adapter-prometheus-adapter:v0.10.0
   type: image
 - source: registry.k8s.io/prometheus-adapter/prometheus-adapter:v0.11.2
@@ -32487,18 +19521,6 @@ sync:
   type: image
 - source: registry.k8s.io/prometheus-adapter/prometheus-adapter:v0.9.0
   target: stgregistry.suse.com/rancher/mirrored-prometheus-adapter-prometheus-adapter:v0.9.0
-  type: image
-- source: registry.k8s.io/prometheus-adapter/prometheus-adapter:v0.10.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-adapter-prometheus-adapter:v0.10.0
-  type: image
-- source: registry.k8s.io/prometheus-adapter/prometheus-adapter:v0.11.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-adapter-prometheus-adapter:v0.11.2
-  type: image
-- source: registry.k8s.io/prometheus-adapter/prometheus-adapter:v0.12.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-adapter-prometheus-adapter:v0.12.0
-  type: image
-- source: registry.k8s.io/prometheus-adapter/prometheus-adapter:v0.9.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-prometheus-adapter-prometheus-adapter:v0.9.0
   type: image
 - source: registry.k8s.io/sig-storage/csi-attacher:v3.2.0
   target: docker.io/rancher/mirrored-sig-storage-csi-attacher:v3.2.0
@@ -32591,51 +19613,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-sig-storage-csi-attacher:v4.9.0
   type: image
 - source: registry.k8s.io/sig-storage/csi-attacher:v3.2.0
-  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-attacher:v3.2.0
-  type: image
-- source: registry.k8s.io/sig-storage/csi-attacher:v3.3.0
-  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-attacher:v3.3.0
-  type: image
-- source: registry.k8s.io/sig-storage/csi-attacher:v3.4.0
-  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-attacher:v3.4.0
-  type: image
-- source: registry.k8s.io/sig-storage/csi-attacher:v3.5.0
-  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-attacher:v3.5.0
-  type: image
-- source: registry.k8s.io/sig-storage/csi-attacher:v4.2.0
-  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-attacher:v4.2.0
-  type: image
-- source: registry.k8s.io/sig-storage/csi-attacher:v4.3.0
-  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-attacher:v4.3.0
-  type: image
-- source: registry.k8s.io/sig-storage/csi-attacher:v4.4.0
-  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-attacher:v4.4.0
-  type: image
-- source: registry.k8s.io/sig-storage/csi-attacher:v4.4.1
-  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-attacher:v4.4.1
-  type: image
-- source: registry.k8s.io/sig-storage/csi-attacher:v4.4.2
-  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-attacher:v4.4.2
-  type: image
-- source: registry.k8s.io/sig-storage/csi-attacher:v4.5.0
-  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-attacher:v4.5.0
-  type: image
-- source: registry.k8s.io/sig-storage/csi-attacher:v4.5.1
-  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-attacher:v4.5.1
-  type: image
-- source: registry.k8s.io/sig-storage/csi-attacher:v4.7.0
-  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-attacher:v4.7.0
-  type: image
-- source: registry.k8s.io/sig-storage/csi-attacher:v4.8.0
-  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-attacher:v4.8.0
-  type: image
-- source: registry.k8s.io/sig-storage/csi-attacher:v4.8.1
-  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-attacher:v4.8.1
-  type: image
-- source: registry.k8s.io/sig-storage/csi-attacher:v4.9.0
-  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-attacher:v4.9.0
-  type: image
-- source: registry.k8s.io/sig-storage/csi-attacher:v3.2.0
   target: stgregistry.suse.com/rancher/mirrored-sig-storage-csi-attacher:v3.2.0
   type: image
 - source: registry.k8s.io/sig-storage/csi-attacher:v3.3.0
@@ -32679,51 +19656,6 @@ sync:
   type: image
 - source: registry.k8s.io/sig-storage/csi-attacher:v4.9.0
   target: stgregistry.suse.com/rancher/mirrored-sig-storage-csi-attacher:v4.9.0
-  type: image
-- source: registry.k8s.io/sig-storage/csi-attacher:v3.2.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-attacher:v3.2.0
-  type: image
-- source: registry.k8s.io/sig-storage/csi-attacher:v3.3.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-attacher:v3.3.0
-  type: image
-- source: registry.k8s.io/sig-storage/csi-attacher:v3.4.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-attacher:v3.4.0
-  type: image
-- source: registry.k8s.io/sig-storage/csi-attacher:v3.5.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-attacher:v3.5.0
-  type: image
-- source: registry.k8s.io/sig-storage/csi-attacher:v4.2.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-attacher:v4.2.0
-  type: image
-- source: registry.k8s.io/sig-storage/csi-attacher:v4.3.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-attacher:v4.3.0
-  type: image
-- source: registry.k8s.io/sig-storage/csi-attacher:v4.4.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-attacher:v4.4.0
-  type: image
-- source: registry.k8s.io/sig-storage/csi-attacher:v4.4.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-attacher:v4.4.1
-  type: image
-- source: registry.k8s.io/sig-storage/csi-attacher:v4.4.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-attacher:v4.4.2
-  type: image
-- source: registry.k8s.io/sig-storage/csi-attacher:v4.5.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-attacher:v4.5.0
-  type: image
-- source: registry.k8s.io/sig-storage/csi-attacher:v4.5.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-attacher:v4.5.1
-  type: image
-- source: registry.k8s.io/sig-storage/csi-attacher:v4.7.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-attacher:v4.7.0
-  type: image
-- source: registry.k8s.io/sig-storage/csi-attacher:v4.8.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-attacher:v4.8.0
-  type: image
-- source: registry.k8s.io/sig-storage/csi-attacher:v4.8.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-attacher:v4.8.1
-  type: image
-- source: registry.k8s.io/sig-storage/csi-attacher:v4.9.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-attacher:v4.9.0
   type: image
 - source: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.10.0
   target: docker.io/rancher/mirrored-sig-storage-csi-node-driver-registrar:v2.10.0
@@ -32804,45 +19736,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-sig-storage-csi-node-driver-registrar:v2.9.1
   type: image
 - source: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.10.0
-  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-node-driver-registrar:v2.10.0
-  type: image
-- source: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.10.1
-  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-node-driver-registrar:v2.10.1
-  type: image
-- source: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.12.0
-  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-node-driver-registrar:v2.12.0
-  type: image
-- source: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.13.0
-  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-node-driver-registrar:v2.13.0
-  type: image
-- source: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.14.0
-  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-node-driver-registrar:v2.14.0
-  type: image
-- source: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.3.0
-  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-node-driver-registrar:v2.3.0
-  type: image
-- source: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.5.0
-  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-node-driver-registrar:v2.5.0
-  type: image
-- source: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.5.1
-  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-node-driver-registrar:v2.5.1
-  type: image
-- source: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.6.2
-  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-node-driver-registrar:v2.6.2
-  type: image
-- source: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.7.0
-  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-node-driver-registrar:v2.7.0
-  type: image
-- source: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.8.0
-  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-node-driver-registrar:v2.8.0
-  type: image
-- source: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.9.0
-  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-node-driver-registrar:v2.9.0
-  type: image
-- source: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.9.1
-  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-node-driver-registrar:v2.9.1
-  type: image
-- source: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.10.0
   target: stgregistry.suse.com/rancher/mirrored-sig-storage-csi-node-driver-registrar:v2.10.0
   type: image
 - source: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.10.1
@@ -32880,45 +19773,6 @@ sync:
   type: image
 - source: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.9.1
   target: stgregistry.suse.com/rancher/mirrored-sig-storage-csi-node-driver-registrar:v2.9.1
-  type: image
-- source: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.10.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-node-driver-registrar:v2.10.0
-  type: image
-- source: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.10.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-node-driver-registrar:v2.10.1
-  type: image
-- source: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.12.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-node-driver-registrar:v2.12.0
-  type: image
-- source: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.13.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-node-driver-registrar:v2.13.0
-  type: image
-- source: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.14.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-node-driver-registrar:v2.14.0
-  type: image
-- source: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.3.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-node-driver-registrar:v2.3.0
-  type: image
-- source: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.5.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-node-driver-registrar:v2.5.0
-  type: image
-- source: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.5.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-node-driver-registrar:v2.5.1
-  type: image
-- source: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.6.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-node-driver-registrar:v2.6.2
-  type: image
-- source: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.7.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-node-driver-registrar:v2.7.0
-  type: image
-- source: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.8.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-node-driver-registrar:v2.8.0
-  type: image
-- source: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.9.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-node-driver-registrar:v2.9.0
-  type: image
-- source: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.9.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-node-driver-registrar:v2.9.1
   type: image
 - source: registry.k8s.io/sig-storage/csi-provisioner:v2.2.0
   target: docker.io/rancher/mirrored-sig-storage-csi-provisioner:v2.2.0
@@ -33011,51 +19865,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-sig-storage-csi-provisioner:v5.3.0
   type: image
 - source: registry.k8s.io/sig-storage/csi-provisioner:v2.2.0
-  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-provisioner:v2.2.0
-  type: image
-- source: registry.k8s.io/sig-storage/csi-provisioner:v3.0.0
-  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-provisioner:v3.0.0
-  type: image
-- source: registry.k8s.io/sig-storage/csi-provisioner:v3.1.0
-  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-provisioner:v3.1.0
-  type: image
-- source: registry.k8s.io/sig-storage/csi-provisioner:v3.2.1
-  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-provisioner:v3.2.1
-  type: image
-- source: registry.k8s.io/sig-storage/csi-provisioner:v3.3.0
-  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-provisioner:v3.3.0
-  type: image
-- source: registry.k8s.io/sig-storage/csi-provisioner:v3.4.0
-  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-provisioner:v3.4.0
-  type: image
-- source: registry.k8s.io/sig-storage/csi-provisioner:v3.5.0
-  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-provisioner:v3.5.0
-  type: image
-- source: registry.k8s.io/sig-storage/csi-provisioner:v3.6.0
-  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-provisioner:v3.6.0
-  type: image
-- source: registry.k8s.io/sig-storage/csi-provisioner:v3.6.1
-  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-provisioner:v3.6.1
-  type: image
-- source: registry.k8s.io/sig-storage/csi-provisioner:v3.6.2
-  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-provisioner:v3.6.2
-  type: image
-- source: registry.k8s.io/sig-storage/csi-provisioner:v4.0.0
-  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-provisioner:v4.0.0
-  type: image
-- source: registry.k8s.io/sig-storage/csi-provisioner:v4.0.1
-  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-provisioner:v4.0.1
-  type: image
-- source: registry.k8s.io/sig-storage/csi-provisioner:v5.1.0
-  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-provisioner:v5.1.0
-  type: image
-- source: registry.k8s.io/sig-storage/csi-provisioner:v5.2.0
-  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-provisioner:v5.2.0
-  type: image
-- source: registry.k8s.io/sig-storage/csi-provisioner:v5.3.0
-  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-provisioner:v5.3.0
-  type: image
-- source: registry.k8s.io/sig-storage/csi-provisioner:v2.2.0
   target: stgregistry.suse.com/rancher/mirrored-sig-storage-csi-provisioner:v2.2.0
   type: image
 - source: registry.k8s.io/sig-storage/csi-provisioner:v3.0.0
@@ -33099,51 +19908,6 @@ sync:
   type: image
 - source: registry.k8s.io/sig-storage/csi-provisioner:v5.3.0
   target: stgregistry.suse.com/rancher/mirrored-sig-storage-csi-provisioner:v5.3.0
-  type: image
-- source: registry.k8s.io/sig-storage/csi-provisioner:v2.2.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-provisioner:v2.2.0
-  type: image
-- source: registry.k8s.io/sig-storage/csi-provisioner:v3.0.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-provisioner:v3.0.0
-  type: image
-- source: registry.k8s.io/sig-storage/csi-provisioner:v3.1.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-provisioner:v3.1.0
-  type: image
-- source: registry.k8s.io/sig-storage/csi-provisioner:v3.2.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-provisioner:v3.2.1
-  type: image
-- source: registry.k8s.io/sig-storage/csi-provisioner:v3.3.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-provisioner:v3.3.0
-  type: image
-- source: registry.k8s.io/sig-storage/csi-provisioner:v3.4.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-provisioner:v3.4.0
-  type: image
-- source: registry.k8s.io/sig-storage/csi-provisioner:v3.5.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-provisioner:v3.5.0
-  type: image
-- source: registry.k8s.io/sig-storage/csi-provisioner:v3.6.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-provisioner:v3.6.0
-  type: image
-- source: registry.k8s.io/sig-storage/csi-provisioner:v3.6.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-provisioner:v3.6.1
-  type: image
-- source: registry.k8s.io/sig-storage/csi-provisioner:v3.6.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-provisioner:v3.6.2
-  type: image
-- source: registry.k8s.io/sig-storage/csi-provisioner:v4.0.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-provisioner:v4.0.0
-  type: image
-- source: registry.k8s.io/sig-storage/csi-provisioner:v4.0.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-provisioner:v4.0.1
-  type: image
-- source: registry.k8s.io/sig-storage/csi-provisioner:v5.1.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-provisioner:v5.1.0
-  type: image
-- source: registry.k8s.io/sig-storage/csi-provisioner:v5.2.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-provisioner:v5.2.0
-  type: image
-- source: registry.k8s.io/sig-storage/csi-provisioner:v5.3.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-provisioner:v5.3.0
   type: image
 - source: registry.k8s.io/sig-storage/csi-resizer:v1.10.0
   target: docker.io/rancher/mirrored-sig-storage-csi-resizer:v1.10.0
@@ -33224,45 +19988,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-sig-storage-csi-resizer:v1.9.2
   type: image
 - source: registry.k8s.io/sig-storage/csi-resizer:v1.10.0
-  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-resizer:v1.10.0
-  type: image
-- source: registry.k8s.io/sig-storage/csi-resizer:v1.10.1
-  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-resizer:v1.10.1
-  type: image
-- source: registry.k8s.io/sig-storage/csi-resizer:v1.12.0
-  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-resizer:v1.12.0
-  type: image
-- source: registry.k8s.io/sig-storage/csi-resizer:v1.13.1
-  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-resizer:v1.13.1
-  type: image
-- source: registry.k8s.io/sig-storage/csi-resizer:v1.13.2
-  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-resizer:v1.13.2
-  type: image
-- source: registry.k8s.io/sig-storage/csi-resizer:v1.3.0
-  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-resizer:v1.3.0
-  type: image
-- source: registry.k8s.io/sig-storage/csi-resizer:v1.4.0
-  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-resizer:v1.4.0
-  type: image
-- source: registry.k8s.io/sig-storage/csi-resizer:v1.6.0
-  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-resizer:v1.6.0
-  type: image
-- source: registry.k8s.io/sig-storage/csi-resizer:v1.7.0
-  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-resizer:v1.7.0
-  type: image
-- source: registry.k8s.io/sig-storage/csi-resizer:v1.8.0
-  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-resizer:v1.8.0
-  type: image
-- source: registry.k8s.io/sig-storage/csi-resizer:v1.9.0
-  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-resizer:v1.9.0
-  type: image
-- source: registry.k8s.io/sig-storage/csi-resizer:v1.9.1
-  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-resizer:v1.9.1
-  type: image
-- source: registry.k8s.io/sig-storage/csi-resizer:v1.9.2
-  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-resizer:v1.9.2
-  type: image
-- source: registry.k8s.io/sig-storage/csi-resizer:v1.10.0
   target: stgregistry.suse.com/rancher/mirrored-sig-storage-csi-resizer:v1.10.0
   type: image
 - source: registry.k8s.io/sig-storage/csi-resizer:v1.10.1
@@ -33300,45 +20025,6 @@ sync:
   type: image
 - source: registry.k8s.io/sig-storage/csi-resizer:v1.9.2
   target: stgregistry.suse.com/rancher/mirrored-sig-storage-csi-resizer:v1.9.2
-  type: image
-- source: registry.k8s.io/sig-storage/csi-resizer:v1.10.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-resizer:v1.10.0
-  type: image
-- source: registry.k8s.io/sig-storage/csi-resizer:v1.10.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-resizer:v1.10.1
-  type: image
-- source: registry.k8s.io/sig-storage/csi-resizer:v1.12.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-resizer:v1.12.0
-  type: image
-- source: registry.k8s.io/sig-storage/csi-resizer:v1.13.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-resizer:v1.13.1
-  type: image
-- source: registry.k8s.io/sig-storage/csi-resizer:v1.13.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-resizer:v1.13.2
-  type: image
-- source: registry.k8s.io/sig-storage/csi-resizer:v1.3.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-resizer:v1.3.0
-  type: image
-- source: registry.k8s.io/sig-storage/csi-resizer:v1.4.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-resizer:v1.4.0
-  type: image
-- source: registry.k8s.io/sig-storage/csi-resizer:v1.6.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-resizer:v1.6.0
-  type: image
-- source: registry.k8s.io/sig-storage/csi-resizer:v1.7.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-resizer:v1.7.0
-  type: image
-- source: registry.k8s.io/sig-storage/csi-resizer:v1.8.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-resizer:v1.8.0
-  type: image
-- source: registry.k8s.io/sig-storage/csi-resizer:v1.9.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-resizer:v1.9.0
-  type: image
-- source: registry.k8s.io/sig-storage/csi-resizer:v1.9.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-resizer:v1.9.1
-  type: image
-- source: registry.k8s.io/sig-storage/csi-resizer:v1.9.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-resizer:v1.9.2
   type: image
 - source: registry.k8s.io/sig-storage/csi-snapshotter:v5.0.1
   target: docker.io/rancher/mirrored-sig-storage-csi-snapshotter:v5.0.1
@@ -33389,30 +20075,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-sig-storage-csi-snapshotter:v8.2.0
   type: image
 - source: registry.k8s.io/sig-storage/csi-snapshotter:v5.0.1
-  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-snapshotter:v5.0.1
-  type: image
-- source: registry.k8s.io/sig-storage/csi-snapshotter:v6.0.1
-  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-snapshotter:v6.0.1
-  type: image
-- source: registry.k8s.io/sig-storage/csi-snapshotter:v6.2.1
-  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-snapshotter:v6.2.1
-  type: image
-- source: registry.k8s.io/sig-storage/csi-snapshotter:v6.2.2
-  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-snapshotter:v6.2.2
-  type: image
-- source: registry.k8s.io/sig-storage/csi-snapshotter:v7.0.1
-  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-snapshotter:v7.0.1
-  type: image
-- source: registry.k8s.io/sig-storage/csi-snapshotter:v7.0.2
-  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-snapshotter:v7.0.2
-  type: image
-- source: registry.k8s.io/sig-storage/csi-snapshotter:v8.1.0
-  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-snapshotter:v8.1.0
-  type: image
-- source: registry.k8s.io/sig-storage/csi-snapshotter:v8.2.0
-  target: registry.suse.com/rancher/charts/mirrored-sig-storage-csi-snapshotter:v8.2.0
-  type: image
-- source: registry.k8s.io/sig-storage/csi-snapshotter:v5.0.1
   target: stgregistry.suse.com/rancher/mirrored-sig-storage-csi-snapshotter:v5.0.1
   type: image
 - source: registry.k8s.io/sig-storage/csi-snapshotter:v6.0.1
@@ -33435,30 +20097,6 @@ sync:
   type: image
 - source: registry.k8s.io/sig-storage/csi-snapshotter:v8.2.0
   target: stgregistry.suse.com/rancher/mirrored-sig-storage-csi-snapshotter:v8.2.0
-  type: image
-- source: registry.k8s.io/sig-storage/csi-snapshotter:v5.0.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-snapshotter:v5.0.1
-  type: image
-- source: registry.k8s.io/sig-storage/csi-snapshotter:v6.0.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-snapshotter:v6.0.1
-  type: image
-- source: registry.k8s.io/sig-storage/csi-snapshotter:v6.2.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-snapshotter:v6.2.1
-  type: image
-- source: registry.k8s.io/sig-storage/csi-snapshotter:v6.2.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-snapshotter:v6.2.2
-  type: image
-- source: registry.k8s.io/sig-storage/csi-snapshotter:v7.0.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-snapshotter:v7.0.1
-  type: image
-- source: registry.k8s.io/sig-storage/csi-snapshotter:v7.0.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-snapshotter:v7.0.2
-  type: image
-- source: registry.k8s.io/sig-storage/csi-snapshotter:v8.1.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-snapshotter:v8.1.0
-  type: image
-- source: registry.k8s.io/sig-storage/csi-snapshotter:v8.2.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-csi-snapshotter:v8.2.0
   type: image
 - source: registry.k8s.io/sig-storage/livenessprobe:v2.10.0
   target: docker.io/rancher/mirrored-sig-storage-livenessprobe:v2.10.0
@@ -33527,39 +20165,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-sig-storage-livenessprobe:v2.9.0
   type: image
 - source: registry.k8s.io/sig-storage/livenessprobe:v2.10.0
-  target: registry.suse.com/rancher/charts/mirrored-sig-storage-livenessprobe:v2.10.0
-  type: image
-- source: registry.k8s.io/sig-storage/livenessprobe:v2.11.0
-  target: registry.suse.com/rancher/charts/mirrored-sig-storage-livenessprobe:v2.11.0
-  type: image
-- source: registry.k8s.io/sig-storage/livenessprobe:v2.12.0
-  target: registry.suse.com/rancher/charts/mirrored-sig-storage-livenessprobe:v2.12.0
-  type: image
-- source: registry.k8s.io/sig-storage/livenessprobe:v2.14.0
-  target: registry.suse.com/rancher/charts/mirrored-sig-storage-livenessprobe:v2.14.0
-  type: image
-- source: registry.k8s.io/sig-storage/livenessprobe:v2.15.0
-  target: registry.suse.com/rancher/charts/mirrored-sig-storage-livenessprobe:v2.15.0
-  type: image
-- source: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
-  target: registry.suse.com/rancher/charts/mirrored-sig-storage-livenessprobe:v2.16.0
-  type: image
-- source: registry.k8s.io/sig-storage/livenessprobe:v2.4.0
-  target: registry.suse.com/rancher/charts/mirrored-sig-storage-livenessprobe:v2.4.0
-  type: image
-- source: registry.k8s.io/sig-storage/livenessprobe:v2.6.0
-  target: registry.suse.com/rancher/charts/mirrored-sig-storage-livenessprobe:v2.6.0
-  type: image
-- source: registry.k8s.io/sig-storage/livenessprobe:v2.7.0
-  target: registry.suse.com/rancher/charts/mirrored-sig-storage-livenessprobe:v2.7.0
-  type: image
-- source: registry.k8s.io/sig-storage/livenessprobe:v2.8.0
-  target: registry.suse.com/rancher/charts/mirrored-sig-storage-livenessprobe:v2.8.0
-  type: image
-- source: registry.k8s.io/sig-storage/livenessprobe:v2.9.0
-  target: registry.suse.com/rancher/charts/mirrored-sig-storage-livenessprobe:v2.9.0
-  type: image
-- source: registry.k8s.io/sig-storage/livenessprobe:v2.10.0
   target: stgregistry.suse.com/rancher/mirrored-sig-storage-livenessprobe:v2.10.0
   type: image
 - source: registry.k8s.io/sig-storage/livenessprobe:v2.11.0
@@ -33592,39 +20197,6 @@ sync:
 - source: registry.k8s.io/sig-storage/livenessprobe:v2.9.0
   target: stgregistry.suse.com/rancher/mirrored-sig-storage-livenessprobe:v2.9.0
   type: image
-- source: registry.k8s.io/sig-storage/livenessprobe:v2.10.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-livenessprobe:v2.10.0
-  type: image
-- source: registry.k8s.io/sig-storage/livenessprobe:v2.11.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-livenessprobe:v2.11.0
-  type: image
-- source: registry.k8s.io/sig-storage/livenessprobe:v2.12.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-livenessprobe:v2.12.0
-  type: image
-- source: registry.k8s.io/sig-storage/livenessprobe:v2.14.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-livenessprobe:v2.14.0
-  type: image
-- source: registry.k8s.io/sig-storage/livenessprobe:v2.15.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-livenessprobe:v2.15.0
-  type: image
-- source: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-livenessprobe:v2.16.0
-  type: image
-- source: registry.k8s.io/sig-storage/livenessprobe:v2.4.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-livenessprobe:v2.4.0
-  type: image
-- source: registry.k8s.io/sig-storage/livenessprobe:v2.6.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-livenessprobe:v2.6.0
-  type: image
-- source: registry.k8s.io/sig-storage/livenessprobe:v2.7.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-livenessprobe:v2.7.0
-  type: image
-- source: registry.k8s.io/sig-storage/livenessprobe:v2.8.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-livenessprobe:v2.8.0
-  type: image
-- source: registry.k8s.io/sig-storage/livenessprobe:v2.9.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-livenessprobe:v2.9.0
-  type: image
 - source: registry.k8s.io/sig-storage/snapshot-controller:v6.1.0
   target: docker.io/rancher/mirrored-sig-storage-snapshot-controller:v6.1.0
   type: image
@@ -33650,18 +20222,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-sig-storage-snapshot-controller:v8.2.0
   type: image
 - source: registry.k8s.io/sig-storage/snapshot-controller:v6.1.0
-  target: registry.suse.com/rancher/charts/mirrored-sig-storage-snapshot-controller:v6.1.0
-  type: image
-- source: registry.k8s.io/sig-storage/snapshot-controller:v6.2.1
-  target: registry.suse.com/rancher/charts/mirrored-sig-storage-snapshot-controller:v6.2.1
-  type: image
-- source: registry.k8s.io/sig-storage/snapshot-controller:v8.1.0
-  target: registry.suse.com/rancher/charts/mirrored-sig-storage-snapshot-controller:v8.1.0
-  type: image
-- source: registry.k8s.io/sig-storage/snapshot-controller:v8.2.0
-  target: registry.suse.com/rancher/charts/mirrored-sig-storage-snapshot-controller:v8.2.0
-  type: image
-- source: registry.k8s.io/sig-storage/snapshot-controller:v6.1.0
   target: stgregistry.suse.com/rancher/mirrored-sig-storage-snapshot-controller:v6.1.0
   type: image
 - source: registry.k8s.io/sig-storage/snapshot-controller:v6.2.1
@@ -33672,18 +20232,6 @@ sync:
   type: image
 - source: registry.k8s.io/sig-storage/snapshot-controller:v8.2.0
   target: stgregistry.suse.com/rancher/mirrored-sig-storage-snapshot-controller:v8.2.0
-  type: image
-- source: registry.k8s.io/sig-storage/snapshot-controller:v6.1.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-snapshot-controller:v6.1.0
-  type: image
-- source: registry.k8s.io/sig-storage/snapshot-controller:v6.2.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-snapshot-controller:v6.2.1
-  type: image
-- source: registry.k8s.io/sig-storage/snapshot-controller:v8.1.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-snapshot-controller:v8.1.0
-  type: image
-- source: registry.k8s.io/sig-storage/snapshot-controller:v8.2.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-snapshot-controller:v8.2.0
   type: image
 - source: registry.k8s.io/sig-storage/snapshot-validation-webhook:v6.1.0
   target: docker.io/rancher/mirrored-sig-storage-snapshot-validation-webhook:v6.1.0
@@ -33710,18 +20258,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-sig-storage-snapshot-validation-webhook:v8.1.0
   type: image
 - source: registry.k8s.io/sig-storage/snapshot-validation-webhook:v6.1.0
-  target: registry.suse.com/rancher/charts/mirrored-sig-storage-snapshot-validation-webhook:v6.1.0
-  type: image
-- source: registry.k8s.io/sig-storage/snapshot-validation-webhook:v6.2.1
-  target: registry.suse.com/rancher/charts/mirrored-sig-storage-snapshot-validation-webhook:v6.2.1
-  type: image
-- source: registry.k8s.io/sig-storage/snapshot-validation-webhook:v6.2.2
-  target: registry.suse.com/rancher/charts/mirrored-sig-storage-snapshot-validation-webhook:v6.2.2
-  type: image
-- source: registry.k8s.io/sig-storage/snapshot-validation-webhook:v8.1.0
-  target: registry.suse.com/rancher/charts/mirrored-sig-storage-snapshot-validation-webhook:v8.1.0
-  type: image
-- source: registry.k8s.io/sig-storage/snapshot-validation-webhook:v6.1.0
   target: stgregistry.suse.com/rancher/mirrored-sig-storage-snapshot-validation-webhook:v6.1.0
   type: image
 - source: registry.k8s.io/sig-storage/snapshot-validation-webhook:v6.2.1
@@ -33732,18 +20268,6 @@ sync:
   type: image
 - source: registry.k8s.io/sig-storage/snapshot-validation-webhook:v8.1.0
   target: stgregistry.suse.com/rancher/mirrored-sig-storage-snapshot-validation-webhook:v8.1.0
-  type: image
-- source: registry.k8s.io/sig-storage/snapshot-validation-webhook:v6.1.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-snapshot-validation-webhook:v6.1.0
-  type: image
-- source: registry.k8s.io/sig-storage/snapshot-validation-webhook:v6.2.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-snapshot-validation-webhook:v6.2.1
-  type: image
-- source: registry.k8s.io/sig-storage/snapshot-validation-webhook:v6.2.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-snapshot-validation-webhook:v6.2.2
-  type: image
-- source: registry.k8s.io/sig-storage/snapshot-validation-webhook:v8.1.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-sig-storage-snapshot-validation-webhook:v8.1.0
   type: image
 - source: registry.suse.com/bci/bci-busybox:15.4.11.2
   target: docker.io/rancher/mirrored-bci-busybox:15.4.11.2
@@ -33764,15 +20288,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-bci-busybox:15.6.24.2
   type: image
 - source: registry.suse.com/bci/bci-busybox:15.4.11.2
-  target: registry.suse.com/rancher/charts/mirrored-bci-busybox:15.4.11.2
-  type: image
-- source: registry.suse.com/bci/bci-busybox:15.6.19.1
-  target: registry.suse.com/rancher/charts/mirrored-bci-busybox:15.6.19.1
-  type: image
-- source: registry.suse.com/bci/bci-busybox:15.6.24.2
-  target: registry.suse.com/rancher/charts/mirrored-bci-busybox:15.6.24.2
-  type: image
-- source: registry.suse.com/bci/bci-busybox:15.4.11.2
   target: stgregistry.suse.com/rancher/mirrored-bci-busybox:15.4.11.2
   type: image
 - source: registry.suse.com/bci/bci-busybox:15.6.19.1
@@ -33780,15 +20295,6 @@ sync:
   type: image
 - source: registry.suse.com/bci/bci-busybox:15.6.24.2
   target: stgregistry.suse.com/rancher/mirrored-bci-busybox:15.6.24.2
-  type: image
-- source: registry.suse.com/bci/bci-busybox:15.4.11.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-bci-busybox:15.4.11.2
-  type: image
-- source: registry.suse.com/bci/bci-busybox:15.6.19.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-bci-busybox:15.6.19.1
-  type: image
-- source: registry.suse.com/bci/bci-busybox:15.6.24.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-bci-busybox:15.6.24.2
   type: image
 - source: registry.suse.com/bci/bci-micro:15.4.14.3
   target: docker.io/rancher/mirrored-bci-micro:15.4.14.3
@@ -33809,15 +20315,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-bci-micro:15.6.24.2
   type: image
 - source: registry.suse.com/bci/bci-micro:15.4.14.3
-  target: registry.suse.com/rancher/charts/mirrored-bci-micro:15.4.14.3
-  type: image
-- source: registry.suse.com/bci/bci-micro:15.6.19.1
-  target: registry.suse.com/rancher/charts/mirrored-bci-micro:15.6.19.1
-  type: image
-- source: registry.suse.com/bci/bci-micro:15.6.24.2
-  target: registry.suse.com/rancher/charts/mirrored-bci-micro:15.6.24.2
-  type: image
-- source: registry.suse.com/bci/bci-micro:15.4.14.3
   target: stgregistry.suse.com/rancher/mirrored-bci-micro:15.4.14.3
   type: image
 - source: registry.suse.com/bci/bci-micro:15.6.19.1
@@ -33825,15 +20322,6 @@ sync:
   type: image
 - source: registry.suse.com/bci/bci-micro:15.6.24.2
   target: stgregistry.suse.com/rancher/mirrored-bci-micro:15.6.24.2
-  type: image
-- source: registry.suse.com/bci/bci-micro:15.4.14.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-bci-micro:15.4.14.3
-  type: image
-- source: registry.suse.com/bci/bci-micro:15.6.19.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-bci-micro:15.6.19.1
-  type: image
-- source: registry.suse.com/bci/bci-micro:15.6.24.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-bci-micro:15.6.24.2
   type: image
 - source: registry.suse.com/rancher/elemental-operator:1.4.2
   target: docker.io/rancher/mirrored-elemental-operator:1.4.2
@@ -33890,33 +20378,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-elemental-operator:1.7.3
   type: image
 - source: registry.suse.com/rancher/elemental-operator:1.4.2
-  target: registry.suse.com/rancher/charts/mirrored-elemental-operator:1.4.2
-  type: image
-- source: registry.suse.com/rancher/elemental-operator:1.4.3
-  target: registry.suse.com/rancher/charts/mirrored-elemental-operator:1.4.3
-  type: image
-- source: registry.suse.com/rancher/elemental-operator:1.5.3
-  target: registry.suse.com/rancher/charts/mirrored-elemental-operator:1.5.3
-  type: image
-- source: registry.suse.com/rancher/elemental-operator:1.5.4
-  target: registry.suse.com/rancher/charts/mirrored-elemental-operator:1.5.4
-  type: image
-- source: registry.suse.com/rancher/elemental-operator:1.6.4
-  target: registry.suse.com/rancher/charts/mirrored-elemental-operator:1.6.4
-  type: image
-- source: registry.suse.com/rancher/elemental-operator:1.6.5
-  target: registry.suse.com/rancher/charts/mirrored-elemental-operator:1.6.5
-  type: image
-- source: registry.suse.com/rancher/elemental-operator:1.6.8
-  target: registry.suse.com/rancher/charts/mirrored-elemental-operator:1.6.8
-  type: image
-- source: registry.suse.com/rancher/elemental-operator:1.6.9
-  target: registry.suse.com/rancher/charts/mirrored-elemental-operator:1.6.9
-  type: image
-- source: registry.suse.com/rancher/elemental-operator:1.7.3
-  target: registry.suse.com/rancher/charts/mirrored-elemental-operator:1.7.3
-  type: image
-- source: registry.suse.com/rancher/elemental-operator:1.4.2
   target: stgregistry.suse.com/rancher/mirrored-elemental-operator:1.4.2
   type: image
 - source: registry.suse.com/rancher/elemental-operator:1.4.3
@@ -33942,33 +20403,6 @@ sync:
   type: image
 - source: registry.suse.com/rancher/elemental-operator:1.7.3
   target: stgregistry.suse.com/rancher/mirrored-elemental-operator:1.7.3
-  type: image
-- source: registry.suse.com/rancher/elemental-operator:1.4.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-elemental-operator:1.4.2
-  type: image
-- source: registry.suse.com/rancher/elemental-operator:1.4.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-elemental-operator:1.4.3
-  type: image
-- source: registry.suse.com/rancher/elemental-operator:1.5.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-elemental-operator:1.5.3
-  type: image
-- source: registry.suse.com/rancher/elemental-operator:1.5.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-elemental-operator:1.5.4
-  type: image
-- source: registry.suse.com/rancher/elemental-operator:1.6.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-elemental-operator:1.6.4
-  type: image
-- source: registry.suse.com/rancher/elemental-operator:1.6.5
-  target: stgregistry.suse.com/rancher/charts/mirrored-elemental-operator:1.6.5
-  type: image
-- source: registry.suse.com/rancher/elemental-operator:1.6.8
-  target: stgregistry.suse.com/rancher/charts/mirrored-elemental-operator:1.6.8
-  type: image
-- source: registry.suse.com/rancher/elemental-operator:1.6.9
-  target: stgregistry.suse.com/rancher/charts/mirrored-elemental-operator:1.6.9
-  type: image
-- source: registry.suse.com/rancher/elemental-operator:1.7.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-elemental-operator:1.7.3
   type: image
 - source: registry.suse.com/rancher/seedimage-builder:1.3.4
   target: docker.io/rancher/mirrored-elemental-seedimage-builder:1.3.4
@@ -34031,36 +20465,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-elemental-seedimage-builder:1.7.3
   type: image
 - source: registry.suse.com/rancher/seedimage-builder:1.3.4
-  target: registry.suse.com/rancher/charts/mirrored-elemental-seedimage-builder:1.3.4
-  type: image
-- source: registry.suse.com/rancher/seedimage-builder:1.4.2
-  target: registry.suse.com/rancher/charts/mirrored-elemental-seedimage-builder:1.4.2
-  type: image
-- source: registry.suse.com/rancher/seedimage-builder:1.4.3
-  target: registry.suse.com/rancher/charts/mirrored-elemental-seedimage-builder:1.4.3
-  type: image
-- source: registry.suse.com/rancher/seedimage-builder:1.5.3
-  target: registry.suse.com/rancher/charts/mirrored-elemental-seedimage-builder:1.5.3
-  type: image
-- source: registry.suse.com/rancher/seedimage-builder:1.5.4
-  target: registry.suse.com/rancher/charts/mirrored-elemental-seedimage-builder:1.5.4
-  type: image
-- source: registry.suse.com/rancher/seedimage-builder:1.6.4
-  target: registry.suse.com/rancher/charts/mirrored-elemental-seedimage-builder:1.6.4
-  type: image
-- source: registry.suse.com/rancher/seedimage-builder:1.6.5
-  target: registry.suse.com/rancher/charts/mirrored-elemental-seedimage-builder:1.6.5
-  type: image
-- source: registry.suse.com/rancher/seedimage-builder:1.6.8
-  target: registry.suse.com/rancher/charts/mirrored-elemental-seedimage-builder:1.6.8
-  type: image
-- source: registry.suse.com/rancher/seedimage-builder:1.6.9
-  target: registry.suse.com/rancher/charts/mirrored-elemental-seedimage-builder:1.6.9
-  type: image
-- source: registry.suse.com/rancher/seedimage-builder:1.7.3
-  target: registry.suse.com/rancher/charts/mirrored-elemental-seedimage-builder:1.7.3
-  type: image
-- source: registry.suse.com/rancher/seedimage-builder:1.3.4
   target: stgregistry.suse.com/rancher/mirrored-elemental-seedimage-builder:1.3.4
   type: image
 - source: registry.suse.com/rancher/seedimage-builder:1.4.2
@@ -34090,36 +20494,6 @@ sync:
 - source: registry.suse.com/rancher/seedimage-builder:1.7.3
   target: stgregistry.suse.com/rancher/mirrored-elemental-seedimage-builder:1.7.3
   type: image
-- source: registry.suse.com/rancher/seedimage-builder:1.3.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-elemental-seedimage-builder:1.3.4
-  type: image
-- source: registry.suse.com/rancher/seedimage-builder:1.4.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-elemental-seedimage-builder:1.4.2
-  type: image
-- source: registry.suse.com/rancher/seedimage-builder:1.4.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-elemental-seedimage-builder:1.4.3
-  type: image
-- source: registry.suse.com/rancher/seedimage-builder:1.5.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-elemental-seedimage-builder:1.5.3
-  type: image
-- source: registry.suse.com/rancher/seedimage-builder:1.5.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-elemental-seedimage-builder:1.5.4
-  type: image
-- source: registry.suse.com/rancher/seedimage-builder:1.6.4
-  target: stgregistry.suse.com/rancher/charts/mirrored-elemental-seedimage-builder:1.6.4
-  type: image
-- source: registry.suse.com/rancher/seedimage-builder:1.6.5
-  target: stgregistry.suse.com/rancher/charts/mirrored-elemental-seedimage-builder:1.6.5
-  type: image
-- source: registry.suse.com/rancher/seedimage-builder:1.6.8
-  target: stgregistry.suse.com/rancher/charts/mirrored-elemental-seedimage-builder:1.6.8
-  type: image
-- source: registry.suse.com/rancher/seedimage-builder:1.6.9
-  target: stgregistry.suse.com/rancher/charts/mirrored-elemental-seedimage-builder:1.6.9
-  type: image
-- source: registry.suse.com/rancher/seedimage-builder:1.7.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-elemental-seedimage-builder:1.7.3
-  type: image
 - source: rpardini/docker-registry-proxy:0.6.1
   target: docker.io/rancher/rpardini-docker-registry-proxy:0.6.1
   type: image
@@ -34127,13 +20501,7 @@ sync:
   target: registry.suse.com/rancher/rpardini-docker-registry-proxy:0.6.1
   type: image
 - source: rpardini/docker-registry-proxy:0.6.1
-  target: registry.suse.com/rancher/charts/rpardini-docker-registry-proxy:0.6.1
-  type: image
-- source: rpardini/docker-registry-proxy:0.6.1
   target: stgregistry.suse.com/rancher/rpardini-docker-registry-proxy:0.6.1
-  type: image
-- source: rpardini/docker-registry-proxy:0.6.1
-  target: stgregistry.suse.com/rancher/charts/rpardini-docker-registry-proxy:0.6.1
   type: image
 - source: sigwindowstools/k8s-gmsa-webhook:v0.3.0
   target: docker.io/rancher/mirrored-sigwindowstools-k8s-gmsa-webhook:v0.3.0
@@ -34142,13 +20510,7 @@ sync:
   target: registry.suse.com/rancher/mirrored-sigwindowstools-k8s-gmsa-webhook:v0.3.0
   type: image
 - source: sigwindowstools/k8s-gmsa-webhook:v0.3.0
-  target: registry.suse.com/rancher/charts/mirrored-sigwindowstools-k8s-gmsa-webhook:v0.3.0
-  type: image
-- source: sigwindowstools/k8s-gmsa-webhook:v0.3.0
   target: stgregistry.suse.com/rancher/mirrored-sigwindowstools-k8s-gmsa-webhook:v0.3.0
-  type: image
-- source: sigwindowstools/k8s-gmsa-webhook:v0.3.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-sigwindowstools-k8s-gmsa-webhook:v0.3.0
   type: image
 - source: sonobuoy/sonobuoy:v0.16.3
   target: docker.io/rancher/mirrored-sonobuoy-sonobuoy:v0.16.3
@@ -34229,45 +20591,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-sonobuoy-sonobuoy:v0.57.3
   type: image
 - source: sonobuoy/sonobuoy:v0.16.3
-  target: registry.suse.com/rancher/charts/mirrored-sonobuoy-sonobuoy:v0.16.3
-  type: image
-- source: sonobuoy/sonobuoy:v0.19.0
-  target: registry.suse.com/rancher/charts/mirrored-sonobuoy-sonobuoy:v0.19.0
-  type: image
-- source: sonobuoy/sonobuoy:v0.52.0
-  target: registry.suse.com/rancher/charts/mirrored-sonobuoy-sonobuoy:v0.52.0
-  type: image
-- source: sonobuoy/sonobuoy:v0.53.2
-  target: registry.suse.com/rancher/charts/mirrored-sonobuoy-sonobuoy:v0.53.2
-  type: image
-- source: sonobuoy/sonobuoy:v0.56.14
-  target: registry.suse.com/rancher/charts/mirrored-sonobuoy-sonobuoy:v0.56.14
-  type: image
-- source: sonobuoy/sonobuoy:v0.56.15
-  target: registry.suse.com/rancher/charts/mirrored-sonobuoy-sonobuoy:v0.56.15
-  type: image
-- source: sonobuoy/sonobuoy:v0.56.16
-  target: registry.suse.com/rancher/charts/mirrored-sonobuoy-sonobuoy:v0.56.16
-  type: image
-- source: sonobuoy/sonobuoy:v0.56.17
-  target: registry.suse.com/rancher/charts/mirrored-sonobuoy-sonobuoy:v0.56.17
-  type: image
-- source: sonobuoy/sonobuoy:v0.56.7
-  target: registry.suse.com/rancher/charts/mirrored-sonobuoy-sonobuoy:v0.56.7
-  type: image
-- source: sonobuoy/sonobuoy:v0.57.0
-  target: registry.suse.com/rancher/charts/mirrored-sonobuoy-sonobuoy:v0.57.0
-  type: image
-- source: sonobuoy/sonobuoy:v0.57.1
-  target: registry.suse.com/rancher/charts/mirrored-sonobuoy-sonobuoy:v0.57.1
-  type: image
-- source: sonobuoy/sonobuoy:v0.57.2
-  target: registry.suse.com/rancher/charts/mirrored-sonobuoy-sonobuoy:v0.57.2
-  type: image
-- source: sonobuoy/sonobuoy:v0.57.3
-  target: registry.suse.com/rancher/charts/mirrored-sonobuoy-sonobuoy:v0.57.3
-  type: image
-- source: sonobuoy/sonobuoy:v0.16.3
   target: stgregistry.suse.com/rancher/mirrored-sonobuoy-sonobuoy:v0.16.3
   type: image
 - source: sonobuoy/sonobuoy:v0.19.0
@@ -34306,45 +20629,6 @@ sync:
 - source: sonobuoy/sonobuoy:v0.57.3
   target: stgregistry.suse.com/rancher/mirrored-sonobuoy-sonobuoy:v0.57.3
   type: image
-- source: sonobuoy/sonobuoy:v0.16.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-sonobuoy-sonobuoy:v0.16.3
-  type: image
-- source: sonobuoy/sonobuoy:v0.19.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-sonobuoy-sonobuoy:v0.19.0
-  type: image
-- source: sonobuoy/sonobuoy:v0.52.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-sonobuoy-sonobuoy:v0.52.0
-  type: image
-- source: sonobuoy/sonobuoy:v0.53.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-sonobuoy-sonobuoy:v0.53.2
-  type: image
-- source: sonobuoy/sonobuoy:v0.56.14
-  target: stgregistry.suse.com/rancher/charts/mirrored-sonobuoy-sonobuoy:v0.56.14
-  type: image
-- source: sonobuoy/sonobuoy:v0.56.15
-  target: stgregistry.suse.com/rancher/charts/mirrored-sonobuoy-sonobuoy:v0.56.15
-  type: image
-- source: sonobuoy/sonobuoy:v0.56.16
-  target: stgregistry.suse.com/rancher/charts/mirrored-sonobuoy-sonobuoy:v0.56.16
-  type: image
-- source: sonobuoy/sonobuoy:v0.56.17
-  target: stgregistry.suse.com/rancher/charts/mirrored-sonobuoy-sonobuoy:v0.56.17
-  type: image
-- source: sonobuoy/sonobuoy:v0.56.7
-  target: stgregistry.suse.com/rancher/charts/mirrored-sonobuoy-sonobuoy:v0.56.7
-  type: image
-- source: sonobuoy/sonobuoy:v0.57.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-sonobuoy-sonobuoy:v0.57.0
-  type: image
-- source: sonobuoy/sonobuoy:v0.57.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-sonobuoy-sonobuoy:v0.57.1
-  type: image
-- source: sonobuoy/sonobuoy:v0.57.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-sonobuoy-sonobuoy:v0.57.2
-  type: image
-- source: sonobuoy/sonobuoy:v0.57.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-sonobuoy-sonobuoy:v0.57.3
-  type: image
 - source: sonobuoy/sonobuoy:v0.19.0
   target: docker.io/rancher/sonobuoy-sonobuoy:v0.19.0
   type: image
@@ -34352,13 +20636,7 @@ sync:
   target: registry.suse.com/rancher/sonobuoy-sonobuoy:v0.19.0
   type: image
 - source: sonobuoy/sonobuoy:v0.19.0
-  target: registry.suse.com/rancher/charts/sonobuoy-sonobuoy:v0.19.0
-  type: image
-- source: sonobuoy/sonobuoy:v0.19.0
   target: stgregistry.suse.com/rancher/sonobuoy-sonobuoy:v0.19.0
-  type: image
-- source: sonobuoy/sonobuoy:v0.19.0
-  target: stgregistry.suse.com/rancher/charts/sonobuoy-sonobuoy:v0.19.0
   type: image
 - source: squareup/ghostunnel:v1.5.2
   target: docker.io/rancher/mirrored-squareup-ghostunnel:v1.5.2
@@ -34367,13 +20645,7 @@ sync:
   target: registry.suse.com/rancher/mirrored-squareup-ghostunnel:v1.5.2
   type: image
 - source: squareup/ghostunnel:v1.5.2
-  target: registry.suse.com/rancher/charts/mirrored-squareup-ghostunnel:v1.5.2
-  type: image
-- source: squareup/ghostunnel:v1.5.2
   target: stgregistry.suse.com/rancher/mirrored-squareup-ghostunnel:v1.5.2
-  type: image
-- source: squareup/ghostunnel:v1.5.2
-  target: stgregistry.suse.com/rancher/charts/mirrored-squareup-ghostunnel:v1.5.2
   type: image
 - source: squareup/ghostunnel:v1.5.2
   target: docker.io/rancher/squareup-ghostunnel:v1.5.2
@@ -34382,13 +20654,7 @@ sync:
   target: registry.suse.com/rancher/squareup-ghostunnel:v1.5.2
   type: image
 - source: squareup/ghostunnel:v1.5.2
-  target: registry.suse.com/rancher/charts/squareup-ghostunnel:v1.5.2
-  type: image
-- source: squareup/ghostunnel:v1.5.2
   target: stgregistry.suse.com/rancher/squareup-ghostunnel:v1.5.2
-  type: image
-- source: squareup/ghostunnel:v1.5.2
-  target: stgregistry.suse.com/rancher/charts/squareup-ghostunnel:v1.5.2
   type: image
 - source: thanosio/thanos:v0.15.0
   target: docker.io/rancher/mirrored-thanosio-thanos:v0.15.0
@@ -34403,22 +20669,10 @@ sync:
   target: registry.suse.com/rancher/mirrored-thanosio-thanos:v0.21.1
   type: image
 - source: thanosio/thanos:v0.15.0
-  target: registry.suse.com/rancher/charts/mirrored-thanosio-thanos:v0.15.0
-  type: image
-- source: thanosio/thanos:v0.21.1
-  target: registry.suse.com/rancher/charts/mirrored-thanosio-thanos:v0.21.1
-  type: image
-- source: thanosio/thanos:v0.15.0
   target: stgregistry.suse.com/rancher/mirrored-thanosio-thanos:v0.15.0
   type: image
 - source: thanosio/thanos:v0.21.1
   target: stgregistry.suse.com/rancher/mirrored-thanosio-thanos:v0.21.1
-  type: image
-- source: thanosio/thanos:v0.15.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-thanosio-thanos:v0.15.0
-  type: image
-- source: thanosio/thanos:v0.21.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-thanosio-thanos:v0.21.1
   type: image
 - source: thanosio/thanos:v0.15.0
   target: docker.io/rancher/thanosio-thanos:v0.15.0
@@ -34427,13 +20681,7 @@ sync:
   target: registry.suse.com/rancher/thanosio-thanos:v0.15.0
   type: image
 - source: thanosio/thanos:v0.15.0
-  target: registry.suse.com/rancher/charts/thanosio-thanos:v0.15.0
-  type: image
-- source: thanosio/thanos:v0.15.0
   target: stgregistry.suse.com/rancher/thanosio-thanos:v0.15.0
-  type: image
-- source: thanosio/thanos:v0.15.0
-  target: stgregistry.suse.com/rancher/charts/thanosio-thanos:v0.15.0
   type: image
 - source: tonistiigi/xx:1.3.0
   target: docker.io/rancher/mirrored-tonistiigi-xx:1.3.0
@@ -34460,18 +20708,6 @@ sync:
   target: registry.suse.com/rancher/mirrored-tonistiigi-xx:1.6.1
   type: image
 - source: tonistiigi/xx:1.3.0
-  target: registry.suse.com/rancher/charts/mirrored-tonistiigi-xx:1.3.0
-  type: image
-- source: tonistiigi/xx:1.5.0
-  target: registry.suse.com/rancher/charts/mirrored-tonistiigi-xx:1.5.0
-  type: image
-- source: tonistiigi/xx:1.6.0
-  target: registry.suse.com/rancher/charts/mirrored-tonistiigi-xx:1.6.0
-  type: image
-- source: tonistiigi/xx:1.6.1
-  target: registry.suse.com/rancher/charts/mirrored-tonistiigi-xx:1.6.1
-  type: image
-- source: tonistiigi/xx:1.3.0
   target: stgregistry.suse.com/rancher/mirrored-tonistiigi-xx:1.3.0
   type: image
 - source: tonistiigi/xx:1.5.0
@@ -34483,18 +20719,6 @@ sync:
 - source: tonistiigi/xx:1.6.1
   target: stgregistry.suse.com/rancher/mirrored-tonistiigi-xx:1.6.1
   type: image
-- source: tonistiigi/xx:1.3.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-tonistiigi-xx:1.3.0
-  type: image
-- source: tonistiigi/xx:1.5.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-tonistiigi-xx:1.5.0
-  type: image
-- source: tonistiigi/xx:1.6.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-tonistiigi-xx:1.6.0
-  type: image
-- source: tonistiigi/xx:1.6.1
-  target: stgregistry.suse.com/rancher/charts/mirrored-tonistiigi-xx:1.6.1
-  type: image
 - source: us.gcr.io/k8s-artifacts-prod/external-dns/external-dns:v0.7.3
   target: docker.io/rancher/kubernetes-external-dns:v0.7.3
   type: image
@@ -34502,13 +20726,7 @@ sync:
   target: registry.suse.com/rancher/kubernetes-external-dns:v0.7.3
   type: image
 - source: us.gcr.io/k8s-artifacts-prod/external-dns/external-dns:v0.7.3
-  target: registry.suse.com/rancher/charts/kubernetes-external-dns:v0.7.3
-  type: image
-- source: us.gcr.io/k8s-artifacts-prod/external-dns/external-dns:v0.7.3
   target: stgregistry.suse.com/rancher/kubernetes-external-dns:v0.7.3
-  type: image
-- source: us.gcr.io/k8s-artifacts-prod/external-dns/external-dns:v0.7.3
-  target: stgregistry.suse.com/rancher/charts/kubernetes-external-dns:v0.7.3
   type: image
 - source: us.gcr.io/k8s-artifacts-prod/external-dns/external-dns:v0.7.3
   target: docker.io/rancher/mirrored-kubernetes-external-dns:v0.7.3
@@ -34517,11 +20735,5 @@ sync:
   target: registry.suse.com/rancher/mirrored-kubernetes-external-dns:v0.7.3
   type: image
 - source: us.gcr.io/k8s-artifacts-prod/external-dns/external-dns:v0.7.3
-  target: registry.suse.com/rancher/charts/mirrored-kubernetes-external-dns:v0.7.3
-  type: image
-- source: us.gcr.io/k8s-artifacts-prod/external-dns/external-dns:v0.7.3
   target: stgregistry.suse.com/rancher/mirrored-kubernetes-external-dns:v0.7.3
-  type: image
-- source: us.gcr.io/k8s-artifacts-prod/external-dns/external-dns:v0.7.3
-  target: stgregistry.suse.com/rancher/charts/mirrored-kubernetes-external-dns:v0.7.3
   type: image

--- a/tools/internal/config/config.go
+++ b/tools/internal/config/config.go
@@ -23,8 +23,9 @@ type Repository struct {
 	// "mirrored-rancher-cis-operator" and a BaseUrl of "docker.io/rancher"
 	// produce a target image ref of "docker.io/rancher/mirrored-rancher-cis-operator".
 	BaseUrl string
-	// Whether the repository should have images mirrored to it.
-	Target bool
+	// Whether the Repository is used as a target repository for a given
+	// Image when the TargetRepositories field of the Image is not set.
+	DefaultTarget bool
 	// Password is what goes into the "pass" field of regsync.yaml
 	// for this repository. For more information please see
 	// https://github.com/regclient/regclient/blob/main/docs/regsync.md

--- a/tools/internal/config/config_test.go
+++ b/tools/internal/config/config_test.go
@@ -8,25 +8,25 @@ import (
 
 func TestConfig(t *testing.T) {
 	t.Run("ToRegsyncConfig", func(t *testing.T) {
-		t.Run("should always include Repositories in regsync config even if Target field is false", func(t *testing.T) {
+		t.Run("should always include Repositories in regsync config even if DefaultTarget field is false", func(t *testing.T) {
 			// Non-target repos should still be included in regsync.yaml, since
 			// they may be the source of some images.
 			config := &Config{
 				Images: []*Image{},
 				Repositories: []Repository{
 					{
-						BaseUrl:  "docker.io/target-repo",
-						Target:   true,
-						Username: "target-user",
-						Password: "target-pass",
-						Registry: "docker.io",
+						BaseUrl:       "docker.io/target-repo",
+						DefaultTarget: true,
+						Username:      "target-user",
+						Password:      "target-pass",
+						Registry:      "docker.io",
 					},
 					{
-						BaseUrl:  "docker.io/non-target-repo",
-						Target:   false,
-						Username: "non-target-user",
-						Password: "non-target-pass",
-						Registry: "docker.io",
+						BaseUrl:       "docker.io/non-target-repo",
+						DefaultTarget: false,
+						Username:      "non-target-user",
+						Password:      "non-target-pass",
+						Registry:      "docker.io",
 					},
 				},
 			}

--- a/tools/internal/config/image.go
+++ b/tools/internal/config/image.go
@@ -32,10 +32,10 @@ type Image struct {
 	SpecifiedTargetImageName string `json:"TargetImageName,omitempty"`
 	// The tags that we want to mirror.
 	Tags []string
-	// The Repositories that you want to limit mirroring to. Repositories
+	// The Repositories that you want to mirror the Image to. Repositories
 	// are specified via their BaseUrl field. If TargetRepositories is not
 	// specified, the Image is mirrored to all Repositories that have
-	// their Target field set to true.
+	// DefaultTarget set to true.
 	TargetRepositories []string `json:",omitempty"`
 }
 
@@ -133,7 +133,7 @@ func (image *Image) CombineSourceImageAndTags() []string {
 func (image *Image) ToRegsyncImages(repositories []Repository) ([]regsync.ConfigSync, error) {
 	entries := make([]regsync.ConfigSync, 0)
 	for _, repository := range repositories {
-		if !repository.Target && len(image.TargetRepositories) == 0 {
+		if !repository.DefaultTarget && len(image.TargetRepositories) == 0 {
 			continue
 		}
 		if len(image.TargetRepositories) > 0 && !slices.Contains(image.TargetRepositories, repository.BaseUrl) {

--- a/tools/internal/config/image.go
+++ b/tools/internal/config/image.go
@@ -133,7 +133,7 @@ func (image *Image) CombineSourceImageAndTags() []string {
 func (image *Image) ToRegsyncImages(repositories []Repository) ([]regsync.ConfigSync, error) {
 	entries := make([]regsync.ConfigSync, 0)
 	for _, repository := range repositories {
-		if !repository.Target {
+		if !repository.Target && len(image.TargetRepositories) == 0 {
 			continue
 		}
 		if len(image.TargetRepositories) > 0 && !slices.Contains(image.TargetRepositories, repository.BaseUrl) {


### PR DESCRIPTION
#### Pull Request Checklist ####

- [x] If an entire image is being added, a repo has been created for the image in DockerHub under the `rancher` org
- [x] Additions are licensed with Rancher favored licenses - Apache 2 and MIT - or approved licenses - as according to [CNCF approved licenses](https://github.com/cncf/foundation/blob/main/allowed-third-party-license-policy.md).
- [x] Additions, when used in Rancher or Rancher's provided charts, have their corresponding origin added in Rancher's images [origins](https://github.com/rancher/rancher/blob/release/v2.7/pkg/image/origins.go) file (must be added for all Rancher versions `>= v2.7`).
- [x] Any changes to scripting or CI config have been tested to the best of your ability

#### Change Description ####

<!-- Describe what you are doing and why. Link any related issues, pull requests and commit hashes. -->

~moving~ changing the cluster-autoscaler chart from `{stg,}registry.suse.com/rancher` to `{stg,}registry.suse.com/rancher/charts` in order to prevent tag conflicts. 

the old chart oci image will still be left there - but conflicts are unlikely. 

#### Final Checks after the PR is merged ####

- [ ] Confirm that you can pull the mirrored images and tags from all target locations
