### PR TITLE
Add new versions of appco cluster-autoscaler chart

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -101,6 +101,8 @@ Artifacts:
 - SourceArtifact: dp.apps.rancher.io/charts/kubernetes-cluster-autoscaler
   Tags:
   - 9.50.1
+  - 9.56.0
+  - 9.57.0
   TargetRepositories:
   - registry.suse.com/rancher/charts
   - stgregistry.suse.com/rancher/charts

--- a/regsync.yaml
+++ b/regsync.yaml
@@ -617,8 +617,20 @@ sync:
 - source: dp.apps.rancher.io/charts/kubernetes-cluster-autoscaler:9.50.1
   target: registry.suse.com/rancher/charts/appco-kubernetes-cluster-autoscaler:9.50.1
   type: image
+- source: dp.apps.rancher.io/charts/kubernetes-cluster-autoscaler:9.56.0
+  target: registry.suse.com/rancher/charts/appco-kubernetes-cluster-autoscaler:9.56.0
+  type: image
+- source: dp.apps.rancher.io/charts/kubernetes-cluster-autoscaler:9.57.0
+  target: registry.suse.com/rancher/charts/appco-kubernetes-cluster-autoscaler:9.57.0
+  type: image
 - source: dp.apps.rancher.io/charts/kubernetes-cluster-autoscaler:9.50.1
   target: stgregistry.suse.com/rancher/charts/appco-kubernetes-cluster-autoscaler:9.50.1
+  type: image
+- source: dp.apps.rancher.io/charts/kubernetes-cluster-autoscaler:9.56.0
+  target: stgregistry.suse.com/rancher/charts/appco-kubernetes-cluster-autoscaler:9.56.0
+  type: image
+- source: dp.apps.rancher.io/charts/kubernetes-cluster-autoscaler:9.57.0
+  target: stgregistry.suse.com/rancher/charts/appco-kubernetes-cluster-autoscaler:9.57.0
   type: image
 - source: dp.apps.rancher.io/charts/suse-virtual-cluster-engine:1.0.0
   target: registry.suse.com/rancher/charts/appco-suse-virtual-cluster-engine:1.0.0


### PR DESCRIPTION
#### Pull Request Checklist ####

- [x] If an entire artifact is being added, a repo has been created for the artifact in DockerHub under the `rancher` org
- [x] Additions are licensed with Rancher favored licenses - Apache 2 and MIT - or approved licenses - as according to [CNCF approved licenses](https://github.com/cncf/foundation/blob/main/allowed-third-party-license-policy.md).
- [x] Additions, when used in Rancher or Rancher's provided charts, have their corresponding origin added in Rancher's images [origins](https://github.com/rancher/rancher/blob/release/v2.7/pkg/image/origins.go) file (must be added for all Rancher versions `>= v2.7`).
- [x] Any changes to scripting or CI config have been tested to the best of your ability

#### Change Description ####

Just adding some new versions of the cluster-autoscaler chart.

<!-- Describe what you are doing and why. Link any related issues, pull requests and commit hashes. -->

#### Final Checks after the PR is merged ####

- [ ] Confirm that you can pull the mirrored artifact and tags from all target locations
