### PR TITLE
Update regsync command in mirror-artifacts workflow

### DIFF
--- a/.github/workflows/mirror-artifacts.yml
+++ b/.github/workflows/mirror-artifacts.yml
@@ -39,11 +39,11 @@ jobs:
           curl --silent --fail --location --output regsync https://github.com/regclient/regclient/releases/download/v0.8.3/regsync-linux-amd64
           chmod +x regsync
 
-      - name: Mirror artifacts
+   - name: Mirror artifacts
         run: |
           export PATH=$PATH:$(pwd)
           if [ "${{ inputs.debug }}" = "true" ]; then
-            time regsync once --logopt json --missing --config regsync.yaml --verbosity debug
+            time regsync once --logopt json --config regsync.yaml --verbosity debug
           else
-            time regsync once --logopt json --missing --config regsync.yaml
+            time regsync once --logopt json --config regsync.yaml
           fi


### PR DESCRIPTION
Removed the '--missing' option from regsync command.

#### Pull Request Checklist ####
- [ ] If an entire artifact is being added, a repo has been created for the artifact in DockerHub under the `rancher` org
- [ ] Additions are licensed with Rancher favored licenses - Apache 2 and MIT - or approved licenses - as according to [CNCF approved licenses](https://github.com/cncf/foundation/blob/main/allowed-third-party-license-policy.md).
- [ ] Additions, when used in Rancher or Rancher's provided charts, have their corresponding origin added in Rancher's images [origins](https://github.com/rancher/rancher/blob/release/v2.7/pkg/image/origins.go) file (must be added for all Rancher versions `>= v2.7`).
- [x] Any changes to scripting or CI config have been tested to the best of your ability

#### Change Description ####
Fixes #1237

The CI workflow used `regsync once --missing` which only syncs NEW tags,
skipping new architectures for existing tags. Upstream riscv64 images exist
but were being skipped because tags already existed with amd64/arm64.

Removing `--missing` allows regsync to backfill riscv64 for all existing
tags, enabling k3s to be built natively on linux/riscv64.

#### Final Checks after the PR is merged ####
- [ ] Confirm that you can pull the mirrored artifact and tags from all target locations
