### PR TITLE
feat: add longhorn v1.10.2 images

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -957,6 +957,7 @@ Artifacts:
 - SourceArtifact: longhornio/backing-image-manager
   Tags:
   - v1.10.1
+  - v1.10.2
   - v1.4.0
   - v1.4.1
   - v1.4.2
@@ -1005,6 +1006,7 @@ Artifacts:
   - v3.2.1
   - v3.4.0
   - v4.10.0-20251030
+  - v4.10.0-20251226
   - v4.2.0
   - v4.4.2
   - v4.5.1
@@ -1032,6 +1034,7 @@ Artifacts:
   - v2.14.0
   - v2.14.0-20250709
   - v2.15.0-20251030
+  - v2.15.0-20251226
   - v2.3.0
   - v2.5.0
   - v2.7.0
@@ -1060,6 +1063,7 @@ Artifacts:
   - v5.3.0
   - v5.3.0-20250709
   - v5.3.0-20251030
+  - v5.3.0-20251226
 - SourceArtifact: longhornio/csi-resizer
   Tags:
   - v0.3.0
@@ -1079,6 +1083,7 @@ Artifacts:
   - v1.13.2
   - v1.14.0-20250709
   - v1.14.0-20251030
+  - v1.14.0-20260119
   - v1.2.0
   - v1.3.0
   - v1.7.0
@@ -1105,6 +1110,7 @@ Artifacts:
   - v8.2.0
   - v8.3.0-20250709
   - v8.4.0-20251030
+  - v8.4.0-20251226
 - SourceArtifact: longhornio/livenessprobe
   Tags:
   - v2.11.0
@@ -1116,11 +1122,13 @@ Artifacts:
   - v2.16.0
   - v2.16.0-20250709
   - v2.17.0-20251030
+  - v2.17.0-20251226
   - v2.8.0
   - v2.9.0
 - SourceArtifact: longhornio/longhorn-cli
   Tags:
   - v1.10.1
+  - v1.10.2
   - v1.7.0
   - v1.7.1
   - v1.7.2
@@ -1152,6 +1160,7 @@ Artifacts:
   - v1.1.2
   - v1.1.3
   - v1.10.1
+  - v1.10.2
   - v1.2.0
   - v1.2.1
   - v1.2.2
@@ -1202,6 +1211,7 @@ Artifacts:
 - SourceArtifact: longhornio/longhorn-instance-manager
   Tags:
   - v1.10.1
+  - v1.10.2
   - v1.4.0
   - v1.4.1
   - v1.4.2
@@ -1262,6 +1272,7 @@ Artifacts:
   - v1.10.1
   - v1.10.1-hotfix-1
   - v1.10.1-hotfix-2
+  - v1.10.2
   - v1.2.0
   - v1.2.1
   - v1.2.2
@@ -1313,6 +1324,7 @@ Artifacts:
 - SourceArtifact: longhornio/longhorn-share-manager
   Tags:
   - v1.10.1
+  - v1.10.2
   - v1.4.0
   - v1.4.1
   - v1.4.2
@@ -1372,6 +1384,7 @@ Artifacts:
   - v1.1.2
   - v1.1.3
   - v1.10.1
+  - v1.10.2
   - v1.2.0
   - v1.2.1
   - v1.2.2
@@ -1433,6 +1446,7 @@ Artifacts:
   - v0.0.61
   - v0.0.69
   - v0.0.71
+  - v0.0.79
 - SourceArtifact: messagebird/sachet
   Tags:
   - 0.2.3

--- a/regsync.yaml
+++ b/regsync.yaml
@@ -5537,6 +5537,9 @@ sync:
 - source: longhornio/backing-image-manager:v1.10.1
   target: docker.io/rancher/mirrored-longhornio-backing-image-manager:v1.10.1
   type: image
+- source: longhornio/backing-image-manager:v1.10.2
+  target: docker.io/rancher/mirrored-longhornio-backing-image-manager:v1.10.2
+  type: image
 - source: longhornio/backing-image-manager:v1.4.0
   target: docker.io/rancher/mirrored-longhornio-backing-image-manager:v1.4.0
   type: image
@@ -5639,6 +5642,9 @@ sync:
 - source: longhornio/backing-image-manager:v1.10.1
   target: registry.suse.com/rancher/mirrored-longhornio-backing-image-manager:v1.10.1
   type: image
+- source: longhornio/backing-image-manager:v1.10.2
+  target: registry.suse.com/rancher/mirrored-longhornio-backing-image-manager:v1.10.2
+  type: image
 - source: longhornio/backing-image-manager:v1.4.0
   target: registry.suse.com/rancher/mirrored-longhornio-backing-image-manager:v1.4.0
   type: image
@@ -5740,6 +5746,9 @@ sync:
   type: image
 - source: longhornio/backing-image-manager:v1.10.1
   target: stgregistry.suse.com/rancher/mirrored-longhornio-backing-image-manager:v1.10.1
+  type: image
+- source: longhornio/backing-image-manager:v1.10.2
+  target: stgregistry.suse.com/rancher/mirrored-longhornio-backing-image-manager:v1.10.2
   type: image
 - source: longhornio/backing-image-manager:v1.4.0
   target: stgregistry.suse.com/rancher/mirrored-longhornio-backing-image-manager:v1.4.0
@@ -5900,6 +5909,9 @@ sync:
 - source: longhornio/csi-attacher:v4.10.0-20251030
   target: docker.io/rancher/mirrored-longhornio-csi-attacher:v4.10.0-20251030
   type: image
+- source: longhornio/csi-attacher:v4.10.0-20251226
+  target: docker.io/rancher/mirrored-longhornio-csi-attacher:v4.10.0-20251226
+  type: image
 - source: longhornio/csi-attacher:v4.2.0
   target: docker.io/rancher/mirrored-longhornio-csi-attacher:v4.2.0
   type: image
@@ -5945,6 +5957,9 @@ sync:
 - source: longhornio/csi-attacher:v4.10.0-20251030
   target: registry.suse.com/rancher/mirrored-longhornio-csi-attacher:v4.10.0-20251030
   type: image
+- source: longhornio/csi-attacher:v4.10.0-20251226
+  target: registry.suse.com/rancher/mirrored-longhornio-csi-attacher:v4.10.0-20251226
+  type: image
 - source: longhornio/csi-attacher:v4.2.0
   target: registry.suse.com/rancher/mirrored-longhornio-csi-attacher:v4.2.0
   type: image
@@ -5989,6 +6004,9 @@ sync:
   type: image
 - source: longhornio/csi-attacher:v4.10.0-20251030
   target: stgregistry.suse.com/rancher/mirrored-longhornio-csi-attacher:v4.10.0-20251030
+  type: image
+- source: longhornio/csi-attacher:v4.10.0-20251226
+  target: stgregistry.suse.com/rancher/mirrored-longhornio-csi-attacher:v4.10.0-20251226
   type: image
 - source: longhornio/csi-attacher:v4.2.0
   target: stgregistry.suse.com/rancher/mirrored-longhornio-csi-attacher:v4.2.0
@@ -6080,6 +6098,9 @@ sync:
 - source: longhornio/csi-node-driver-registrar:v2.15.0-20251030
   target: docker.io/rancher/mirrored-longhornio-csi-node-driver-registrar:v2.15.0-20251030
   type: image
+- source: longhornio/csi-node-driver-registrar:v2.15.0-20251226
+  target: docker.io/rancher/mirrored-longhornio-csi-node-driver-registrar:v2.15.0-20251226
+  type: image
 - source: longhornio/csi-node-driver-registrar:v2.3.0
   target: docker.io/rancher/mirrored-longhornio-csi-node-driver-registrar:v2.3.0
   type: image
@@ -6116,6 +6137,9 @@ sync:
 - source: longhornio/csi-node-driver-registrar:v2.15.0-20251030
   target: registry.suse.com/rancher/mirrored-longhornio-csi-node-driver-registrar:v2.15.0-20251030
   type: image
+- source: longhornio/csi-node-driver-registrar:v2.15.0-20251226
+  target: registry.suse.com/rancher/mirrored-longhornio-csi-node-driver-registrar:v2.15.0-20251226
+  type: image
 - source: longhornio/csi-node-driver-registrar:v2.3.0
   target: registry.suse.com/rancher/mirrored-longhornio-csi-node-driver-registrar:v2.3.0
   type: image
@@ -6151,6 +6175,9 @@ sync:
   type: image
 - source: longhornio/csi-node-driver-registrar:v2.15.0-20251030
   target: stgregistry.suse.com/rancher/mirrored-longhornio-csi-node-driver-registrar:v2.15.0-20251030
+  type: image
+- source: longhornio/csi-node-driver-registrar:v2.15.0-20251226
+  target: stgregistry.suse.com/rancher/mirrored-longhornio-csi-node-driver-registrar:v2.15.0-20251226
   type: image
 - source: longhornio/csi-node-driver-registrar:v2.3.0
   target: stgregistry.suse.com/rancher/mirrored-longhornio-csi-node-driver-registrar:v2.3.0
@@ -6245,6 +6272,9 @@ sync:
 - source: longhornio/csi-provisioner:v5.3.0-20251030
   target: docker.io/rancher/mirrored-longhornio-csi-provisioner:v5.3.0-20251030
   type: image
+- source: longhornio/csi-provisioner:v5.3.0-20251226
+  target: docker.io/rancher/mirrored-longhornio-csi-provisioner:v5.3.0-20251226
+  type: image
 - source: longhornio/csi-provisioner:v1.6.0-lh1
   target: registry.suse.com/rancher/mirrored-longhornio-csi-provisioner:v1.6.0-lh1
   type: image
@@ -6290,6 +6320,9 @@ sync:
 - source: longhornio/csi-provisioner:v5.3.0-20251030
   target: registry.suse.com/rancher/mirrored-longhornio-csi-provisioner:v5.3.0-20251030
   type: image
+- source: longhornio/csi-provisioner:v5.3.0-20251226
+  target: registry.suse.com/rancher/mirrored-longhornio-csi-provisioner:v5.3.0-20251226
+  type: image
 - source: longhornio/csi-provisioner:v1.6.0-lh1
   target: stgregistry.suse.com/rancher/mirrored-longhornio-csi-provisioner:v1.6.0-lh1
   type: image
@@ -6334,6 +6367,9 @@ sync:
   type: image
 - source: longhornio/csi-provisioner:v5.3.0-20251030
   target: stgregistry.suse.com/rancher/mirrored-longhornio-csi-provisioner:v5.3.0-20251030
+  type: image
+- source: longhornio/csi-provisioner:v5.3.0-20251226
+  target: stgregistry.suse.com/rancher/mirrored-longhornio-csi-provisioner:v5.3.0-20251226
   type: image
 - source: longhornio/csi-resizer:v0.3.0
   target: docker.io/rancher/longhornio-csi-resizer:v0.3.0
@@ -6401,6 +6437,9 @@ sync:
 - source: longhornio/csi-resizer:v1.14.0-20251030
   target: docker.io/rancher/mirrored-longhornio-csi-resizer:v1.14.0-20251030
   type: image
+- source: longhornio/csi-resizer:v1.14.0-20260119
+  target: docker.io/rancher/mirrored-longhornio-csi-resizer:v1.14.0-20260119
+  type: image
 - source: longhornio/csi-resizer:v1.2.0
   target: docker.io/rancher/mirrored-longhornio-csi-resizer:v1.2.0
   type: image
@@ -6443,6 +6482,9 @@ sync:
 - source: longhornio/csi-resizer:v1.14.0-20251030
   target: registry.suse.com/rancher/mirrored-longhornio-csi-resizer:v1.14.0-20251030
   type: image
+- source: longhornio/csi-resizer:v1.14.0-20260119
+  target: registry.suse.com/rancher/mirrored-longhornio-csi-resizer:v1.14.0-20260119
+  type: image
 - source: longhornio/csi-resizer:v1.2.0
   target: registry.suse.com/rancher/mirrored-longhornio-csi-resizer:v1.2.0
   type: image
@@ -6484,6 +6526,9 @@ sync:
   type: image
 - source: longhornio/csi-resizer:v1.14.0-20251030
   target: stgregistry.suse.com/rancher/mirrored-longhornio-csi-resizer:v1.14.0-20251030
+  type: image
+- source: longhornio/csi-resizer:v1.14.0-20260119
+  target: stgregistry.suse.com/rancher/mirrored-longhornio-csi-resizer:v1.14.0-20260119
   type: image
 - source: longhornio/csi-resizer:v1.2.0
   target: stgregistry.suse.com/rancher/mirrored-longhornio-csi-resizer:v1.2.0
@@ -6566,6 +6611,9 @@ sync:
 - source: longhornio/csi-snapshotter:v8.4.0-20251030
   target: docker.io/rancher/mirrored-longhornio-csi-snapshotter:v8.4.0-20251030
   type: image
+- source: longhornio/csi-snapshotter:v8.4.0-20251226
+  target: docker.io/rancher/mirrored-longhornio-csi-snapshotter:v8.4.0-20251226
+  type: image
 - source: longhornio/csi-snapshotter:v2.1.1-lh1
   target: registry.suse.com/rancher/mirrored-longhornio-csi-snapshotter:v2.1.1-lh1
   type: image
@@ -6607,6 +6655,9 @@ sync:
   type: image
 - source: longhornio/csi-snapshotter:v8.4.0-20251030
   target: registry.suse.com/rancher/mirrored-longhornio-csi-snapshotter:v8.4.0-20251030
+  type: image
+- source: longhornio/csi-snapshotter:v8.4.0-20251226
+  target: registry.suse.com/rancher/mirrored-longhornio-csi-snapshotter:v8.4.0-20251226
   type: image
 - source: longhornio/csi-snapshotter:v2.1.1-lh1
   target: stgregistry.suse.com/rancher/mirrored-longhornio-csi-snapshotter:v2.1.1-lh1
@@ -6650,6 +6701,9 @@ sync:
 - source: longhornio/csi-snapshotter:v8.4.0-20251030
   target: stgregistry.suse.com/rancher/mirrored-longhornio-csi-snapshotter:v8.4.0-20251030
   type: image
+- source: longhornio/csi-snapshotter:v8.4.0-20251226
+  target: stgregistry.suse.com/rancher/mirrored-longhornio-csi-snapshotter:v8.4.0-20251226
+  type: image
 - source: longhornio/livenessprobe:v2.11.0
   target: docker.io/rancher/mirrored-longhornio-livenessprobe:v2.11.0
   type: image
@@ -6676,6 +6730,9 @@ sync:
   type: image
 - source: longhornio/livenessprobe:v2.17.0-20251030
   target: docker.io/rancher/mirrored-longhornio-livenessprobe:v2.17.0-20251030
+  type: image
+- source: longhornio/livenessprobe:v2.17.0-20251226
+  target: docker.io/rancher/mirrored-longhornio-livenessprobe:v2.17.0-20251226
   type: image
 - source: longhornio/livenessprobe:v2.8.0
   target: docker.io/rancher/mirrored-longhornio-livenessprobe:v2.8.0
@@ -6710,6 +6767,9 @@ sync:
 - source: longhornio/livenessprobe:v2.17.0-20251030
   target: registry.suse.com/rancher/mirrored-longhornio-livenessprobe:v2.17.0-20251030
   type: image
+- source: longhornio/livenessprobe:v2.17.0-20251226
+  target: registry.suse.com/rancher/mirrored-longhornio-livenessprobe:v2.17.0-20251226
+  type: image
 - source: longhornio/livenessprobe:v2.8.0
   target: registry.suse.com/rancher/mirrored-longhornio-livenessprobe:v2.8.0
   type: image
@@ -6743,6 +6803,9 @@ sync:
 - source: longhornio/livenessprobe:v2.17.0-20251030
   target: stgregistry.suse.com/rancher/mirrored-longhornio-livenessprobe:v2.17.0-20251030
   type: image
+- source: longhornio/livenessprobe:v2.17.0-20251226
+  target: stgregistry.suse.com/rancher/mirrored-longhornio-livenessprobe:v2.17.0-20251226
+  type: image
 - source: longhornio/livenessprobe:v2.8.0
   target: stgregistry.suse.com/rancher/mirrored-longhornio-livenessprobe:v2.8.0
   type: image
@@ -6751,6 +6814,9 @@ sync:
   type: image
 - source: longhornio/longhorn-cli:v1.10.1
   target: docker.io/rancher/mirrored-longhornio-longhorn-cli:v1.10.1
+  type: image
+- source: longhornio/longhorn-cli:v1.10.2
+  target: docker.io/rancher/mirrored-longhornio-longhorn-cli:v1.10.2
   type: image
 - source: longhornio/longhorn-cli:v1.7.0
   target: docker.io/rancher/mirrored-longhornio-longhorn-cli:v1.7.0
@@ -6779,6 +6845,9 @@ sync:
 - source: longhornio/longhorn-cli:v1.10.1
   target: registry.suse.com/rancher/mirrored-longhornio-longhorn-cli:v1.10.1
   type: image
+- source: longhornio/longhorn-cli:v1.10.2
+  target: registry.suse.com/rancher/mirrored-longhornio-longhorn-cli:v1.10.2
+  type: image
 - source: longhornio/longhorn-cli:v1.7.0
   target: registry.suse.com/rancher/mirrored-longhornio-longhorn-cli:v1.7.0
   type: image
@@ -6805,6 +6874,9 @@ sync:
   type: image
 - source: longhornio/longhorn-cli:v1.10.1
   target: stgregistry.suse.com/rancher/mirrored-longhornio-longhorn-cli:v1.10.1
+  type: image
+- source: longhornio/longhorn-cli:v1.10.2
+  target: stgregistry.suse.com/rancher/mirrored-longhornio-longhorn-cli:v1.10.2
   type: image
 - source: longhornio/longhorn-cli:v1.7.0
   target: stgregistry.suse.com/rancher/mirrored-longhornio-longhorn-cli:v1.7.0
@@ -6962,6 +7034,9 @@ sync:
 - source: longhornio/longhorn-engine:v1.10.1
   target: docker.io/rancher/mirrored-longhornio-longhorn-engine:v1.10.1
   type: image
+- source: longhornio/longhorn-engine:v1.10.2
+  target: docker.io/rancher/mirrored-longhornio-longhorn-engine:v1.10.2
+  type: image
 - source: longhornio/longhorn-engine:v1.2.0
   target: docker.io/rancher/mirrored-longhornio-longhorn-engine:v1.2.0
   type: image
@@ -7082,6 +7157,9 @@ sync:
 - source: longhornio/longhorn-engine:v1.10.1
   target: registry.suse.com/rancher/mirrored-longhornio-longhorn-engine:v1.10.1
   type: image
+- source: longhornio/longhorn-engine:v1.10.2
+  target: registry.suse.com/rancher/mirrored-longhornio-longhorn-engine:v1.10.2
+  type: image
 - source: longhornio/longhorn-engine:v1.2.0
   target: registry.suse.com/rancher/mirrored-longhornio-longhorn-engine:v1.2.0
   type: image
@@ -7201,6 +7279,9 @@ sync:
   type: image
 - source: longhornio/longhorn-engine:v1.10.1
   target: stgregistry.suse.com/rancher/mirrored-longhornio-longhorn-engine:v1.10.1
+  type: image
+- source: longhornio/longhorn-engine:v1.10.2
+  target: stgregistry.suse.com/rancher/mirrored-longhornio-longhorn-engine:v1.10.2
   type: image
 - source: longhornio/longhorn-engine:v1.2.0
   target: stgregistry.suse.com/rancher/mirrored-longhornio-longhorn-engine:v1.2.0
@@ -7391,6 +7472,9 @@ sync:
 - source: longhornio/longhorn-instance-manager:v1.10.1
   target: docker.io/rancher/mirrored-longhornio-longhorn-instance-manager:v1.10.1
   type: image
+- source: longhornio/longhorn-instance-manager:v1.10.2
+  target: docker.io/rancher/mirrored-longhornio-longhorn-instance-manager:v1.10.2
+  type: image
 - source: longhornio/longhorn-instance-manager:v1.4.0
   target: docker.io/rancher/mirrored-longhornio-longhorn-instance-manager:v1.4.0
   type: image
@@ -7499,6 +7583,9 @@ sync:
 - source: longhornio/longhorn-instance-manager:v1.10.1
   target: registry.suse.com/rancher/mirrored-longhornio-longhorn-instance-manager:v1.10.1
   type: image
+- source: longhornio/longhorn-instance-manager:v1.10.2
+  target: registry.suse.com/rancher/mirrored-longhornio-longhorn-instance-manager:v1.10.2
+  type: image
 - source: longhornio/longhorn-instance-manager:v1.4.0
   target: registry.suse.com/rancher/mirrored-longhornio-longhorn-instance-manager:v1.4.0
   type: image
@@ -7606,6 +7693,9 @@ sync:
   type: image
 - source: longhornio/longhorn-instance-manager:v1.10.1
   target: stgregistry.suse.com/rancher/mirrored-longhornio-longhorn-instance-manager:v1.10.1
+  type: image
+- source: longhornio/longhorn-instance-manager:v1.10.2
+  target: stgregistry.suse.com/rancher/mirrored-longhornio-longhorn-instance-manager:v1.10.2
   type: image
 - source: longhornio/longhorn-instance-manager:v1.4.0
   target: stgregistry.suse.com/rancher/mirrored-longhornio-longhorn-instance-manager:v1.4.0
@@ -7850,6 +7940,9 @@ sync:
 - source: longhornio/longhorn-manager:v1.10.1-hotfix-2
   target: docker.io/rancher/mirrored-longhornio-longhorn-manager:v1.10.1-hotfix-2
   type: image
+- source: longhornio/longhorn-manager:v1.10.2
+  target: docker.io/rancher/mirrored-longhornio-longhorn-manager:v1.10.2
+  type: image
 - source: longhornio/longhorn-manager:v1.2.0
   target: docker.io/rancher/mirrored-longhornio-longhorn-manager:v1.2.0
   type: image
@@ -7979,6 +8072,9 @@ sync:
 - source: longhornio/longhorn-manager:v1.10.1-hotfix-2
   target: registry.suse.com/rancher/mirrored-longhornio-longhorn-manager:v1.10.1-hotfix-2
   type: image
+- source: longhornio/longhorn-manager:v1.10.2
+  target: registry.suse.com/rancher/mirrored-longhornio-longhorn-manager:v1.10.2
+  type: image
 - source: longhornio/longhorn-manager:v1.2.0
   target: registry.suse.com/rancher/mirrored-longhornio-longhorn-manager:v1.2.0
   type: image
@@ -8107,6 +8203,9 @@ sync:
   type: image
 - source: longhornio/longhorn-manager:v1.10.1-hotfix-2
   target: stgregistry.suse.com/rancher/mirrored-longhornio-longhorn-manager:v1.10.1-hotfix-2
+  type: image
+- source: longhornio/longhorn-manager:v1.10.2
+  target: stgregistry.suse.com/rancher/mirrored-longhornio-longhorn-manager:v1.10.2
   type: image
 - source: longhornio/longhorn-manager:v1.2.0
   target: stgregistry.suse.com/rancher/mirrored-longhornio-longhorn-manager:v1.2.0
@@ -8300,6 +8399,9 @@ sync:
 - source: longhornio/longhorn-share-manager:v1.10.1
   target: docker.io/rancher/mirrored-longhornio-longhorn-share-manager:v1.10.1
   type: image
+- source: longhornio/longhorn-share-manager:v1.10.2
+  target: docker.io/rancher/mirrored-longhornio-longhorn-share-manager:v1.10.2
+  type: image
 - source: longhornio/longhorn-share-manager:v1.4.0
   target: docker.io/rancher/mirrored-longhornio-longhorn-share-manager:v1.4.0
   type: image
@@ -8411,6 +8513,9 @@ sync:
 - source: longhornio/longhorn-share-manager:v1.10.1
   target: registry.suse.com/rancher/mirrored-longhornio-longhorn-share-manager:v1.10.1
   type: image
+- source: longhornio/longhorn-share-manager:v1.10.2
+  target: registry.suse.com/rancher/mirrored-longhornio-longhorn-share-manager:v1.10.2
+  type: image
 - source: longhornio/longhorn-share-manager:v1.4.0
   target: registry.suse.com/rancher/mirrored-longhornio-longhorn-share-manager:v1.4.0
   type: image
@@ -8521,6 +8626,9 @@ sync:
   type: image
 - source: longhornio/longhorn-share-manager:v1.10.1
   target: stgregistry.suse.com/rancher/mirrored-longhornio-longhorn-share-manager:v1.10.1
+  type: image
+- source: longhornio/longhorn-share-manager:v1.10.2
+  target: stgregistry.suse.com/rancher/mirrored-longhornio-longhorn-share-manager:v1.10.2
   type: image
 - source: longhornio/longhorn-share-manager:v1.4.0
   target: stgregistry.suse.com/rancher/mirrored-longhornio-longhorn-share-manager:v1.4.0
@@ -8762,6 +8870,9 @@ sync:
 - source: longhornio/longhorn-ui:v1.10.1
   target: docker.io/rancher/mirrored-longhornio-longhorn-ui:v1.10.1
   type: image
+- source: longhornio/longhorn-ui:v1.10.2
+  target: docker.io/rancher/mirrored-longhornio-longhorn-ui:v1.10.2
+  type: image
 - source: longhornio/longhorn-ui:v1.2.0
   target: docker.io/rancher/mirrored-longhornio-longhorn-ui:v1.2.0
   type: image
@@ -8882,6 +8993,9 @@ sync:
 - source: longhornio/longhorn-ui:v1.10.1
   target: registry.suse.com/rancher/mirrored-longhornio-longhorn-ui:v1.10.1
   type: image
+- source: longhornio/longhorn-ui:v1.10.2
+  target: registry.suse.com/rancher/mirrored-longhornio-longhorn-ui:v1.10.2
+  type: image
 - source: longhornio/longhorn-ui:v1.2.0
   target: registry.suse.com/rancher/mirrored-longhornio-longhorn-ui:v1.2.0
   type: image
@@ -9001,6 +9115,9 @@ sync:
   type: image
 - source: longhornio/longhorn-ui:v1.10.1
   target: stgregistry.suse.com/rancher/mirrored-longhornio-longhorn-ui:v1.10.1
+  type: image
+- source: longhornio/longhorn-ui:v1.10.2
+  target: stgregistry.suse.com/rancher/mirrored-longhornio-longhorn-ui:v1.10.2
   type: image
 - source: longhornio/longhorn-ui:v1.2.0
   target: stgregistry.suse.com/rancher/mirrored-longhornio-longhorn-ui:v1.2.0
@@ -9185,6 +9302,9 @@ sync:
 - source: longhornio/support-bundle-kit:v0.0.71
   target: docker.io/rancher/mirrored-longhornio-support-bundle-kit:v0.0.71
   type: image
+- source: longhornio/support-bundle-kit:v0.0.79
+  target: docker.io/rancher/mirrored-longhornio-support-bundle-kit:v0.0.79
+  type: image
 - source: longhornio/support-bundle-kit:v0.0.17
   target: registry.suse.com/rancher/mirrored-longhornio-support-bundle-kit:v0.0.17
   type: image
@@ -9245,6 +9365,9 @@ sync:
 - source: longhornio/support-bundle-kit:v0.0.71
   target: registry.suse.com/rancher/mirrored-longhornio-support-bundle-kit:v0.0.71
   type: image
+- source: longhornio/support-bundle-kit:v0.0.79
+  target: registry.suse.com/rancher/mirrored-longhornio-support-bundle-kit:v0.0.79
+  type: image
 - source: longhornio/support-bundle-kit:v0.0.17
   target: stgregistry.suse.com/rancher/mirrored-longhornio-support-bundle-kit:v0.0.17
   type: image
@@ -9304,6 +9427,9 @@ sync:
   type: image
 - source: longhornio/support-bundle-kit:v0.0.71
   target: stgregistry.suse.com/rancher/mirrored-longhornio-support-bundle-kit:v0.0.71
+  type: image
+- source: longhornio/support-bundle-kit:v0.0.79
+  target: stgregistry.suse.com/rancher/mirrored-longhornio-support-bundle-kit:v0.0.79
   type: image
 - source: messagebird/sachet:0.2.3
   target: docker.io/rancher/mirrored-messagebird-sachet:0.2.3


### PR DESCRIPTION
#### Pull Request Checklist ####

- [ ] If an entire artifact is being added, a repo has been created for the artifact in DockerHub under the `rancher` org
- [ ] Additions are licensed with Rancher favored licenses - Apache 2 and MIT - or approved licenses - as according to [CNCF approved licenses](https://github.com/cncf/foundation/blob/main/allowed-third-party-license-policy.md).
- [ ] Additions, when used in Rancher or Rancher's provided charts, have their corresponding origin added in Rancher's images [origins](https://github.com/rancher/rancher/blob/release/v2.7/pkg/image/origins.go) file (must be added for all Rancher versions `>= v2.7`).
- [ ] Any changes to scripting or CI config have been tested to the best of your ability

#### Change Description ####

<!-- Describe what you are doing and why. Link any related issues, pull requests and commit hashes. -->

#### Final Checks after the PR is merged ####

- [ ] Confirm that you can pull the mirrored artifact and tags from all target locations

longhorn/longhorn#12432
cc @brandond, @adamkpickering