### PR TITLE
feat: add longhorn v1.10.1 images

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -928,6 +928,7 @@ Images:
   TargetImageName: longhornio-backing-image-manager
 - SourceImage: longhornio/backing-image-manager
   Tags:
+  - v1.10.1
   - v1.4.0
   - v1.4.1
   - v1.4.2
@@ -975,6 +976,7 @@ Images:
   - v2.2.1-lh2
   - v3.2.1
   - v3.4.0
+  - v4.10.0-20251030
   - v4.2.0
   - v4.4.2
   - v4.5.1
@@ -1001,6 +1003,7 @@ Images:
   - v2.13.0
   - v2.14.0
   - v2.14.0-20250709
+  - v2.15.0-20251030
   - v2.3.0
   - v2.5.0
   - v2.7.0
@@ -1028,6 +1031,7 @@ Images:
   - v5.2.0
   - v5.3.0
   - v5.3.0-20250709
+  - v5.3.0-20251030
 - SourceImage: longhornio/csi-resizer
   Tags:
   - v0.3.0
@@ -1046,6 +1050,7 @@ Images:
   - v1.13.1
   - v1.13.2
   - v1.14.0-20250709
+  - v1.14.0-20251030
   - v1.2.0
   - v1.3.0
   - v1.7.0
@@ -1071,6 +1076,7 @@ Images:
   - v7.0.2-20250204
   - v8.2.0
   - v8.3.0-20250709
+  - v8.4.0-20251030
 - SourceImage: longhornio/livenessprobe
   Tags:
   - v2.11.0
@@ -1081,10 +1087,12 @@ Images:
   - v2.15.0
   - v2.16.0
   - v2.16.0-20250709
+  - v2.17.0-20251030
   - v2.8.0
   - v2.9.0
 - SourceImage: longhornio/longhorn-cli
   Tags:
+  - v1.10.1
   - v1.7.0
   - v1.7.1
   - v1.7.2
@@ -1115,6 +1123,7 @@ Images:
   - v1.1.1
   - v1.1.2
   - v1.1.3
+  - v1.10.1
   - v1.2.0
   - v1.2.1
   - v1.2.2
@@ -1164,6 +1173,7 @@ Images:
   TargetImageName: longhornio-longhorn-instance-manager
 - SourceImage: longhornio/longhorn-instance-manager
   Tags:
+  - v1.10.1
   - v1.4.0
   - v1.4.1
   - v1.4.2
@@ -1221,6 +1231,7 @@ Images:
   - v1.1.1
   - v1.1.2
   - v1.1.3
+  - v1.10.1
   - v1.2.0
   - v1.2.1
   - v1.2.2
@@ -1270,6 +1281,7 @@ Images:
   TargetImageName: longhornio-longhorn-share-manager
 - SourceImage: longhornio/longhorn-share-manager
   Tags:
+  - v1.10.1
   - v1.4.0
   - v1.4.1
   - v1.4.2
@@ -1328,6 +1340,7 @@ Images:
   - v1.1.1
   - v1.1.2
   - v1.1.3
+  - v1.10.1
   - v1.2.0
   - v1.2.1
   - v1.2.2
@@ -1388,6 +1401,7 @@ Images:
   - v0.0.56
   - v0.0.61
   - v0.0.69
+  - v0.0.71
 - SourceImage: messagebird/sachet
   Tags:
   - 0.2.3

--- a/regsync.yaml
+++ b/regsync.yaml
@@ -5309,6 +5309,9 @@ sync:
 - source: longhornio/backing-image-manager:v3_20220808
   target: stgregistry.suse.com/rancher/longhornio-backing-image-manager:v3_20220808
   type: image
+- source: longhornio/backing-image-manager:v1.10.1
+  target: docker.io/rancher/mirrored-longhornio-backing-image-manager:v1.10.1
+  type: image
 - source: longhornio/backing-image-manager:v1.4.0
   target: docker.io/rancher/mirrored-longhornio-backing-image-manager:v1.4.0
   type: image
@@ -5408,6 +5411,9 @@ sync:
 - source: longhornio/backing-image-manager:v3_20230320
   target: docker.io/rancher/mirrored-longhornio-backing-image-manager:v3_20230320
   type: image
+- source: longhornio/backing-image-manager:v1.10.1
+  target: registry.suse.com/rancher/mirrored-longhornio-backing-image-manager:v1.10.1
+  type: image
 - source: longhornio/backing-image-manager:v1.4.0
   target: registry.suse.com/rancher/mirrored-longhornio-backing-image-manager:v1.4.0
   type: image
@@ -5506,6 +5512,9 @@ sync:
   type: image
 - source: longhornio/backing-image-manager:v3_20230320
   target: registry.suse.com/rancher/mirrored-longhornio-backing-image-manager:v3_20230320
+  type: image
+- source: longhornio/backing-image-manager:v1.10.1
+  target: stgregistry.suse.com/rancher/mirrored-longhornio-backing-image-manager:v1.10.1
   type: image
 - source: longhornio/backing-image-manager:v1.4.0
   target: stgregistry.suse.com/rancher/mirrored-longhornio-backing-image-manager:v1.4.0
@@ -5663,6 +5672,9 @@ sync:
 - source: longhornio/csi-attacher:v3.4.0
   target: docker.io/rancher/mirrored-longhornio-csi-attacher:v3.4.0
   type: image
+- source: longhornio/csi-attacher:v4.10.0-20251030
+  target: docker.io/rancher/mirrored-longhornio-csi-attacher:v4.10.0-20251030
+  type: image
 - source: longhornio/csi-attacher:v4.2.0
   target: docker.io/rancher/mirrored-longhornio-csi-attacher:v4.2.0
   type: image
@@ -5705,6 +5717,9 @@ sync:
 - source: longhornio/csi-attacher:v3.4.0
   target: registry.suse.com/rancher/mirrored-longhornio-csi-attacher:v3.4.0
   type: image
+- source: longhornio/csi-attacher:v4.10.0-20251030
+  target: registry.suse.com/rancher/mirrored-longhornio-csi-attacher:v4.10.0-20251030
+  type: image
 - source: longhornio/csi-attacher:v4.2.0
   target: registry.suse.com/rancher/mirrored-longhornio-csi-attacher:v4.2.0
   type: image
@@ -5746,6 +5761,9 @@ sync:
   type: image
 - source: longhornio/csi-attacher:v3.4.0
   target: stgregistry.suse.com/rancher/mirrored-longhornio-csi-attacher:v3.4.0
+  type: image
+- source: longhornio/csi-attacher:v4.10.0-20251030
+  target: stgregistry.suse.com/rancher/mirrored-longhornio-csi-attacher:v4.10.0-20251030
   type: image
 - source: longhornio/csi-attacher:v4.2.0
   target: stgregistry.suse.com/rancher/mirrored-longhornio-csi-attacher:v4.2.0
@@ -5834,6 +5852,9 @@ sync:
 - source: longhornio/csi-node-driver-registrar:v2.14.0-20250709
   target: docker.io/rancher/mirrored-longhornio-csi-node-driver-registrar:v2.14.0-20250709
   type: image
+- source: longhornio/csi-node-driver-registrar:v2.15.0-20251030
+  target: docker.io/rancher/mirrored-longhornio-csi-node-driver-registrar:v2.15.0-20251030
+  type: image
 - source: longhornio/csi-node-driver-registrar:v2.3.0
   target: docker.io/rancher/mirrored-longhornio-csi-node-driver-registrar:v2.3.0
   type: image
@@ -5867,6 +5888,9 @@ sync:
 - source: longhornio/csi-node-driver-registrar:v2.14.0-20250709
   target: registry.suse.com/rancher/mirrored-longhornio-csi-node-driver-registrar:v2.14.0-20250709
   type: image
+- source: longhornio/csi-node-driver-registrar:v2.15.0-20251030
+  target: registry.suse.com/rancher/mirrored-longhornio-csi-node-driver-registrar:v2.15.0-20251030
+  type: image
 - source: longhornio/csi-node-driver-registrar:v2.3.0
   target: registry.suse.com/rancher/mirrored-longhornio-csi-node-driver-registrar:v2.3.0
   type: image
@@ -5899,6 +5923,9 @@ sync:
   type: image
 - source: longhornio/csi-node-driver-registrar:v2.14.0-20250709
   target: stgregistry.suse.com/rancher/mirrored-longhornio-csi-node-driver-registrar:v2.14.0-20250709
+  type: image
+- source: longhornio/csi-node-driver-registrar:v2.15.0-20251030
+  target: stgregistry.suse.com/rancher/mirrored-longhornio-csi-node-driver-registrar:v2.15.0-20251030
   type: image
 - source: longhornio/csi-node-driver-registrar:v2.3.0
   target: stgregistry.suse.com/rancher/mirrored-longhornio-csi-node-driver-registrar:v2.3.0
@@ -5990,6 +6017,9 @@ sync:
 - source: longhornio/csi-provisioner:v5.3.0-20250709
   target: docker.io/rancher/mirrored-longhornio-csi-provisioner:v5.3.0-20250709
   type: image
+- source: longhornio/csi-provisioner:v5.3.0-20251030
+  target: docker.io/rancher/mirrored-longhornio-csi-provisioner:v5.3.0-20251030
+  type: image
 - source: longhornio/csi-provisioner:v1.6.0-lh1
   target: registry.suse.com/rancher/mirrored-longhornio-csi-provisioner:v1.6.0-lh1
   type: image
@@ -6032,6 +6062,9 @@ sync:
 - source: longhornio/csi-provisioner:v5.3.0-20250709
   target: registry.suse.com/rancher/mirrored-longhornio-csi-provisioner:v5.3.0-20250709
   type: image
+- source: longhornio/csi-provisioner:v5.3.0-20251030
+  target: registry.suse.com/rancher/mirrored-longhornio-csi-provisioner:v5.3.0-20251030
+  type: image
 - source: longhornio/csi-provisioner:v1.6.0-lh1
   target: stgregistry.suse.com/rancher/mirrored-longhornio-csi-provisioner:v1.6.0-lh1
   type: image
@@ -6073,6 +6106,9 @@ sync:
   type: image
 - source: longhornio/csi-provisioner:v5.3.0-20250709
   target: stgregistry.suse.com/rancher/mirrored-longhornio-csi-provisioner:v5.3.0-20250709
+  type: image
+- source: longhornio/csi-provisioner:v5.3.0-20251030
+  target: stgregistry.suse.com/rancher/mirrored-longhornio-csi-provisioner:v5.3.0-20251030
   type: image
 - source: longhornio/csi-resizer:v0.3.0
   target: docker.io/rancher/longhornio-csi-resizer:v0.3.0
@@ -6137,6 +6173,9 @@ sync:
 - source: longhornio/csi-resizer:v1.14.0-20250709
   target: docker.io/rancher/mirrored-longhornio-csi-resizer:v1.14.0-20250709
   type: image
+- source: longhornio/csi-resizer:v1.14.0-20251030
+  target: docker.io/rancher/mirrored-longhornio-csi-resizer:v1.14.0-20251030
+  type: image
 - source: longhornio/csi-resizer:v1.2.0
   target: docker.io/rancher/mirrored-longhornio-csi-resizer:v1.2.0
   type: image
@@ -6176,6 +6215,9 @@ sync:
 - source: longhornio/csi-resizer:v1.14.0-20250709
   target: registry.suse.com/rancher/mirrored-longhornio-csi-resizer:v1.14.0-20250709
   type: image
+- source: longhornio/csi-resizer:v1.14.0-20251030
+  target: registry.suse.com/rancher/mirrored-longhornio-csi-resizer:v1.14.0-20251030
+  type: image
 - source: longhornio/csi-resizer:v1.2.0
   target: registry.suse.com/rancher/mirrored-longhornio-csi-resizer:v1.2.0
   type: image
@@ -6214,6 +6256,9 @@ sync:
   type: image
 - source: longhornio/csi-resizer:v1.14.0-20250709
   target: stgregistry.suse.com/rancher/mirrored-longhornio-csi-resizer:v1.14.0-20250709
+  type: image
+- source: longhornio/csi-resizer:v1.14.0-20251030
+  target: stgregistry.suse.com/rancher/mirrored-longhornio-csi-resizer:v1.14.0-20251030
   type: image
 - source: longhornio/csi-resizer:v1.2.0
   target: stgregistry.suse.com/rancher/mirrored-longhornio-csi-resizer:v1.2.0
@@ -6293,6 +6338,9 @@ sync:
 - source: longhornio/csi-snapshotter:v8.3.0-20250709
   target: docker.io/rancher/mirrored-longhornio-csi-snapshotter:v8.3.0-20250709
   type: image
+- source: longhornio/csi-snapshotter:v8.4.0-20251030
+  target: docker.io/rancher/mirrored-longhornio-csi-snapshotter:v8.4.0-20251030
+  type: image
 - source: longhornio/csi-snapshotter:v2.1.1-lh1
   target: registry.suse.com/rancher/mirrored-longhornio-csi-snapshotter:v2.1.1-lh1
   type: image
@@ -6331,6 +6379,9 @@ sync:
   type: image
 - source: longhornio/csi-snapshotter:v8.3.0-20250709
   target: registry.suse.com/rancher/mirrored-longhornio-csi-snapshotter:v8.3.0-20250709
+  type: image
+- source: longhornio/csi-snapshotter:v8.4.0-20251030
+  target: registry.suse.com/rancher/mirrored-longhornio-csi-snapshotter:v8.4.0-20251030
   type: image
 - source: longhornio/csi-snapshotter:v2.1.1-lh1
   target: stgregistry.suse.com/rancher/mirrored-longhornio-csi-snapshotter:v2.1.1-lh1
@@ -6371,6 +6422,9 @@ sync:
 - source: longhornio/csi-snapshotter:v8.3.0-20250709
   target: stgregistry.suse.com/rancher/mirrored-longhornio-csi-snapshotter:v8.3.0-20250709
   type: image
+- source: longhornio/csi-snapshotter:v8.4.0-20251030
+  target: stgregistry.suse.com/rancher/mirrored-longhornio-csi-snapshotter:v8.4.0-20251030
+  type: image
 - source: longhornio/livenessprobe:v2.11.0
   target: docker.io/rancher/mirrored-longhornio-livenessprobe:v2.11.0
   type: image
@@ -6394,6 +6448,9 @@ sync:
   type: image
 - source: longhornio/livenessprobe:v2.16.0-20250709
   target: docker.io/rancher/mirrored-longhornio-livenessprobe:v2.16.0-20250709
+  type: image
+- source: longhornio/livenessprobe:v2.17.0-20251030
+  target: docker.io/rancher/mirrored-longhornio-livenessprobe:v2.17.0-20251030
   type: image
 - source: longhornio/livenessprobe:v2.8.0
   target: docker.io/rancher/mirrored-longhornio-livenessprobe:v2.8.0
@@ -6425,6 +6482,9 @@ sync:
 - source: longhornio/livenessprobe:v2.16.0-20250709
   target: registry.suse.com/rancher/mirrored-longhornio-livenessprobe:v2.16.0-20250709
   type: image
+- source: longhornio/livenessprobe:v2.17.0-20251030
+  target: registry.suse.com/rancher/mirrored-longhornio-livenessprobe:v2.17.0-20251030
+  type: image
 - source: longhornio/livenessprobe:v2.8.0
   target: registry.suse.com/rancher/mirrored-longhornio-livenessprobe:v2.8.0
   type: image
@@ -6455,11 +6515,17 @@ sync:
 - source: longhornio/livenessprobe:v2.16.0-20250709
   target: stgregistry.suse.com/rancher/mirrored-longhornio-livenessprobe:v2.16.0-20250709
   type: image
+- source: longhornio/livenessprobe:v2.17.0-20251030
+  target: stgregistry.suse.com/rancher/mirrored-longhornio-livenessprobe:v2.17.0-20251030
+  type: image
 - source: longhornio/livenessprobe:v2.8.0
   target: stgregistry.suse.com/rancher/mirrored-longhornio-livenessprobe:v2.8.0
   type: image
 - source: longhornio/livenessprobe:v2.9.0
   target: stgregistry.suse.com/rancher/mirrored-longhornio-livenessprobe:v2.9.0
+  type: image
+- source: longhornio/longhorn-cli:v1.10.1
+  target: docker.io/rancher/mirrored-longhornio-longhorn-cli:v1.10.1
   type: image
 - source: longhornio/longhorn-cli:v1.7.0
   target: docker.io/rancher/mirrored-longhornio-longhorn-cli:v1.7.0
@@ -6485,6 +6551,9 @@ sync:
 - source: longhornio/longhorn-cli:v1.9.2
   target: docker.io/rancher/mirrored-longhornio-longhorn-cli:v1.9.2
   type: image
+- source: longhornio/longhorn-cli:v1.10.1
+  target: registry.suse.com/rancher/mirrored-longhornio-longhorn-cli:v1.10.1
+  type: image
 - source: longhornio/longhorn-cli:v1.7.0
   target: registry.suse.com/rancher/mirrored-longhornio-longhorn-cli:v1.7.0
   type: image
@@ -6508,6 +6577,9 @@ sync:
   type: image
 - source: longhornio/longhorn-cli:v1.9.2
   target: registry.suse.com/rancher/mirrored-longhornio-longhorn-cli:v1.9.2
+  type: image
+- source: longhornio/longhorn-cli:v1.10.1
+  target: stgregistry.suse.com/rancher/mirrored-longhornio-longhorn-cli:v1.10.1
   type: image
 - source: longhornio/longhorn-cli:v1.7.0
   target: stgregistry.suse.com/rancher/mirrored-longhornio-longhorn-cli:v1.7.0
@@ -6662,6 +6734,9 @@ sync:
 - source: longhornio/longhorn-engine:v1.1.3
   target: docker.io/rancher/mirrored-longhornio-longhorn-engine:v1.1.3
   type: image
+- source: longhornio/longhorn-engine:v1.10.1
+  target: docker.io/rancher/mirrored-longhornio-longhorn-engine:v1.10.1
+  type: image
 - source: longhornio/longhorn-engine:v1.2.0
   target: docker.io/rancher/mirrored-longhornio-longhorn-engine:v1.2.0
   type: image
@@ -6779,6 +6854,9 @@ sync:
 - source: longhornio/longhorn-engine:v1.1.3
   target: registry.suse.com/rancher/mirrored-longhornio-longhorn-engine:v1.1.3
   type: image
+- source: longhornio/longhorn-engine:v1.10.1
+  target: registry.suse.com/rancher/mirrored-longhornio-longhorn-engine:v1.10.1
+  type: image
 - source: longhornio/longhorn-engine:v1.2.0
   target: registry.suse.com/rancher/mirrored-longhornio-longhorn-engine:v1.2.0
   type: image
@@ -6895,6 +6973,9 @@ sync:
   type: image
 - source: longhornio/longhorn-engine:v1.1.3
   target: stgregistry.suse.com/rancher/mirrored-longhornio-longhorn-engine:v1.1.3
+  type: image
+- source: longhornio/longhorn-engine:v1.10.1
+  target: stgregistry.suse.com/rancher/mirrored-longhornio-longhorn-engine:v1.10.1
   type: image
 - source: longhornio/longhorn-engine:v1.2.0
   target: stgregistry.suse.com/rancher/mirrored-longhornio-longhorn-engine:v1.2.0
@@ -7082,6 +7163,9 @@ sync:
 - source: longhornio/longhorn-instance-manager:v1_20220808
   target: stgregistry.suse.com/rancher/longhornio-longhorn-instance-manager:v1_20220808
   type: image
+- source: longhornio/longhorn-instance-manager:v1.10.1
+  target: docker.io/rancher/mirrored-longhornio-longhorn-instance-manager:v1.10.1
+  type: image
 - source: longhornio/longhorn-instance-manager:v1.4.0
   target: docker.io/rancher/mirrored-longhornio-longhorn-instance-manager:v1.4.0
   type: image
@@ -7187,6 +7271,9 @@ sync:
 - source: longhornio/longhorn-instance-manager:v1_20230407
   target: docker.io/rancher/mirrored-longhornio-longhorn-instance-manager:v1_20230407
   type: image
+- source: longhornio/longhorn-instance-manager:v1.10.1
+  target: registry.suse.com/rancher/mirrored-longhornio-longhorn-instance-manager:v1.10.1
+  type: image
 - source: longhornio/longhorn-instance-manager:v1.4.0
   target: registry.suse.com/rancher/mirrored-longhornio-longhorn-instance-manager:v1.4.0
   type: image
@@ -7291,6 +7378,9 @@ sync:
   type: image
 - source: longhornio/longhorn-instance-manager:v1_20230407
   target: registry.suse.com/rancher/mirrored-longhornio-longhorn-instance-manager:v1_20230407
+  type: image
+- source: longhornio/longhorn-instance-manager:v1.10.1
+  target: stgregistry.suse.com/rancher/mirrored-longhornio-longhorn-instance-manager:v1.10.1
   type: image
 - source: longhornio/longhorn-instance-manager:v1.4.0
   target: stgregistry.suse.com/rancher/mirrored-longhornio-longhorn-instance-manager:v1.4.0
@@ -7526,6 +7616,9 @@ sync:
 - source: longhornio/longhorn-manager:v1.1.3
   target: docker.io/rancher/mirrored-longhornio-longhorn-manager:v1.1.3
   type: image
+- source: longhornio/longhorn-manager:v1.10.1
+  target: docker.io/rancher/mirrored-longhornio-longhorn-manager:v1.10.1
+  type: image
 - source: longhornio/longhorn-manager:v1.2.0
   target: docker.io/rancher/mirrored-longhornio-longhorn-manager:v1.2.0
   type: image
@@ -7643,6 +7736,9 @@ sync:
 - source: longhornio/longhorn-manager:v1.1.3
   target: registry.suse.com/rancher/mirrored-longhornio-longhorn-manager:v1.1.3
   type: image
+- source: longhornio/longhorn-manager:v1.10.1
+  target: registry.suse.com/rancher/mirrored-longhornio-longhorn-manager:v1.10.1
+  type: image
 - source: longhornio/longhorn-manager:v1.2.0
   target: registry.suse.com/rancher/mirrored-longhornio-longhorn-manager:v1.2.0
   type: image
@@ -7759,6 +7855,9 @@ sync:
   type: image
 - source: longhornio/longhorn-manager:v1.1.3
   target: stgregistry.suse.com/rancher/mirrored-longhornio-longhorn-manager:v1.1.3
+  type: image
+- source: longhornio/longhorn-manager:v1.10.1
+  target: stgregistry.suse.com/rancher/mirrored-longhornio-longhorn-manager:v1.10.1
   type: image
 - source: longhornio/longhorn-manager:v1.2.0
   target: stgregistry.suse.com/rancher/mirrored-longhornio-longhorn-manager:v1.2.0
@@ -7946,6 +8045,9 @@ sync:
 - source: longhornio/longhorn-share-manager:v1_20220808
   target: stgregistry.suse.com/rancher/longhornio-longhorn-share-manager:v1_20220808
   type: image
+- source: longhornio/longhorn-share-manager:v1.10.1
+  target: docker.io/rancher/mirrored-longhornio-longhorn-share-manager:v1.10.1
+  type: image
 - source: longhornio/longhorn-share-manager:v1.4.0
   target: docker.io/rancher/mirrored-longhornio-longhorn-share-manager:v1.4.0
   type: image
@@ -8054,6 +8156,9 @@ sync:
 - source: longhornio/longhorn-share-manager:v1_20230320
   target: docker.io/rancher/mirrored-longhornio-longhorn-share-manager:v1_20230320
   type: image
+- source: longhornio/longhorn-share-manager:v1.10.1
+  target: registry.suse.com/rancher/mirrored-longhornio-longhorn-share-manager:v1.10.1
+  type: image
 - source: longhornio/longhorn-share-manager:v1.4.0
   target: registry.suse.com/rancher/mirrored-longhornio-longhorn-share-manager:v1.4.0
   type: image
@@ -8161,6 +8266,9 @@ sync:
   type: image
 - source: longhornio/longhorn-share-manager:v1_20230320
   target: registry.suse.com/rancher/mirrored-longhornio-longhorn-share-manager:v1_20230320
+  type: image
+- source: longhornio/longhorn-share-manager:v1.10.1
+  target: stgregistry.suse.com/rancher/mirrored-longhornio-longhorn-share-manager:v1.10.1
   type: image
 - source: longhornio/longhorn-share-manager:v1.4.0
   target: stgregistry.suse.com/rancher/mirrored-longhornio-longhorn-share-manager:v1.4.0
@@ -8399,6 +8507,9 @@ sync:
 - source: longhornio/longhorn-ui:v1.1.3
   target: docker.io/rancher/mirrored-longhornio-longhorn-ui:v1.1.3
   type: image
+- source: longhornio/longhorn-ui:v1.10.1
+  target: docker.io/rancher/mirrored-longhornio-longhorn-ui:v1.10.1
+  type: image
 - source: longhornio/longhorn-ui:v1.2.0
   target: docker.io/rancher/mirrored-longhornio-longhorn-ui:v1.2.0
   type: image
@@ -8516,6 +8627,9 @@ sync:
 - source: longhornio/longhorn-ui:v1.1.3
   target: registry.suse.com/rancher/mirrored-longhornio-longhorn-ui:v1.1.3
   type: image
+- source: longhornio/longhorn-ui:v1.10.1
+  target: registry.suse.com/rancher/mirrored-longhornio-longhorn-ui:v1.10.1
+  type: image
 - source: longhornio/longhorn-ui:v1.2.0
   target: registry.suse.com/rancher/mirrored-longhornio-longhorn-ui:v1.2.0
   type: image
@@ -8632,6 +8746,9 @@ sync:
   type: image
 - source: longhornio/longhorn-ui:v1.1.3
   target: stgregistry.suse.com/rancher/mirrored-longhornio-longhorn-ui:v1.1.3
+  type: image
+- source: longhornio/longhorn-ui:v1.10.1
+  target: stgregistry.suse.com/rancher/mirrored-longhornio-longhorn-ui:v1.10.1
   type: image
 - source: longhornio/longhorn-ui:v1.2.0
   target: stgregistry.suse.com/rancher/mirrored-longhornio-longhorn-ui:v1.2.0
@@ -8813,6 +8930,9 @@ sync:
 - source: longhornio/support-bundle-kit:v0.0.69
   target: docker.io/rancher/mirrored-longhornio-support-bundle-kit:v0.0.69
   type: image
+- source: longhornio/support-bundle-kit:v0.0.71
+  target: docker.io/rancher/mirrored-longhornio-support-bundle-kit:v0.0.71
+  type: image
 - source: longhornio/support-bundle-kit:v0.0.17
   target: registry.suse.com/rancher/mirrored-longhornio-support-bundle-kit:v0.0.17
   type: image
@@ -8870,6 +8990,9 @@ sync:
 - source: longhornio/support-bundle-kit:v0.0.69
   target: registry.suse.com/rancher/mirrored-longhornio-support-bundle-kit:v0.0.69
   type: image
+- source: longhornio/support-bundle-kit:v0.0.71
+  target: registry.suse.com/rancher/mirrored-longhornio-support-bundle-kit:v0.0.71
+  type: image
 - source: longhornio/support-bundle-kit:v0.0.17
   target: stgregistry.suse.com/rancher/mirrored-longhornio-support-bundle-kit:v0.0.17
   type: image
@@ -8926,6 +9049,9 @@ sync:
   type: image
 - source: longhornio/support-bundle-kit:v0.0.69
   target: stgregistry.suse.com/rancher/mirrored-longhornio-support-bundle-kit:v0.0.69
+  type: image
+- source: longhornio/support-bundle-kit:v0.0.71
+  target: stgregistry.suse.com/rancher/mirrored-longhornio-support-bundle-kit:v0.0.71
   type: image
 - source: messagebird/sachet:0.2.3
   target: docker.io/rancher/mirrored-messagebird-sachet:0.2.3


### PR DESCRIPTION
#### Pull Request Checklist ####

- [ ] If an entire image is being added, a repo has been created for the image in DockerHub under the `rancher` org
- [ ] Additions are licensed with Rancher favored licenses - Apache 2 and MIT - or approved licenses - as according to [CNCF approved licenses](https://github.com/cncf/foundation/blob/main/allowed-third-party-license-policy.md).
- [ ] Additions, when used in Rancher or Rancher's provided charts, have their corresponding origin added in Rancher's images [origins](https://github.com/rancher/rancher/blob/release/v2.7/pkg/image/origins.go) file (must be added for all Rancher versions `>= v2.7`).
- [ ] Any changes to scripting or CI config have been tested to the best of your ability

#### Change Description ####

<!-- Describe what you are doing and why. Link any related issues, pull requests and commit hashes. -->

#### Final Checks after the PR is merged ####

- [ ] Confirm that you can pull the mirrored images and tags from all target locations

longhorn/longhorn#11985

cc @brandond, @adamkpickering, @PhanLe1010 