### PR TITLE
Add cilium certgen v0.4.1

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -2176,6 +2176,7 @@ Artifacts:
   - v0.2.4
   - v0.3.1
   - v0.3.2
+  - v0.4.1
 - SourceArtifact: quay.io/cilium/cilium
   Tags:
   - v1.10.4

--- a/regsync.yaml
+++ b/regsync.yaml
@@ -15050,6 +15050,9 @@ sync:
 - source: quay.io/cilium/certgen:v0.3.2
   target: docker.io/rancher/mirrored-cilium-certgen:v0.3.2
   type: image
+- source: quay.io/cilium/certgen:v0.4.1
+  target: docker.io/rancher/mirrored-cilium-certgen:v0.4.1
+  type: image
 - source: quay.io/cilium/certgen:v0.1.11
   target: registry.suse.com/rancher/mirrored-cilium-certgen:v0.1.11
   type: image
@@ -15080,6 +15083,9 @@ sync:
 - source: quay.io/cilium/certgen:v0.3.2
   target: registry.suse.com/rancher/mirrored-cilium-certgen:v0.3.2
   type: image
+- source: quay.io/cilium/certgen:v0.4.1
+  target: registry.suse.com/rancher/mirrored-cilium-certgen:v0.4.1
+  type: image
 - source: quay.io/cilium/certgen:v0.1.11
   target: stgregistry.suse.com/rancher/mirrored-cilium-certgen:v0.1.11
   type: image
@@ -15109,6 +15115,9 @@ sync:
   type: image
 - source: quay.io/cilium/certgen:v0.3.2
   target: stgregistry.suse.com/rancher/mirrored-cilium-certgen:v0.3.2
+  type: image
+- source: quay.io/cilium/certgen:v0.4.1
+  target: stgregistry.suse.com/rancher/mirrored-cilium-certgen:v0.4.1
   type: image
 - source: quay.io/cilium/cilium:v1.10.4
   target: docker.io/rancher/mirrored-cilium-cilium:v1.10.4


### PR DESCRIPTION
#### Pull Request Checklist ####

- [ ] If an entire artifact is being added, a repo has been created for the artifact in DockerHub under the `rancher` org
- [ ] Additions are licensed with Rancher favored licenses - Apache 2 and MIT - or approved licenses - as according to [CNCF approved licenses](https://github.com/cncf/foundation/blob/main/allowed-third-party-license-policy.md).
- [ ] Additions, when used in Rancher or Rancher's provided charts, have their corresponding origin added in Rancher's images [origins](https://github.com/rancher/rancher/blob/release/v2.7/pkg/image/origins.go) file (must be added for all Rancher versions `>= v2.7`).
- [ ] Any changes to scripting or CI config have been tested to the best of your ability

#### Change Description ####

<!-- Describe what you are doing and why. Link any related issues, pull requests and commit hashes. -->

#### Final Checks after the PR is merged ####

- [ ] Confirm that you can pull the mirrored artifact and tags from all target locations
