### PR TITLE
Include `TargetRepositories` in `Image.DeepCopy`

### DIFF
--- a/tools/internal/config/image.go
+++ b/tools/internal/config/image.go
@@ -188,6 +188,7 @@ func (image *Image) DeepCopy() *Image {
 		excludeAllTags:           image.excludeAllTags,
 		excludedTags:             maps.Clone(image.excludedTags),
 		Tags:                     slices.Clone(image.Tags),
+		TargetRepositories:       slices.Clone(image.TargetRepositories),
 	}
 	return copiedImage
 }

--- a/tools/internal/config/image_test.go
+++ b/tools/internal/config/image_test.go
@@ -278,6 +278,7 @@ func TestImage(t *testing.T) {
 			assert.Equal(t, original.Tags, copy.Tags)
 			assert.Equal(t, original.excludeAllTags, copy.excludeAllTags)
 			assert.Equal(t, original.excludedTags, copy.excludedTags)
+			assert.Equal(t, original.TargetRepositories, copy.TargetRepositories)
 		})
 	})
 }


### PR DESCRIPTION
Closes https://github.com/rancher/rancher/issues/52487.