### PR TITLE
feat: add longhorn v1.11.1 images

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -968,6 +968,7 @@ Artifacts:
   Tags:
   - v1.10.1
   - v1.10.2
+  - v1.11.1
   - v1.4.0
   - v1.4.1
   - v1.4.2
@@ -1017,6 +1018,7 @@ Artifacts:
   - v3.4.0
   - v4.10.0-20251030
   - v4.10.0-20251226
+  - v4.11.0
   - v4.2.0
   - v4.4.2
   - v4.5.1
@@ -1045,6 +1047,7 @@ Artifacts:
   - v2.14.0-20250709
   - v2.15.0-20251030
   - v2.15.0-20251226
+  - v2.16.0
   - v2.3.0
   - v2.5.0
   - v2.7.0
@@ -1074,6 +1077,7 @@ Artifacts:
   - v5.3.0-20250709
   - v5.3.0-20251030
   - v5.3.0-20251226
+  - v5.3.0-20260225
 - SourceArtifact: longhornio/csi-resizer
   Tags:
   - v0.3.0
@@ -1098,6 +1102,7 @@ Artifacts:
   - v1.3.0
   - v1.7.0
   - v1.9.2
+  - v2.1.0
 - SourceArtifact: longhornio/csi-snapshotter
   Tags:
   - v2.1.1-lh1
@@ -1121,6 +1126,7 @@ Artifacts:
   - v8.3.0-20250709
   - v8.4.0-20251030
   - v8.4.0-20251226
+  - v8.5.0
 - SourceArtifact: longhornio/livenessprobe
   Tags:
   - v2.11.0
@@ -1133,12 +1139,14 @@ Artifacts:
   - v2.16.0-20250709
   - v2.17.0-20251030
   - v2.17.0-20251226
+  - v2.18.0
   - v2.8.0
   - v2.9.0
 - SourceArtifact: longhornio/longhorn-cli
   Tags:
   - v1.10.1
   - v1.10.2
+  - v1.11.1
   - v1.7.0
   - v1.7.1
   - v1.7.2
@@ -1171,6 +1179,7 @@ Artifacts:
   - v1.1.3
   - v1.10.1
   - v1.10.2
+  - v1.11.1
   - v1.2.0
   - v1.2.1
   - v1.2.2
@@ -1222,6 +1231,7 @@ Artifacts:
   Tags:
   - v1.10.1
   - v1.10.2
+  - v1.11.1
   - v1.4.0
   - v1.4.1
   - v1.4.2
@@ -1283,6 +1293,7 @@ Artifacts:
   - v1.10.1-hotfix-1
   - v1.10.1-hotfix-2
   - v1.10.2
+  - v1.11.1
   - v1.2.0
   - v1.2.1
   - v1.2.2
@@ -1335,6 +1346,7 @@ Artifacts:
   Tags:
   - v1.10.1
   - v1.10.2
+  - v1.11.1
   - v1.4.0
   - v1.4.1
   - v1.4.2
@@ -1395,6 +1407,7 @@ Artifacts:
   - v1.1.3
   - v1.10.1
   - v1.10.2
+  - v1.11.1
   - v1.2.0
   - v1.2.1
   - v1.2.2
@@ -1457,6 +1470,7 @@ Artifacts:
   - v0.0.69
   - v0.0.71
   - v0.0.79
+  - v0.0.81
 - SourceArtifact: messagebird/sachet
   Tags:
   - 0.2.3

--- a/regsync.yaml
+++ b/regsync.yaml
@@ -5621,6 +5621,9 @@ sync:
 - source: longhornio/backing-image-manager:v1.10.2
   target: docker.io/rancher/mirrored-longhornio-backing-image-manager:v1.10.2
   type: image
+- source: longhornio/backing-image-manager:v1.11.1
+  target: docker.io/rancher/mirrored-longhornio-backing-image-manager:v1.11.1
+  type: image
 - source: longhornio/backing-image-manager:v1.4.0
   target: docker.io/rancher/mirrored-longhornio-backing-image-manager:v1.4.0
   type: image
@@ -5726,6 +5729,9 @@ sync:
 - source: longhornio/backing-image-manager:v1.10.2
   target: registry.suse.com/rancher/mirrored-longhornio-backing-image-manager:v1.10.2
   type: image
+- source: longhornio/backing-image-manager:v1.11.1
+  target: registry.suse.com/rancher/mirrored-longhornio-backing-image-manager:v1.11.1
+  type: image
 - source: longhornio/backing-image-manager:v1.4.0
   target: registry.suse.com/rancher/mirrored-longhornio-backing-image-manager:v1.4.0
   type: image
@@ -5830,6 +5836,9 @@ sync:
   type: image
 - source: longhornio/backing-image-manager:v1.10.2
   target: stgregistry.suse.com/rancher/mirrored-longhornio-backing-image-manager:v1.10.2
+  type: image
+- source: longhornio/backing-image-manager:v1.11.1
+  target: stgregistry.suse.com/rancher/mirrored-longhornio-backing-image-manager:v1.11.1
   type: image
 - source: longhornio/backing-image-manager:v1.4.0
   target: stgregistry.suse.com/rancher/mirrored-longhornio-backing-image-manager:v1.4.0
@@ -5993,6 +6002,9 @@ sync:
 - source: longhornio/csi-attacher:v4.10.0-20251226
   target: docker.io/rancher/mirrored-longhornio-csi-attacher:v4.10.0-20251226
   type: image
+- source: longhornio/csi-attacher:v4.11.0
+  target: docker.io/rancher/mirrored-longhornio-csi-attacher:v4.11.0
+  type: image
 - source: longhornio/csi-attacher:v4.2.0
   target: docker.io/rancher/mirrored-longhornio-csi-attacher:v4.2.0
   type: image
@@ -6041,6 +6053,9 @@ sync:
 - source: longhornio/csi-attacher:v4.10.0-20251226
   target: registry.suse.com/rancher/mirrored-longhornio-csi-attacher:v4.10.0-20251226
   type: image
+- source: longhornio/csi-attacher:v4.11.0
+  target: registry.suse.com/rancher/mirrored-longhornio-csi-attacher:v4.11.0
+  type: image
 - source: longhornio/csi-attacher:v4.2.0
   target: registry.suse.com/rancher/mirrored-longhornio-csi-attacher:v4.2.0
   type: image
@@ -6088,6 +6103,9 @@ sync:
   type: image
 - source: longhornio/csi-attacher:v4.10.0-20251226
   target: stgregistry.suse.com/rancher/mirrored-longhornio-csi-attacher:v4.10.0-20251226
+  type: image
+- source: longhornio/csi-attacher:v4.11.0
+  target: stgregistry.suse.com/rancher/mirrored-longhornio-csi-attacher:v4.11.0
   type: image
 - source: longhornio/csi-attacher:v4.2.0
   target: stgregistry.suse.com/rancher/mirrored-longhornio-csi-attacher:v4.2.0
@@ -6182,6 +6200,9 @@ sync:
 - source: longhornio/csi-node-driver-registrar:v2.15.0-20251226
   target: docker.io/rancher/mirrored-longhornio-csi-node-driver-registrar:v2.15.0-20251226
   type: image
+- source: longhornio/csi-node-driver-registrar:v2.16.0
+  target: docker.io/rancher/mirrored-longhornio-csi-node-driver-registrar:v2.16.0
+  type: image
 - source: longhornio/csi-node-driver-registrar:v2.3.0
   target: docker.io/rancher/mirrored-longhornio-csi-node-driver-registrar:v2.3.0
   type: image
@@ -6221,6 +6242,9 @@ sync:
 - source: longhornio/csi-node-driver-registrar:v2.15.0-20251226
   target: registry.suse.com/rancher/mirrored-longhornio-csi-node-driver-registrar:v2.15.0-20251226
   type: image
+- source: longhornio/csi-node-driver-registrar:v2.16.0
+  target: registry.suse.com/rancher/mirrored-longhornio-csi-node-driver-registrar:v2.16.0
+  type: image
 - source: longhornio/csi-node-driver-registrar:v2.3.0
   target: registry.suse.com/rancher/mirrored-longhornio-csi-node-driver-registrar:v2.3.0
   type: image
@@ -6259,6 +6283,9 @@ sync:
   type: image
 - source: longhornio/csi-node-driver-registrar:v2.15.0-20251226
   target: stgregistry.suse.com/rancher/mirrored-longhornio-csi-node-driver-registrar:v2.15.0-20251226
+  type: image
+- source: longhornio/csi-node-driver-registrar:v2.16.0
+  target: stgregistry.suse.com/rancher/mirrored-longhornio-csi-node-driver-registrar:v2.16.0
   type: image
 - source: longhornio/csi-node-driver-registrar:v2.3.0
   target: stgregistry.suse.com/rancher/mirrored-longhornio-csi-node-driver-registrar:v2.3.0
@@ -6356,6 +6383,9 @@ sync:
 - source: longhornio/csi-provisioner:v5.3.0-20251226
   target: docker.io/rancher/mirrored-longhornio-csi-provisioner:v5.3.0-20251226
   type: image
+- source: longhornio/csi-provisioner:v5.3.0-20260225
+  target: docker.io/rancher/mirrored-longhornio-csi-provisioner:v5.3.0-20260225
+  type: image
 - source: longhornio/csi-provisioner:v1.6.0-lh1
   target: registry.suse.com/rancher/mirrored-longhornio-csi-provisioner:v1.6.0-lh1
   type: image
@@ -6404,6 +6434,9 @@ sync:
 - source: longhornio/csi-provisioner:v5.3.0-20251226
   target: registry.suse.com/rancher/mirrored-longhornio-csi-provisioner:v5.3.0-20251226
   type: image
+- source: longhornio/csi-provisioner:v5.3.0-20260225
+  target: registry.suse.com/rancher/mirrored-longhornio-csi-provisioner:v5.3.0-20260225
+  type: image
 - source: longhornio/csi-provisioner:v1.6.0-lh1
   target: stgregistry.suse.com/rancher/mirrored-longhornio-csi-provisioner:v1.6.0-lh1
   type: image
@@ -6451,6 +6484,9 @@ sync:
   type: image
 - source: longhornio/csi-provisioner:v5.3.0-20251226
   target: stgregistry.suse.com/rancher/mirrored-longhornio-csi-provisioner:v5.3.0-20251226
+  type: image
+- source: longhornio/csi-provisioner:v5.3.0-20260225
+  target: stgregistry.suse.com/rancher/mirrored-longhornio-csi-provisioner:v5.3.0-20260225
   type: image
 - source: longhornio/csi-resizer:v0.3.0
   target: docker.io/rancher/longhornio-csi-resizer:v0.3.0
@@ -6533,6 +6569,9 @@ sync:
 - source: longhornio/csi-resizer:v1.9.2
   target: docker.io/rancher/mirrored-longhornio-csi-resizer:v1.9.2
   type: image
+- source: longhornio/csi-resizer:v2.1.0
+  target: docker.io/rancher/mirrored-longhornio-csi-resizer:v2.1.0
+  type: image
 - source: longhornio/csi-resizer:v0.5.1-lh1
   target: registry.suse.com/rancher/mirrored-longhornio-csi-resizer:v0.5.1-lh1
   type: image
@@ -6578,6 +6617,9 @@ sync:
 - source: longhornio/csi-resizer:v1.9.2
   target: registry.suse.com/rancher/mirrored-longhornio-csi-resizer:v1.9.2
   type: image
+- source: longhornio/csi-resizer:v2.1.0
+  target: registry.suse.com/rancher/mirrored-longhornio-csi-resizer:v2.1.0
+  type: image
 - source: longhornio/csi-resizer:v0.5.1-lh1
   target: stgregistry.suse.com/rancher/mirrored-longhornio-csi-resizer:v0.5.1-lh1
   type: image
@@ -6622,6 +6664,9 @@ sync:
   type: image
 - source: longhornio/csi-resizer:v1.9.2
   target: stgregistry.suse.com/rancher/mirrored-longhornio-csi-resizer:v1.9.2
+  type: image
+- source: longhornio/csi-resizer:v2.1.0
+  target: stgregistry.suse.com/rancher/mirrored-longhornio-csi-resizer:v2.1.0
   type: image
 - source: longhornio/csi-snapshotter:v2.1.1-lh1
   target: docker.io/rancher/longhornio-csi-snapshotter:v2.1.1-lh1
@@ -6695,6 +6740,9 @@ sync:
 - source: longhornio/csi-snapshotter:v8.4.0-20251226
   target: docker.io/rancher/mirrored-longhornio-csi-snapshotter:v8.4.0-20251226
   type: image
+- source: longhornio/csi-snapshotter:v8.5.0
+  target: docker.io/rancher/mirrored-longhornio-csi-snapshotter:v8.5.0
+  type: image
 - source: longhornio/csi-snapshotter:v2.1.1-lh1
   target: registry.suse.com/rancher/mirrored-longhornio-csi-snapshotter:v2.1.1-lh1
   type: image
@@ -6739,6 +6787,9 @@ sync:
   type: image
 - source: longhornio/csi-snapshotter:v8.4.0-20251226
   target: registry.suse.com/rancher/mirrored-longhornio-csi-snapshotter:v8.4.0-20251226
+  type: image
+- source: longhornio/csi-snapshotter:v8.5.0
+  target: registry.suse.com/rancher/mirrored-longhornio-csi-snapshotter:v8.5.0
   type: image
 - source: longhornio/csi-snapshotter:v2.1.1-lh1
   target: stgregistry.suse.com/rancher/mirrored-longhornio-csi-snapshotter:v2.1.1-lh1
@@ -6785,6 +6836,9 @@ sync:
 - source: longhornio/csi-snapshotter:v8.4.0-20251226
   target: stgregistry.suse.com/rancher/mirrored-longhornio-csi-snapshotter:v8.4.0-20251226
   type: image
+- source: longhornio/csi-snapshotter:v8.5.0
+  target: stgregistry.suse.com/rancher/mirrored-longhornio-csi-snapshotter:v8.5.0
+  type: image
 - source: longhornio/livenessprobe:v2.11.0
   target: docker.io/rancher/mirrored-longhornio-livenessprobe:v2.11.0
   type: image
@@ -6814,6 +6868,9 @@ sync:
   type: image
 - source: longhornio/livenessprobe:v2.17.0-20251226
   target: docker.io/rancher/mirrored-longhornio-livenessprobe:v2.17.0-20251226
+  type: image
+- source: longhornio/livenessprobe:v2.18.0
+  target: docker.io/rancher/mirrored-longhornio-livenessprobe:v2.18.0
   type: image
 - source: longhornio/livenessprobe:v2.8.0
   target: docker.io/rancher/mirrored-longhornio-livenessprobe:v2.8.0
@@ -6851,6 +6908,9 @@ sync:
 - source: longhornio/livenessprobe:v2.17.0-20251226
   target: registry.suse.com/rancher/mirrored-longhornio-livenessprobe:v2.17.0-20251226
   type: image
+- source: longhornio/livenessprobe:v2.18.0
+  target: registry.suse.com/rancher/mirrored-longhornio-livenessprobe:v2.18.0
+  type: image
 - source: longhornio/livenessprobe:v2.8.0
   target: registry.suse.com/rancher/mirrored-longhornio-livenessprobe:v2.8.0
   type: image
@@ -6887,6 +6947,9 @@ sync:
 - source: longhornio/livenessprobe:v2.17.0-20251226
   target: stgregistry.suse.com/rancher/mirrored-longhornio-livenessprobe:v2.17.0-20251226
   type: image
+- source: longhornio/livenessprobe:v2.18.0
+  target: stgregistry.suse.com/rancher/mirrored-longhornio-livenessprobe:v2.18.0
+  type: image
 - source: longhornio/livenessprobe:v2.8.0
   target: stgregistry.suse.com/rancher/mirrored-longhornio-livenessprobe:v2.8.0
   type: image
@@ -6898,6 +6961,9 @@ sync:
   type: image
 - source: longhornio/longhorn-cli:v1.10.2
   target: docker.io/rancher/mirrored-longhornio-longhorn-cli:v1.10.2
+  type: image
+- source: longhornio/longhorn-cli:v1.11.1
+  target: docker.io/rancher/mirrored-longhornio-longhorn-cli:v1.11.1
   type: image
 - source: longhornio/longhorn-cli:v1.7.0
   target: docker.io/rancher/mirrored-longhornio-longhorn-cli:v1.7.0
@@ -6929,6 +6995,9 @@ sync:
 - source: longhornio/longhorn-cli:v1.10.2
   target: registry.suse.com/rancher/mirrored-longhornio-longhorn-cli:v1.10.2
   type: image
+- source: longhornio/longhorn-cli:v1.11.1
+  target: registry.suse.com/rancher/mirrored-longhornio-longhorn-cli:v1.11.1
+  type: image
 - source: longhornio/longhorn-cli:v1.7.0
   target: registry.suse.com/rancher/mirrored-longhornio-longhorn-cli:v1.7.0
   type: image
@@ -6958,6 +7027,9 @@ sync:
   type: image
 - source: longhornio/longhorn-cli:v1.10.2
   target: stgregistry.suse.com/rancher/mirrored-longhornio-longhorn-cli:v1.10.2
+  type: image
+- source: longhornio/longhorn-cli:v1.11.1
+  target: stgregistry.suse.com/rancher/mirrored-longhornio-longhorn-cli:v1.11.1
   type: image
 - source: longhornio/longhorn-cli:v1.7.0
   target: stgregistry.suse.com/rancher/mirrored-longhornio-longhorn-cli:v1.7.0
@@ -7118,6 +7190,9 @@ sync:
 - source: longhornio/longhorn-engine:v1.10.2
   target: docker.io/rancher/mirrored-longhornio-longhorn-engine:v1.10.2
   type: image
+- source: longhornio/longhorn-engine:v1.11.1
+  target: docker.io/rancher/mirrored-longhornio-longhorn-engine:v1.11.1
+  type: image
 - source: longhornio/longhorn-engine:v1.2.0
   target: docker.io/rancher/mirrored-longhornio-longhorn-engine:v1.2.0
   type: image
@@ -7241,6 +7316,9 @@ sync:
 - source: longhornio/longhorn-engine:v1.10.2
   target: registry.suse.com/rancher/mirrored-longhornio-longhorn-engine:v1.10.2
   type: image
+- source: longhornio/longhorn-engine:v1.11.1
+  target: registry.suse.com/rancher/mirrored-longhornio-longhorn-engine:v1.11.1
+  type: image
 - source: longhornio/longhorn-engine:v1.2.0
   target: registry.suse.com/rancher/mirrored-longhornio-longhorn-engine:v1.2.0
   type: image
@@ -7363,6 +7441,9 @@ sync:
   type: image
 - source: longhornio/longhorn-engine:v1.10.2
   target: stgregistry.suse.com/rancher/mirrored-longhornio-longhorn-engine:v1.10.2
+  type: image
+- source: longhornio/longhorn-engine:v1.11.1
+  target: stgregistry.suse.com/rancher/mirrored-longhornio-longhorn-engine:v1.11.1
   type: image
 - source: longhornio/longhorn-engine:v1.2.0
   target: stgregistry.suse.com/rancher/mirrored-longhornio-longhorn-engine:v1.2.0
@@ -7556,6 +7637,9 @@ sync:
 - source: longhornio/longhorn-instance-manager:v1.10.2
   target: docker.io/rancher/mirrored-longhornio-longhorn-instance-manager:v1.10.2
   type: image
+- source: longhornio/longhorn-instance-manager:v1.11.1
+  target: docker.io/rancher/mirrored-longhornio-longhorn-instance-manager:v1.11.1
+  type: image
 - source: longhornio/longhorn-instance-manager:v1.4.0
   target: docker.io/rancher/mirrored-longhornio-longhorn-instance-manager:v1.4.0
   type: image
@@ -7667,6 +7751,9 @@ sync:
 - source: longhornio/longhorn-instance-manager:v1.10.2
   target: registry.suse.com/rancher/mirrored-longhornio-longhorn-instance-manager:v1.10.2
   type: image
+- source: longhornio/longhorn-instance-manager:v1.11.1
+  target: registry.suse.com/rancher/mirrored-longhornio-longhorn-instance-manager:v1.11.1
+  type: image
 - source: longhornio/longhorn-instance-manager:v1.4.0
   target: registry.suse.com/rancher/mirrored-longhornio-longhorn-instance-manager:v1.4.0
   type: image
@@ -7777,6 +7864,9 @@ sync:
   type: image
 - source: longhornio/longhorn-instance-manager:v1.10.2
   target: stgregistry.suse.com/rancher/mirrored-longhornio-longhorn-instance-manager:v1.10.2
+  type: image
+- source: longhornio/longhorn-instance-manager:v1.11.1
+  target: stgregistry.suse.com/rancher/mirrored-longhornio-longhorn-instance-manager:v1.11.1
   type: image
 - source: longhornio/longhorn-instance-manager:v1.4.0
   target: stgregistry.suse.com/rancher/mirrored-longhornio-longhorn-instance-manager:v1.4.0
@@ -8024,6 +8114,9 @@ sync:
 - source: longhornio/longhorn-manager:v1.10.2
   target: docker.io/rancher/mirrored-longhornio-longhorn-manager:v1.10.2
   type: image
+- source: longhornio/longhorn-manager:v1.11.1
+  target: docker.io/rancher/mirrored-longhornio-longhorn-manager:v1.11.1
+  type: image
 - source: longhornio/longhorn-manager:v1.2.0
   target: docker.io/rancher/mirrored-longhornio-longhorn-manager:v1.2.0
   type: image
@@ -8156,6 +8249,9 @@ sync:
 - source: longhornio/longhorn-manager:v1.10.2
   target: registry.suse.com/rancher/mirrored-longhornio-longhorn-manager:v1.10.2
   type: image
+- source: longhornio/longhorn-manager:v1.11.1
+  target: registry.suse.com/rancher/mirrored-longhornio-longhorn-manager:v1.11.1
+  type: image
 - source: longhornio/longhorn-manager:v1.2.0
   target: registry.suse.com/rancher/mirrored-longhornio-longhorn-manager:v1.2.0
   type: image
@@ -8287,6 +8383,9 @@ sync:
   type: image
 - source: longhornio/longhorn-manager:v1.10.2
   target: stgregistry.suse.com/rancher/mirrored-longhornio-longhorn-manager:v1.10.2
+  type: image
+- source: longhornio/longhorn-manager:v1.11.1
+  target: stgregistry.suse.com/rancher/mirrored-longhornio-longhorn-manager:v1.11.1
   type: image
 - source: longhornio/longhorn-manager:v1.2.0
   target: stgregistry.suse.com/rancher/mirrored-longhornio-longhorn-manager:v1.2.0
@@ -8483,6 +8582,9 @@ sync:
 - source: longhornio/longhorn-share-manager:v1.10.2
   target: docker.io/rancher/mirrored-longhornio-longhorn-share-manager:v1.10.2
   type: image
+- source: longhornio/longhorn-share-manager:v1.11.1
+  target: docker.io/rancher/mirrored-longhornio-longhorn-share-manager:v1.11.1
+  type: image
 - source: longhornio/longhorn-share-manager:v1.4.0
   target: docker.io/rancher/mirrored-longhornio-longhorn-share-manager:v1.4.0
   type: image
@@ -8597,6 +8699,9 @@ sync:
 - source: longhornio/longhorn-share-manager:v1.10.2
   target: registry.suse.com/rancher/mirrored-longhornio-longhorn-share-manager:v1.10.2
   type: image
+- source: longhornio/longhorn-share-manager:v1.11.1
+  target: registry.suse.com/rancher/mirrored-longhornio-longhorn-share-manager:v1.11.1
+  type: image
 - source: longhornio/longhorn-share-manager:v1.4.0
   target: registry.suse.com/rancher/mirrored-longhornio-longhorn-share-manager:v1.4.0
   type: image
@@ -8710,6 +8815,9 @@ sync:
   type: image
 - source: longhornio/longhorn-share-manager:v1.10.2
   target: stgregistry.suse.com/rancher/mirrored-longhornio-longhorn-share-manager:v1.10.2
+  type: image
+- source: longhornio/longhorn-share-manager:v1.11.1
+  target: stgregistry.suse.com/rancher/mirrored-longhornio-longhorn-share-manager:v1.11.1
   type: image
 - source: longhornio/longhorn-share-manager:v1.4.0
   target: stgregistry.suse.com/rancher/mirrored-longhornio-longhorn-share-manager:v1.4.0
@@ -8954,6 +9062,9 @@ sync:
 - source: longhornio/longhorn-ui:v1.10.2
   target: docker.io/rancher/mirrored-longhornio-longhorn-ui:v1.10.2
   type: image
+- source: longhornio/longhorn-ui:v1.11.1
+  target: docker.io/rancher/mirrored-longhornio-longhorn-ui:v1.11.1
+  type: image
 - source: longhornio/longhorn-ui:v1.2.0
   target: docker.io/rancher/mirrored-longhornio-longhorn-ui:v1.2.0
   type: image
@@ -9077,6 +9188,9 @@ sync:
 - source: longhornio/longhorn-ui:v1.10.2
   target: registry.suse.com/rancher/mirrored-longhornio-longhorn-ui:v1.10.2
   type: image
+- source: longhornio/longhorn-ui:v1.11.1
+  target: registry.suse.com/rancher/mirrored-longhornio-longhorn-ui:v1.11.1
+  type: image
 - source: longhornio/longhorn-ui:v1.2.0
   target: registry.suse.com/rancher/mirrored-longhornio-longhorn-ui:v1.2.0
   type: image
@@ -9199,6 +9313,9 @@ sync:
   type: image
 - source: longhornio/longhorn-ui:v1.10.2
   target: stgregistry.suse.com/rancher/mirrored-longhornio-longhorn-ui:v1.10.2
+  type: image
+- source: longhornio/longhorn-ui:v1.11.1
+  target: stgregistry.suse.com/rancher/mirrored-longhornio-longhorn-ui:v1.11.1
   type: image
 - source: longhornio/longhorn-ui:v1.2.0
   target: stgregistry.suse.com/rancher/mirrored-longhornio-longhorn-ui:v1.2.0
@@ -9386,6 +9503,9 @@ sync:
 - source: longhornio/support-bundle-kit:v0.0.79
   target: docker.io/rancher/mirrored-longhornio-support-bundle-kit:v0.0.79
   type: image
+- source: longhornio/support-bundle-kit:v0.0.81
+  target: docker.io/rancher/mirrored-longhornio-support-bundle-kit:v0.0.81
+  type: image
 - source: longhornio/support-bundle-kit:v0.0.17
   target: registry.suse.com/rancher/mirrored-longhornio-support-bundle-kit:v0.0.17
   type: image
@@ -9449,6 +9569,9 @@ sync:
 - source: longhornio/support-bundle-kit:v0.0.79
   target: registry.suse.com/rancher/mirrored-longhornio-support-bundle-kit:v0.0.79
   type: image
+- source: longhornio/support-bundle-kit:v0.0.81
+  target: registry.suse.com/rancher/mirrored-longhornio-support-bundle-kit:v0.0.81
+  type: image
 - source: longhornio/support-bundle-kit:v0.0.17
   target: stgregistry.suse.com/rancher/mirrored-longhornio-support-bundle-kit:v0.0.17
   type: image
@@ -9511,6 +9634,9 @@ sync:
   type: image
 - source: longhornio/support-bundle-kit:v0.0.79
   target: stgregistry.suse.com/rancher/mirrored-longhornio-support-bundle-kit:v0.0.79
+  type: image
+- source: longhornio/support-bundle-kit:v0.0.81
+  target: stgregistry.suse.com/rancher/mirrored-longhornio-support-bundle-kit:v0.0.81
   type: image
 - source: messagebird/sachet:0.2.3
   target: docker.io/rancher/mirrored-messagebird-sachet:0.2.3


### PR DESCRIPTION
#### Pull Request Checklist ####

- [ ] If an entire artifact is being added, a repo has been created for the artifact in DockerHub under the `rancher` org
- [ ] Additions are licensed with Rancher favored licenses - Apache 2 and MIT - or approved licenses - as according to [CNCF approved licenses](https://github.com/cncf/foundation/blob/main/allowed-third-party-license-policy.md).
- [ ] Additions, when used in Rancher or Rancher's provided charts, have their corresponding origin added in Rancher's images [origins](https://github.com/rancher/rancher/blob/release/v2.7/pkg/image/origins.go) file (must be added for all Rancher versions `>= v2.7`).
- [ ] Any changes to scripting or CI config have been tested to the best of your ability

#### Change Description ####

<!-- Describe what you are doing and why. Link any related issues, pull requests and commit hashes. -->

#### Final Checks after the PR is merged ####

- [ ] Confirm that you can pull the mirrored artifact and tags from all target locations


longhorn/longhorn#12705
cc @derekbit 