### PR TITLE
Fix pulling app ID and key in autoupdate workflow

### DIFF
--- a/.github/workflows/autoupdate.yml
+++ b/.github/workflows/autoupdate.yml
@@ -24,8 +24,8 @@ jobs:
       uses: rancher-eio/read-vault-secrets@main
       with:
         secrets: |
-          github/repo/${{ github.repository }}/github/pr-actions-write-app/credentials appId | APP_ID;
-          github/repo/${{ github.repository }}/github/pr-actions-write-app/credentials privateKey | PRIVATE_KEY
+          secret/data/github/repo/${{ github.repository }}/github/pr-actions-write-app/credentials appId | APP_ID;
+          secret/data/github/repo/${{ github.repository }}/github/pr-actions-write-app/credentials privateKey | PRIVATE_KEY
 
     - name: Generate short-lived installation access token from app
       uses: actions/create-github-app-token@v1


### PR DESCRIPTION
For https://github.com/rancher/rancher/issues/52178.

This PR changes pulling the app ID and key, as per https://github.com/rancherlabs/eio/issues/3652#issuecomment-3666653316.