### PR TITLE
Add cloud-provider-vsphere v1.35.0

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -2798,10 +2798,14 @@ Artifacts:
   - v1.32.0
   - v1.32.1
   - v1.32.2
+  - v1.32.3
   - v1.33.0
+  - v1.33.1
   - v1.34.0
+  - v1.35.0
   TargetArtifactName: mirrored-cloud-provider-vsphere
-- SourceArtifact: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere
+- DoNotMirror: true
+  SourceArtifact: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere
   Tags:
   - v1.30.0
   - v1.30.1

--- a/regsync.yaml
+++ b/regsync.yaml
@@ -19418,11 +19418,20 @@ sync:
 - source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.32.2
   target: docker.io/rancher/mirrored-cloud-provider-vsphere:v1.32.2
   type: image
+- source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.32.3
+  target: docker.io/rancher/mirrored-cloud-provider-vsphere:v1.32.3
+  type: image
 - source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.33.0
   target: docker.io/rancher/mirrored-cloud-provider-vsphere:v1.33.0
   type: image
+- source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.33.1
+  target: docker.io/rancher/mirrored-cloud-provider-vsphere:v1.33.1
+  type: image
 - source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.34.0
   target: docker.io/rancher/mirrored-cloud-provider-vsphere:v1.34.0
+  type: image
+- source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.35.0
+  target: docker.io/rancher/mirrored-cloud-provider-vsphere:v1.35.0
   type: image
 - source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.30.0
   target: registry.suse.com/rancher/mirrored-cloud-provider-vsphere:v1.30.0
@@ -19448,11 +19457,20 @@ sync:
 - source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.32.2
   target: registry.suse.com/rancher/mirrored-cloud-provider-vsphere:v1.32.2
   type: image
+- source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.32.3
+  target: registry.suse.com/rancher/mirrored-cloud-provider-vsphere:v1.32.3
+  type: image
 - source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.33.0
   target: registry.suse.com/rancher/mirrored-cloud-provider-vsphere:v1.33.0
   type: image
+- source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.33.1
+  target: registry.suse.com/rancher/mirrored-cloud-provider-vsphere:v1.33.1
+  type: image
 - source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.34.0
   target: registry.suse.com/rancher/mirrored-cloud-provider-vsphere:v1.34.0
+  type: image
+- source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.35.0
+  target: registry.suse.com/rancher/mirrored-cloud-provider-vsphere:v1.35.0
   type: image
 - source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.30.0
   target: stgregistry.suse.com/rancher/mirrored-cloud-provider-vsphere:v1.30.0
@@ -19478,128 +19496,20 @@ sync:
 - source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.32.2
   target: stgregistry.suse.com/rancher/mirrored-cloud-provider-vsphere:v1.32.2
   type: image
+- source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.32.3
+  target: stgregistry.suse.com/rancher/mirrored-cloud-provider-vsphere:v1.32.3
+  type: image
 - source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.33.0
   target: stgregistry.suse.com/rancher/mirrored-cloud-provider-vsphere:v1.33.0
+  type: image
+- source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.33.1
+  target: stgregistry.suse.com/rancher/mirrored-cloud-provider-vsphere:v1.33.1
   type: image
 - source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.34.0
   target: stgregistry.suse.com/rancher/mirrored-cloud-provider-vsphere:v1.34.0
   type: image
-- source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.30.0
-  target: docker.io/rancher/mirrored-cloud-pv-vsphere-cloud-provider-vsphere:v1.30.0
-  type: image
-- source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.30.1
-  target: docker.io/rancher/mirrored-cloud-pv-vsphere-cloud-provider-vsphere:v1.30.1
-  type: image
-- source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.30.2
-  target: docker.io/rancher/mirrored-cloud-pv-vsphere-cloud-provider-vsphere:v1.30.2
-  type: image
-- source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.31.0
-  target: docker.io/rancher/mirrored-cloud-pv-vsphere-cloud-provider-vsphere:v1.31.0
-  type: image
-- source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.31.1
-  target: docker.io/rancher/mirrored-cloud-pv-vsphere-cloud-provider-vsphere:v1.31.1
-  type: image
-- source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.32.0
-  target: docker.io/rancher/mirrored-cloud-pv-vsphere-cloud-provider-vsphere:v1.32.0
-  type: image
-- source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.32.1
-  target: docker.io/rancher/mirrored-cloud-pv-vsphere-cloud-provider-vsphere:v1.32.1
-  type: image
-- source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.32.2
-  target: docker.io/rancher/mirrored-cloud-pv-vsphere-cloud-provider-vsphere:v1.32.2
-  type: image
-- source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.32.3
-  target: docker.io/rancher/mirrored-cloud-pv-vsphere-cloud-provider-vsphere:v1.32.3
-  type: image
-- source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.33.0
-  target: docker.io/rancher/mirrored-cloud-pv-vsphere-cloud-provider-vsphere:v1.33.0
-  type: image
-- source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.33.1
-  target: docker.io/rancher/mirrored-cloud-pv-vsphere-cloud-provider-vsphere:v1.33.1
-  type: image
-- source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.34.0
-  target: docker.io/rancher/mirrored-cloud-pv-vsphere-cloud-provider-vsphere:v1.34.0
-  type: image
 - source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.35.0
-  target: docker.io/rancher/mirrored-cloud-pv-vsphere-cloud-provider-vsphere:v1.35.0
-  type: image
-- source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.30.0
-  target: registry.suse.com/rancher/mirrored-cloud-pv-vsphere-cloud-provider-vsphere:v1.30.0
-  type: image
-- source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.30.1
-  target: registry.suse.com/rancher/mirrored-cloud-pv-vsphere-cloud-provider-vsphere:v1.30.1
-  type: image
-- source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.30.2
-  target: registry.suse.com/rancher/mirrored-cloud-pv-vsphere-cloud-provider-vsphere:v1.30.2
-  type: image
-- source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.31.0
-  target: registry.suse.com/rancher/mirrored-cloud-pv-vsphere-cloud-provider-vsphere:v1.31.0
-  type: image
-- source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.31.1
-  target: registry.suse.com/rancher/mirrored-cloud-pv-vsphere-cloud-provider-vsphere:v1.31.1
-  type: image
-- source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.32.0
-  target: registry.suse.com/rancher/mirrored-cloud-pv-vsphere-cloud-provider-vsphere:v1.32.0
-  type: image
-- source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.32.1
-  target: registry.suse.com/rancher/mirrored-cloud-pv-vsphere-cloud-provider-vsphere:v1.32.1
-  type: image
-- source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.32.2
-  target: registry.suse.com/rancher/mirrored-cloud-pv-vsphere-cloud-provider-vsphere:v1.32.2
-  type: image
-- source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.32.3
-  target: registry.suse.com/rancher/mirrored-cloud-pv-vsphere-cloud-provider-vsphere:v1.32.3
-  type: image
-- source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.33.0
-  target: registry.suse.com/rancher/mirrored-cloud-pv-vsphere-cloud-provider-vsphere:v1.33.0
-  type: image
-- source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.33.1
-  target: registry.suse.com/rancher/mirrored-cloud-pv-vsphere-cloud-provider-vsphere:v1.33.1
-  type: image
-- source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.34.0
-  target: registry.suse.com/rancher/mirrored-cloud-pv-vsphere-cloud-provider-vsphere:v1.34.0
-  type: image
-- source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.35.0
-  target: registry.suse.com/rancher/mirrored-cloud-pv-vsphere-cloud-provider-vsphere:v1.35.0
-  type: image
-- source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.30.0
-  target: stgregistry.suse.com/rancher/mirrored-cloud-pv-vsphere-cloud-provider-vsphere:v1.30.0
-  type: image
-- source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.30.1
-  target: stgregistry.suse.com/rancher/mirrored-cloud-pv-vsphere-cloud-provider-vsphere:v1.30.1
-  type: image
-- source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.30.2
-  target: stgregistry.suse.com/rancher/mirrored-cloud-pv-vsphere-cloud-provider-vsphere:v1.30.2
-  type: image
-- source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.31.0
-  target: stgregistry.suse.com/rancher/mirrored-cloud-pv-vsphere-cloud-provider-vsphere:v1.31.0
-  type: image
-- source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.31.1
-  target: stgregistry.suse.com/rancher/mirrored-cloud-pv-vsphere-cloud-provider-vsphere:v1.31.1
-  type: image
-- source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.32.0
-  target: stgregistry.suse.com/rancher/mirrored-cloud-pv-vsphere-cloud-provider-vsphere:v1.32.0
-  type: image
-- source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.32.1
-  target: stgregistry.suse.com/rancher/mirrored-cloud-pv-vsphere-cloud-provider-vsphere:v1.32.1
-  type: image
-- source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.32.2
-  target: stgregistry.suse.com/rancher/mirrored-cloud-pv-vsphere-cloud-provider-vsphere:v1.32.2
-  type: image
-- source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.32.3
-  target: stgregistry.suse.com/rancher/mirrored-cloud-pv-vsphere-cloud-provider-vsphere:v1.32.3
-  type: image
-- source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.33.0
-  target: stgregistry.suse.com/rancher/mirrored-cloud-pv-vsphere-cloud-provider-vsphere:v1.33.0
-  type: image
-- source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.33.1
-  target: stgregistry.suse.com/rancher/mirrored-cloud-pv-vsphere-cloud-provider-vsphere:v1.33.1
-  type: image
-- source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.34.0
-  target: stgregistry.suse.com/rancher/mirrored-cloud-pv-vsphere-cloud-provider-vsphere:v1.34.0
-  type: image
-- source: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.35.0
-  target: stgregistry.suse.com/rancher/mirrored-cloud-pv-vsphere-cloud-provider-vsphere:v1.35.0
+  target: stgregistry.suse.com/rancher/mirrored-cloud-provider-vsphere:v1.35.0
   type: image
 - source: registry.k8s.io/cluster-api/cluster-api-controller:v1.10.2
   target: docker.io/rancher/mirrored-cluster-api-controller:v1.10.2


### PR DESCRIPTION
#### Pull Request Checklist ####

- [x] If an entire artifact is being added, a repo has been created for the artifact in DockerHub under the `rancher` org
- [x] Additions are licensed with Rancher favored licenses - Apache 2 and MIT - or approved licenses - as according to [CNCF approved licenses](https://github.com/cncf/foundation/blob/main/allowed-third-party-license-policy.md).
- [x] Additions, when used in Rancher or Rancher's provided charts, have their corresponding origin added in Rancher's images [origins](https://github.com/rancher/rancher/blob/release/v2.7/pkg/image/origins.go) file (must be added for all Rancher versions `>= v2.7`).
- [x] Any changes to scripting or CI config have been tested to the best of your ability

#### Change Description ####

- Add cloud-provider-vsphere v1.35.0
- Do not mirror obsolete `cloud-pv-vsphere-cloud-provider-vsphere` images

Fixes: https://github.com/rancher/artifact-mirror/pull/1198#discussion_r2640935299
Issue: https://github.com/rancher/rke2/issues/9434

#### Final Checks after the PR is merged ####

- [x] Confirm that you can pull the mirrored artifact and tags from all target locations
