### PR TITLE
autoupdate: fixup cloud-provider-vsphere TargetArtifactName

### DIFF
--- a/autoupdate.yaml
+++ b/autoupdate.yaml
@@ -79,6 +79,7 @@
   Registry:
     Artifacts:
     - SourceArtifact: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere
+      TargetArtifactName: mirrored-cloud-provider-vsphere
     VersionFilter: ^v1.([3-9][0-9]).[0-9]+$
   Reviewers:
   - rancher/k3s


### PR DESCRIPTION
#### Pull Request Checklist ####

- [x] If an entire artifact is being added, a repo has been created for the artifact in DockerHub under the `rancher` org
- [x] Additions are licensed with Rancher favored licenses - Apache 2 and MIT - or approved licenses - as according to [CNCF approved licenses](https://github.com/cncf/foundation/blob/main/allowed-third-party-license-policy.md).
- [x] Additions, when used in Rancher or Rancher's provided charts, have their corresponding origin added in Rancher's images [origins](https://github.com/rancher/rancher/blob/release/v2.7/pkg/image/origins.go) file (must be added for all Rancher versions `>= v2.7`).
- [x] Any changes to scripting or CI config have been tested to the best of your ability

#### Change Description ####


TargetArtifactName should be: `mirrored-cloud-provider-vsphere`
Instead of the using default: `mirrored-cloud-pv-vsphere-cloud-provider-vsphere`

Fixup: https://github.com/rancher/artifact-mirror/pull/1199
Issue: https://github.com/rancher/rke2/issues/9434

#### Final Checks after the PR is merged ####

- [x] Confirm that you can pull the mirrored artifact and tags from all target locations
