### PR TITLE
Add missing cilium certgen v0.3.1

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -2118,6 +2118,7 @@ Artifacts:
   - v0.2.0
   - v0.2.1
   - v0.2.4
+  - v0.3.1
 - SourceArtifact: quay.io/cilium/cilium
   Tags:
   - v1.10.4

--- a/regsync.yaml
+++ b/regsync.yaml
@@ -14567,6 +14567,9 @@ sync:
 - source: quay.io/cilium/certgen:v0.2.4
   target: docker.io/rancher/mirrored-cilium-certgen:v0.2.4
   type: image
+- source: quay.io/cilium/certgen:v0.3.1
+  target: docker.io/rancher/mirrored-cilium-certgen:v0.3.1
+  type: image
 - source: quay.io/cilium/certgen:v0.1.11
   target: registry.suse.com/rancher/mirrored-cilium-certgen:v0.1.11
   type: image
@@ -14591,6 +14594,9 @@ sync:
 - source: quay.io/cilium/certgen:v0.2.4
   target: registry.suse.com/rancher/mirrored-cilium-certgen:v0.2.4
   type: image
+- source: quay.io/cilium/certgen:v0.3.1
+  target: registry.suse.com/rancher/mirrored-cilium-certgen:v0.3.1
+  type: image
 - source: quay.io/cilium/certgen:v0.1.11
   target: stgregistry.suse.com/rancher/mirrored-cilium-certgen:v0.1.11
   type: image
@@ -14614,6 +14620,9 @@ sync:
   type: image
 - source: quay.io/cilium/certgen:v0.2.4
   target: stgregistry.suse.com/rancher/mirrored-cilium-certgen:v0.2.4
+  type: image
+- source: quay.io/cilium/certgen:v0.3.1
+  target: stgregistry.suse.com/rancher/mirrored-cilium-certgen:v0.3.1
   type: image
 - source: quay.io/cilium/cilium:v1.10.4
   target: docker.io/rancher/mirrored-cilium-cilium:v1.10.4


### PR DESCRIPTION
#### Pull Request Checklist ####

- [ ] If an entire artifact is being added, a repo has been created for the artifact in DockerHub under the `rancher` org
- [ ] Additions are licensed with Rancher favored licenses - Apache 2 and MIT - or approved licenses - as according to [CNCF approved licenses](https://github.com/cncf/foundation/blob/main/allowed-third-party-license-policy.md).
- [ ] Additions, when used in Rancher or Rancher's provided charts, have their corresponding origin added in Rancher's images [origins](https://github.com/rancher/rancher/blob/release/v2.7/pkg/image/origins.go) file (must be added for all Rancher versions `>= v2.7`).
- [ ] Any changes to scripting or CI config have been tested to the best of your ability

#### Change Description ####
For some reason the autoupdate is not finding pulling in the cilium/certgen image with the bulk cilium tag PRs. For now, at least pull in the newest tag
<!-- Describe what you are doing and why. Link any related issues, pull requests and commit hashes. -->

#### Final Checks after the PR is merged ####

- [ ] Confirm that you can pull the mirrored artifact and tags from all target locations
