### PR TITLE
Mirror appco images that can bring CVE reductions to Rancher Monitoring chart

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -146,6 +146,9 @@ Images:
 - SourceImage: dp.apps.rancher.io/containers/redis
   Tags:
   - 8.0.3-2.1
+- SourceImage: dp.apps.rancher.io/containers/thanos
+  Tags:
+  - 0.39.2-7.3
 - SourceImage: flannel/flannel
   Tags:
   - v0.21.2

--- a/regsync.yaml
+++ b/regsync.yaml
@@ -674,6 +674,15 @@ sync:
 - source: dp.apps.rancher.io/containers/redis:8.0.3-2.1
   target: stgregistry.suse.com/rancher/appco-redis:8.0.3-2.1
   type: image
+- source: dp.apps.rancher.io/containers/thanos:0.39.2-7.3
+  target: docker.io/rancher/appco-thanos:0.39.2-7.3
+  type: image
+- source: dp.apps.rancher.io/containers/thanos:0.39.2-7.3
+  target: registry.suse.com/rancher/appco-thanos:0.39.2-7.3
+  type: image
+- source: dp.apps.rancher.io/containers/thanos:0.39.2-7.3
+  target: stgregistry.suse.com/rancher/appco-thanos:0.39.2-7.3
+  type: image
 - source: flannel/flannel:v0.21.2
   target: docker.io/rancher/mirrored-flannel-flannel:v0.21.2
   type: image


### PR DESCRIPTION
#### Pull Request Checklist ####

- [x] If an entire image is being added, a repo has been created for the image in DockerHub under the `rancher` org
- [x] Additions are licensed with Rancher favored licenses - Apache 2 and MIT - or approved licenses - as according to [CNCF approved licenses](https://github.com/cncf/foundation/blob/main/allowed-third-party-license-policy.md).
- [x] Additions, when used in Rancher or Rancher's provided charts, have their corresponding origin added in Rancher's images [origins](https://github.com/rancher/rancher/blob/release/v2.7/pkg/image/origins.go) file (must be added for all Rancher versions `>= v2.7`).
- [x] Any changes to scripting or CI config have been tested to the best of your ability

#### Change Description ####

This is for https://github.com/rancher/rancher/issues/51787.

In https://github.com/rancher/rancher/issues/51728 I found that some appco images, if used in Rancher Monitoring instead of their mainstream counterparts, can give us a significant reduction in CVE counts. This PR mirrors the images, so that we can in turn use the images in the Rancher Monitoring chart.

#### Final Checks after the PR is merged ####

- [ ] Confirm that you can pull the mirrored images and tags from all target locations
