### PR TITLE
Add missing `id-token: write` permission to autoupdate workflow

### DIFF
--- a/.github/workflows/autoupdate.yml
+++ b/.github/workflows/autoupdate.yml
@@ -7,6 +7,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  id-token: write
 
 jobs:
   autoupdate:


### PR DESCRIPTION
Part of https://github.com/rancher/rancher/issues/52178.

I missed this in https://github.com/rancher/artifact-mirror/pull/1170.