### PR TITLE
Generate token from app and use it in autoupdate workflow

### DIFF
--- a/.github/workflows/autoupdate.yml
+++ b/.github/workflows/autoupdate.yml
@@ -19,6 +19,20 @@ jobs:
         git config --global user.email "github-actions[bot]@users.noreply.github.com"
         git config --global user.name "github-actions[bot]"
 
+    - name: Get secrets out of vault
+      uses: rancher-eio/read-vault-secrets@main
+      with:
+        secrets: |
+          github/repo/${{ github.repository }}/github/pr-actions-write-app/credentials appId | APP_ID;
+          github/repo/${{ github.repository }}/github/pr-actions-write-app/credentials privateKey | PRIVATE_KEY
+
+    - name: Generate short-lived installation access token from app
+      uses: actions/create-github-app-token@v1
+      id: app-token
+      with:
+        app-id: ${{ env.APP_ID }}
+        private-key: ${{ env.PRIVATE_KEY }}
+
     - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6
       with:
         go-version: '1.24'
@@ -30,4 +44,4 @@ jobs:
     - name: Run autoupdate
       run: bin/image-mirror-tools autoupdate
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
This is for https://github.com/rancher/rancher/issues/52178.

I was thinking I would have to modify `bin/image-mirror-tools autoupdate` to generate the token and then use it, but I remembered what I did for `rancher/partner-charts`: https://github.com/rancher/partner-charts/blob/main-source/.github/workflows/update-main.yml. This is a nice way of doing this, since it uses the IAT in the same way as one would use a PAT in development.
