### PR TITLE
Mirror dp.apps.rancher.io/containers/kube-state-metrics:2.17.0-10.13 image for rancher-monitoring

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -150,6 +150,7 @@ Artifacts:
 - SourceArtifact: dp.apps.rancher.io/containers/kube-state-metrics
   Tags:
   - 2.17.0-10.11
+  - 2.17.0-10.14
   - 2.17.0-10.7
 - SourceArtifact: dp.apps.rancher.io/containers/kubernetes-cluster-autoscaler
   Tags:

--- a/regsync.yaml
+++ b/regsync.yaml
@@ -758,17 +758,26 @@ sync:
 - source: dp.apps.rancher.io/containers/kube-state-metrics:2.17.0-10.11
   target: docker.io/rancher/appco-kube-state-metrics:2.17.0-10.11
   type: image
+- source: dp.apps.rancher.io/containers/kube-state-metrics:2.17.0-10.14
+  target: docker.io/rancher/appco-kube-state-metrics:2.17.0-10.14
+  type: image
 - source: dp.apps.rancher.io/containers/kube-state-metrics:2.17.0-10.7
   target: docker.io/rancher/appco-kube-state-metrics:2.17.0-10.7
   type: image
 - source: dp.apps.rancher.io/containers/kube-state-metrics:2.17.0-10.11
   target: registry.suse.com/rancher/appco-kube-state-metrics:2.17.0-10.11
   type: image
+- source: dp.apps.rancher.io/containers/kube-state-metrics:2.17.0-10.14
+  target: registry.suse.com/rancher/appco-kube-state-metrics:2.17.0-10.14
+  type: image
 - source: dp.apps.rancher.io/containers/kube-state-metrics:2.17.0-10.7
   target: registry.suse.com/rancher/appco-kube-state-metrics:2.17.0-10.7
   type: image
 - source: dp.apps.rancher.io/containers/kube-state-metrics:2.17.0-10.11
   target: stgregistry.suse.com/rancher/appco-kube-state-metrics:2.17.0-10.11
+  type: image
+- source: dp.apps.rancher.io/containers/kube-state-metrics:2.17.0-10.14
+  target: stgregistry.suse.com/rancher/appco-kube-state-metrics:2.17.0-10.14
   type: image
 - source: dp.apps.rancher.io/containers/kube-state-metrics:2.17.0-10.7
   target: stgregistry.suse.com/rancher/appco-kube-state-metrics:2.17.0-10.7


### PR DESCRIPTION
#### Pull Request Checklist ####

- [ ] If an entire artifact is being added, a repo has been created for the artifact in DockerHub under the `rancher` org
- [ ] Additions are licensed with Rancher favored licenses - Apache 2 and MIT - or approved licenses - as according to [CNCF approved licenses](https://github.com/cncf/foundation/blob/main/allowed-third-party-license-policy.md).
- [ ] Additions, when used in Rancher or Rancher's provided charts, have their corresponding origin added in Rancher's images [origins](https://github.com/rancher/rancher/blob/release/v2.7/pkg/image/origins.go) file (must be added for all Rancher versions `>= v2.7`).
- [ ] Any changes to scripting or CI config have been tested to the best of your ability

#### Change Description ####

This is for https://github.com/rancher/rancher/issues/53194 

<!-- Describe what you are doing and why. Link any related issues, pull requests and commit hashes. -->

#### Final Checks after the PR is merged ####

- [ ] Confirm that you can pull the mirrored artifact and tags from all target locations
