### PR TITLE
chore: mirror Longhorn hotfix images

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1260,6 +1260,8 @@ Artifacts:
   - v1.1.2
   - v1.1.3
   - v1.10.1
+  - v1.10.1-hotfix-1
+  - v1.10.1-hotfix-2
   - v1.2.0
   - v1.2.1
   - v1.2.2
@@ -1295,6 +1297,7 @@ Artifacts:
   - v1.8.2
   - v1.9.1
   - v1.9.2
+  - v1.9.2-hotfix-1
 - SourceArtifact: longhornio/longhorn-share-manager
   Tags:
   - v1_20201204

--- a/regsync.yaml
+++ b/regsync.yaml
@@ -7844,6 +7844,12 @@ sync:
 - source: longhornio/longhorn-manager:v1.10.1
   target: docker.io/rancher/mirrored-longhornio-longhorn-manager:v1.10.1
   type: image
+- source: longhornio/longhorn-manager:v1.10.1-hotfix-1
+  target: docker.io/rancher/mirrored-longhornio-longhorn-manager:v1.10.1-hotfix-1
+  type: image
+- source: longhornio/longhorn-manager:v1.10.1-hotfix-2
+  target: docker.io/rancher/mirrored-longhornio-longhorn-manager:v1.10.1-hotfix-2
+  type: image
 - source: longhornio/longhorn-manager:v1.2.0
   target: docker.io/rancher/mirrored-longhornio-longhorn-manager:v1.2.0
   type: image
@@ -7949,6 +7955,9 @@ sync:
 - source: longhornio/longhorn-manager:v1.9.2
   target: docker.io/rancher/mirrored-longhornio-longhorn-manager:v1.9.2
   type: image
+- source: longhornio/longhorn-manager:v1.9.2-hotfix-1
+  target: docker.io/rancher/mirrored-longhornio-longhorn-manager:v1.9.2-hotfix-1
+  type: image
 - source: longhornio/longhorn-manager:v1.1.0
   target: registry.suse.com/rancher/mirrored-longhornio-longhorn-manager:v1.1.0
   type: image
@@ -7963,6 +7972,12 @@ sync:
   type: image
 - source: longhornio/longhorn-manager:v1.10.1
   target: registry.suse.com/rancher/mirrored-longhornio-longhorn-manager:v1.10.1
+  type: image
+- source: longhornio/longhorn-manager:v1.10.1-hotfix-1
+  target: registry.suse.com/rancher/mirrored-longhornio-longhorn-manager:v1.10.1-hotfix-1
+  type: image
+- source: longhornio/longhorn-manager:v1.10.1-hotfix-2
+  target: registry.suse.com/rancher/mirrored-longhornio-longhorn-manager:v1.10.1-hotfix-2
   type: image
 - source: longhornio/longhorn-manager:v1.2.0
   target: registry.suse.com/rancher/mirrored-longhornio-longhorn-manager:v1.2.0
@@ -8069,6 +8084,9 @@ sync:
 - source: longhornio/longhorn-manager:v1.9.2
   target: registry.suse.com/rancher/mirrored-longhornio-longhorn-manager:v1.9.2
   type: image
+- source: longhornio/longhorn-manager:v1.9.2-hotfix-1
+  target: registry.suse.com/rancher/mirrored-longhornio-longhorn-manager:v1.9.2-hotfix-1
+  type: image
 - source: longhornio/longhorn-manager:v1.1.0
   target: stgregistry.suse.com/rancher/mirrored-longhornio-longhorn-manager:v1.1.0
   type: image
@@ -8083,6 +8101,12 @@ sync:
   type: image
 - source: longhornio/longhorn-manager:v1.10.1
   target: stgregistry.suse.com/rancher/mirrored-longhornio-longhorn-manager:v1.10.1
+  type: image
+- source: longhornio/longhorn-manager:v1.10.1-hotfix-1
+  target: stgregistry.suse.com/rancher/mirrored-longhornio-longhorn-manager:v1.10.1-hotfix-1
+  type: image
+- source: longhornio/longhorn-manager:v1.10.1-hotfix-2
+  target: stgregistry.suse.com/rancher/mirrored-longhornio-longhorn-manager:v1.10.1-hotfix-2
   type: image
 - source: longhornio/longhorn-manager:v1.2.0
   target: stgregistry.suse.com/rancher/mirrored-longhornio-longhorn-manager:v1.2.0
@@ -8188,6 +8212,9 @@ sync:
   type: image
 - source: longhornio/longhorn-manager:v1.9.2
   target: stgregistry.suse.com/rancher/mirrored-longhornio-longhorn-manager:v1.9.2
+  type: image
+- source: longhornio/longhorn-manager:v1.9.2-hotfix-1
+  target: stgregistry.suse.com/rancher/mirrored-longhornio-longhorn-manager:v1.9.2-hotfix-1
   type: image
 - source: longhornio/longhorn-share-manager:v1_20201204
   target: docker.io/rancher/longhornio-longhorn-share-manager:v1_20201204


### PR DESCRIPTION
#### Pull Request Checklist ####

- [ ] If an entire artifact is being added, a repo has been created for the artifact in DockerHub under the `rancher` org
- [ ] Additions are licensed with Rancher favored licenses - Apache 2 and MIT - or approved licenses - as according to [CNCF approved licenses](https://github.com/cncf/foundation/blob/main/allowed-third-party-license-policy.md).
- [ ] Additions, when used in Rancher or Rancher's provided charts, have their corresponding origin added in Rancher's images [origins](https://github.com/rancher/rancher/blob/release/v2.7/pkg/image/origins.go) file (must be added for all Rancher versions `>= v2.7`).
- [ ] Any changes to scripting or CI config have been tested to the best of your ability

#### Change Description ####

<!-- Describe what you are doing and why. Link any related issues, pull requests and commit hashes. -->

#### Final Checks after the PR is merged ####

- [ ] Confirm that you can pull the mirrored artifact and tags from all target locations

Hi @brandond,
Could you review the PR or assign someone to review it? Thanks,