### PR TITLE
Fix failing regsync checksum

### DIFF
--- a/.github/workflows/mirror-artifacts-daily.yml
+++ b/.github/workflows/mirror-artifacts-daily.yml
@@ -34,7 +34,7 @@ jobs:
         run: |
           REGSYNC_CHECKSUM=bbfcf9dc120bd67ad6163eb80667005c47570ff5a90157f0d26efb247906548d
           curl --silent --fail --location --output regsync https://github.com/regclient/regclient/releases/download/v0.8.3/regsync-linux-amd64
-          echo "${REGSYNC_CHECKSUM}  regsync-linux-amd64" | sha256sum -c -
+          echo "${REGSYNC_CHECKSUM}  regsync" | sha256sum -c -
           chmod +x regsync
 
       - name: Mirror daily artifacts

--- a/.github/workflows/mirror-artifacts.yml
+++ b/.github/workflows/mirror-artifacts.yml
@@ -38,7 +38,7 @@ jobs:
         run: |
           REGSYNC_CHECKSUM=bbfcf9dc120bd67ad6163eb80667005c47570ff5a90157f0d26efb247906548d
           curl --silent --fail --location --output regsync https://github.com/regclient/regclient/releases/download/v0.8.3/regsync-linux-amd64
-          echo "${REGSYNC_CHECKSUM}  regsync-linux-amd64" | sha256sum -c -
+          echo "${REGSYNC_CHECKSUM}  regsync" | sha256sum -c -
           chmod +x regsync
 
       - name: Mirror artifacts


### PR DESCRIPTION
regsync actions are [failing](https://github.com/rancher/artifact-mirror/actions/runs/24473753099) 
```
sha256sum: regsync-linux-amd64: No such file or directory
regsync-linux-amd64: FAILED open or read
sha256sum: WARNING: 1 listed file could not be read
```

Fixup: f93498c12cbd2ac25d35cd27d122baa1808029c5
Issue: https://github.com/rancher/rancher-security/issues/1720
