### PR TITLE
add reviewers to PR

### DIFF
--- a/tools/internal/autoupdate/config.go
+++ b/tools/internal/autoupdate/config.go
@@ -200,6 +200,15 @@ func (entry ConfigEntry) Run(ctx context.Context, opts AutoUpdateOptions) error 
 		return fmt.Errorf("failed to list pull requests: %w", err)
 	}
 	if len(pullRequests) == 1 {
+		if len(pullRequests[0].RequestedReviewers) <= 1 && len(entry.Reviewers) > 0 { // only codeowner as reviewer
+			_, _, err := opts.GithubClient.PullRequests.RequestReviewers(ctx, opts.GithubOwner, opts.GithubRepo, pullRequests[0].GetNumber(), github.ReviewersRequest{
+				NodeID:        pullRequests[0].NodeID,
+				TeamReviewers: entry.Reviewers,
+			})
+			if err != nil {
+				fmt.Printf("warning: failed to add reviewers to PR %s: %s\n", pullRequests[0].GetHTMLURL(), err)
+			}
+		}
 		fmt.Printf("%s: found existing PR with head branch %s: %s\n", entry.Name, headBranch, pullRequests[0].GetHTMLURL())
 		return nil
 	} else if len(pullRequests) > 1 {
@@ -288,7 +297,13 @@ func (entry ConfigEntry) CreateArtifactUpdatePullRequest(ctx context.Context, op
 	}
 
 	fmt.Printf("%s: created pull request: %s\n", entry.Name, pullRequest.GetHTMLURL())
-
+	_, _, err = opts.GithubClient.PullRequests.RequestReviewers(requestContext, opts.GithubOwner, opts.GithubRepo, pullRequest.GetNumber(), github.ReviewersRequest{
+		NodeID:        pullRequest.NodeID,
+		TeamReviewers: entry.Reviewers,
+	})
+	if err != nil {
+		fmt.Printf("warning: failed to add reviewers to PR %s: %s\n", pullRequest.GetHTMLURL(), err)
+	}
 	return nil
 }
 


### PR DESCRIPTION
`autoupdate.yaml` contains the reviewers for each mirrored image, but is not currently used. This PR adds those reviewers to the automated PRs