### PR TITLE
autoupdate: fixup cilium certgen image sync

### DIFF
--- a/autoupdate.yaml
+++ b/autoupdate.yaml
@@ -51,11 +51,12 @@
         azure:
         - azure.enabled=true
         generic:
-        - clustermesh.useAPIServer=true,
-        - envoy.enabled=true,
-        - hubble.ui.enabled=true,
-        - hubble.relay.enabled=true,
+        - clustermesh.useAPIServer=true
+        - envoy.enabled=true
+        - hubble.ui.enabled=true
+        - hubble.relay.enabled=true
         - hubble.enabled=true
+        - hubble.tls.auto.method=cronJob
     HelmRepo: https://helm.cilium.io
     ImageDenylist:
     - quay.io/cilium/operator


### PR DESCRIPTION
certgen is used when `clustermesh.apiserver.tls.auto.method=cronJob`

Let autoupdate handle these and avoid manually adding the missing image:
- https://github.com/rancher/artifact-mirror/pull/1207
- https://github.com/rancher/artifact-mirror/pull/1223
- https://github.com/rancher/artifact-mirror/pull/1264


#### Pull Request Checklist ####

- [ ] If an entire artifact is being added, a repo has been created for the artifact in DockerHub under the `rancher` org
- [ ] Additions are licensed with Rancher favored licenses - Apache 2 and MIT - or approved licenses - as according to [CNCF approved licenses](https://github.com/cncf/foundation/blob/main/allowed-third-party-license-policy.md).
- [ ] Additions, when used in Rancher or Rancher's provided charts, have their corresponding origin added in Rancher's images [origins](https://github.com/rancher/rancher/blob/release/v2.7/pkg/image/origins.go) file (must be added for all Rancher versions `>= v2.7`).
- [ ] Any changes to scripting or CI config have been tested to the best of your ability

#### Change Description ####

<!-- Describe what you are doing and why. Link any related issues, pull requests and commit hashes. -->

#### Final Checks after the PR is merged ####

- [ ] Confirm that you can pull the mirrored artifact and tags from all target locations
