### PR TITLE
Add config and regsync for csi-driver and newer images for csi

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -2799,9 +2799,9 @@ Artifacts:
 - SourceArtifact: quay.io/minio/minio
   Tags:
   - RELEASE.2022-03-24T00-43-44Z
-- SourceArtifact: quay.io/ovirt/csi-driver
+- SourceArtifact: quay.io/openshift/origin-ovirt-csi-driver
   Tags:
-  - sha256:ed1f8ef1e23eef345f25e1e256a63ae36983fffd891ca7cc86ebb4c6b29f21fe
+  - 4.21.0
   TargetArtifactName: mirrored-ovirt-csi-driver
   TargetRepositories:
   - registry.suse.com/rancher/charts

--- a/config.yaml
+++ b/config.yaml
@@ -2804,8 +2804,8 @@ Artifacts:
   - 4.21.0
   TargetArtifactName: mirrored-ovirt-csi-driver
   TargetRepositories:
-  - registry.suse.com/rancher/charts
-  - stgregistry.suse.com/rancher/charts
+  - registry.suse.com/rancher
+  - stgregistry.suse.com/rancher
 - SourceArtifact: quay.io/prometheus-operator/admission-webhook
   Tags:
   - v0.72.0

--- a/config.yaml
+++ b/config.yaml
@@ -2799,6 +2799,13 @@ Artifacts:
 - SourceArtifact: quay.io/minio/minio
   Tags:
   - RELEASE.2022-03-24T00-43-44Z
+- SourceArtifact: quay.io/ovirt/csi-driver
+  Tags:
+  - sha256:ed1f8ef1e23eef345f25e1e256a63ae36983fffd891ca7cc86ebb4c6b29f21fe
+  TargetArtifactName: mirrored-csi-driver
+  TargetRepositories:
+  - registry.suse.com/rancher/charts
+  - stgregistry.suse.com/rancher/charts
 - SourceArtifact: quay.io/prometheus-operator/admission-webhook
   Tags:
   - v0.72.0
@@ -3195,6 +3202,7 @@ Artifacts:
   - v3.3.0
   - v3.4.0
   - v3.5.0
+  - v4.10.0
   - v4.2.0
   - v4.3.0
   - v4.4.0
@@ -3213,6 +3221,7 @@ Artifacts:
   - v2.12.0
   - v2.13.0
   - v2.14.0
+  - v2.15.0
   - v2.3.0
   - v2.5.0
   - v2.5.1
@@ -3238,6 +3247,7 @@ Artifacts:
   - v5.1.0
   - v5.2.0
   - v5.3.0
+  - v6.0.0
 - SourceArtifact: registry.k8s.io/sig-storage/csi-resizer
   Tags:
   - v1.10.0
@@ -3245,6 +3255,7 @@ Artifacts:
   - v1.12.0
   - v1.13.1
   - v1.13.2
+  - v1.14.0
   - v1.3.0
   - v1.4.0
   - v1.6.0
@@ -3271,6 +3282,7 @@ Artifacts:
   - v2.14.0
   - v2.15.0
   - v2.16.0
+  - v2.17.0
   - v2.4.0
   - v2.6.0
   - v2.7.0

--- a/config.yaml
+++ b/config.yaml
@@ -2802,7 +2802,7 @@ Artifacts:
 - SourceArtifact: quay.io/ovirt/csi-driver
   Tags:
   - sha256:ed1f8ef1e23eef345f25e1e256a63ae36983fffd891ca7cc86ebb4c6b29f21fe
-  TargetArtifactName: mirrored-csi-driver
+  TargetArtifactName: mirrored-ovirt-csi-driver
   TargetRepositories:
   - registry.suse.com/rancher/charts
   - stgregistry.suse.com/rancher/charts

--- a/regsync.yaml
+++ b/regsync.yaml
@@ -19880,11 +19880,11 @@ sync:
 - source: quay.io/minio/minio:RELEASE.2022-03-24T00-43-44Z
   target: stgregistry.suse.com/rancher/mirrored-minio-minio:RELEASE.2022-03-24T00-43-44Z
   type: image
-- source: quay.io/ovirt/csi-driver@sha256:ed1f8ef1e23eef345f25e1e256a63ae36983fffd891ca7cc86ebb4c6b29f21fe
-  target: registry.suse.com/rancher/charts/mirrored-ovirt-csi-driver:sha256-ed1f8ef1e23eef345f25e1e256a63ae36983fffd891ca7cc86ebb4c6b29f21fe
+- source: quay.io/openshift/origin-ovirt-csi-driver:4.21.0
+  target: registry.suse.com/rancher/charts/mirrored-ovirt-csi-driver:4.21.0
   type: image
-- source: quay.io/ovirt/csi-driver@sha256:ed1f8ef1e23eef345f25e1e256a63ae36983fffd891ca7cc86ebb4c6b29f21fe
-  target: stgregistry.suse.com/rancher/charts/mirrored-ovirt-csi-driver:sha256-ed1f8ef1e23eef345f25e1e256a63ae36983fffd891ca7cc86ebb4c6b29f21fe
+- source: quay.io/openshift/origin-ovirt-csi-driver:4.21.0
+  target: stgregistry.suse.com/rancher/charts/mirrored-ovirt-csi-driver:4.21.0
   type: image
 - source: quay.io/prometheus-operator/admission-webhook:v0.72.0
   target: docker.io/rancher/mirrored-prometheus-operator-admission-webhook:v0.72.0

--- a/regsync.yaml
+++ b/regsync.yaml
@@ -19881,10 +19881,10 @@ sync:
   target: stgregistry.suse.com/rancher/mirrored-minio-minio:RELEASE.2022-03-24T00-43-44Z
   type: image
 - source: quay.io/ovirt/csi-driver@sha256:ed1f8ef1e23eef345f25e1e256a63ae36983fffd891ca7cc86ebb4c6b29f21fe
-  target: registry.suse.com/rancher/charts/mirrored-csi-driver:sha256-ed1f8ef1e23eef345f25e1e256a63ae36983fffd891ca7cc86ebb4c6b29f21fe
+  target: registry.suse.com/rancher/charts/mirrored-ovirt-csi-driver:sha256-ed1f8ef1e23eef345f25e1e256a63ae36983fffd891ca7cc86ebb4c6b29f21fe
   type: image
 - source: quay.io/ovirt/csi-driver@sha256:ed1f8ef1e23eef345f25e1e256a63ae36983fffd891ca7cc86ebb4c6b29f21fe
-  target: stgregistry.suse.com/rancher/charts/mirrored-csi-driver:sha256-ed1f8ef1e23eef345f25e1e256a63ae36983fffd891ca7cc86ebb4c6b29f21fe
+  target: stgregistry.suse.com/rancher/charts/mirrored-ovirt-csi-driver:sha256-ed1f8ef1e23eef345f25e1e256a63ae36983fffd891ca7cc86ebb4c6b29f21fe
   type: image
 - source: quay.io/prometheus-operator/admission-webhook:v0.72.0
   target: docker.io/rancher/mirrored-prometheus-operator-admission-webhook:v0.72.0

--- a/regsync.yaml
+++ b/regsync.yaml
@@ -19880,6 +19880,12 @@ sync:
 - source: quay.io/minio/minio:RELEASE.2022-03-24T00-43-44Z
   target: stgregistry.suse.com/rancher/mirrored-minio-minio:RELEASE.2022-03-24T00-43-44Z
   type: image
+- source: quay.io/ovirt/csi-driver@sha256:ed1f8ef1e23eef345f25e1e256a63ae36983fffd891ca7cc86ebb4c6b29f21fe
+  target: registry.suse.com/rancher/charts/mirrored-csi-driver:sha256-ed1f8ef1e23eef345f25e1e256a63ae36983fffd891ca7cc86ebb4c6b29f21fe
+  type: image
+- source: quay.io/ovirt/csi-driver@sha256:ed1f8ef1e23eef345f25e1e256a63ae36983fffd891ca7cc86ebb4c6b29f21fe
+  target: stgregistry.suse.com/rancher/charts/mirrored-csi-driver:sha256-ed1f8ef1e23eef345f25e1e256a63ae36983fffd891ca7cc86ebb4c6b29f21fe
+  type: image
 - source: quay.io/prometheus-operator/admission-webhook:v0.72.0
   target: docker.io/rancher/mirrored-prometheus-operator-admission-webhook:v0.72.0
   type: image
@@ -22394,6 +22400,9 @@ sync:
 - source: registry.k8s.io/sig-storage/csi-attacher:v3.5.0
   target: docker.io/rancher/mirrored-sig-storage-csi-attacher:v3.5.0
   type: image
+- source: registry.k8s.io/sig-storage/csi-attacher:v4.10.0
+  target: docker.io/rancher/mirrored-sig-storage-csi-attacher:v4.10.0
+  type: image
 - source: registry.k8s.io/sig-storage/csi-attacher:v4.2.0
   target: docker.io/rancher/mirrored-sig-storage-csi-attacher:v4.2.0
   type: image
@@ -22439,6 +22448,9 @@ sync:
 - source: registry.k8s.io/sig-storage/csi-attacher:v3.5.0
   target: registry.suse.com/rancher/mirrored-sig-storage-csi-attacher:v3.5.0
   type: image
+- source: registry.k8s.io/sig-storage/csi-attacher:v4.10.0
+  target: registry.suse.com/rancher/mirrored-sig-storage-csi-attacher:v4.10.0
+  type: image
 - source: registry.k8s.io/sig-storage/csi-attacher:v4.2.0
   target: registry.suse.com/rancher/mirrored-sig-storage-csi-attacher:v4.2.0
   type: image
@@ -22483,6 +22495,9 @@ sync:
   type: image
 - source: registry.k8s.io/sig-storage/csi-attacher:v3.5.0
   target: stgregistry.suse.com/rancher/mirrored-sig-storage-csi-attacher:v3.5.0
+  type: image
+- source: registry.k8s.io/sig-storage/csi-attacher:v4.10.0
+  target: stgregistry.suse.com/rancher/mirrored-sig-storage-csi-attacher:v4.10.0
   type: image
 - source: registry.k8s.io/sig-storage/csi-attacher:v4.2.0
   target: stgregistry.suse.com/rancher/mirrored-sig-storage-csi-attacher:v4.2.0
@@ -22532,6 +22547,9 @@ sync:
 - source: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.14.0
   target: docker.io/rancher/mirrored-sig-storage-csi-node-driver-registrar:v2.14.0
   type: image
+- source: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.15.0
+  target: docker.io/rancher/mirrored-sig-storage-csi-node-driver-registrar:v2.15.0
+  type: image
 - source: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.3.0
   target: docker.io/rancher/mirrored-sig-storage-csi-node-driver-registrar:v2.3.0
   type: image
@@ -22571,6 +22589,9 @@ sync:
 - source: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.14.0
   target: registry.suse.com/rancher/mirrored-sig-storage-csi-node-driver-registrar:v2.14.0
   type: image
+- source: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.15.0
+  target: registry.suse.com/rancher/mirrored-sig-storage-csi-node-driver-registrar:v2.15.0
+  type: image
 - source: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.3.0
   target: registry.suse.com/rancher/mirrored-sig-storage-csi-node-driver-registrar:v2.3.0
   type: image
@@ -22609,6 +22630,9 @@ sync:
   type: image
 - source: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.14.0
   target: stgregistry.suse.com/rancher/mirrored-sig-storage-csi-node-driver-registrar:v2.14.0
+  type: image
+- source: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.15.0
+  target: stgregistry.suse.com/rancher/mirrored-sig-storage-csi-node-driver-registrar:v2.15.0
   type: image
 - source: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.3.0
   target: stgregistry.suse.com/rancher/mirrored-sig-storage-csi-node-driver-registrar:v2.3.0
@@ -22679,6 +22703,9 @@ sync:
 - source: registry.k8s.io/sig-storage/csi-provisioner:v5.3.0
   target: docker.io/rancher/mirrored-sig-storage-csi-provisioner:v5.3.0
   type: image
+- source: registry.k8s.io/sig-storage/csi-provisioner:v6.0.0
+  target: docker.io/rancher/mirrored-sig-storage-csi-provisioner:v6.0.0
+  type: image
 - source: registry.k8s.io/sig-storage/csi-provisioner:v2.2.0
   target: registry.suse.com/rancher/mirrored-sig-storage-csi-provisioner:v2.2.0
   type: image
@@ -22723,6 +22750,9 @@ sync:
   type: image
 - source: registry.k8s.io/sig-storage/csi-provisioner:v5.3.0
   target: registry.suse.com/rancher/mirrored-sig-storage-csi-provisioner:v5.3.0
+  type: image
+- source: registry.k8s.io/sig-storage/csi-provisioner:v6.0.0
+  target: registry.suse.com/rancher/mirrored-sig-storage-csi-provisioner:v6.0.0
   type: image
 - source: registry.k8s.io/sig-storage/csi-provisioner:v2.2.0
   target: stgregistry.suse.com/rancher/mirrored-sig-storage-csi-provisioner:v2.2.0
@@ -22769,6 +22799,9 @@ sync:
 - source: registry.k8s.io/sig-storage/csi-provisioner:v5.3.0
   target: stgregistry.suse.com/rancher/mirrored-sig-storage-csi-provisioner:v5.3.0
   type: image
+- source: registry.k8s.io/sig-storage/csi-provisioner:v6.0.0
+  target: stgregistry.suse.com/rancher/mirrored-sig-storage-csi-provisioner:v6.0.0
+  type: image
 - source: registry.k8s.io/sig-storage/csi-resizer:v1.10.0
   target: docker.io/rancher/mirrored-sig-storage-csi-resizer:v1.10.0
   type: image
@@ -22783,6 +22816,9 @@ sync:
   type: image
 - source: registry.k8s.io/sig-storage/csi-resizer:v1.13.2
   target: docker.io/rancher/mirrored-sig-storage-csi-resizer:v1.13.2
+  type: image
+- source: registry.k8s.io/sig-storage/csi-resizer:v1.14.0
+  target: docker.io/rancher/mirrored-sig-storage-csi-resizer:v1.14.0
   type: image
 - source: registry.k8s.io/sig-storage/csi-resizer:v1.3.0
   target: docker.io/rancher/mirrored-sig-storage-csi-resizer:v1.3.0
@@ -22823,6 +22859,9 @@ sync:
 - source: registry.k8s.io/sig-storage/csi-resizer:v1.13.2
   target: registry.suse.com/rancher/mirrored-sig-storage-csi-resizer:v1.13.2
   type: image
+- source: registry.k8s.io/sig-storage/csi-resizer:v1.14.0
+  target: registry.suse.com/rancher/mirrored-sig-storage-csi-resizer:v1.14.0
+  type: image
 - source: registry.k8s.io/sig-storage/csi-resizer:v1.3.0
   target: registry.suse.com/rancher/mirrored-sig-storage-csi-resizer:v1.3.0
   type: image
@@ -22861,6 +22900,9 @@ sync:
   type: image
 - source: registry.k8s.io/sig-storage/csi-resizer:v1.13.2
   target: stgregistry.suse.com/rancher/mirrored-sig-storage-csi-resizer:v1.13.2
+  type: image
+- source: registry.k8s.io/sig-storage/csi-resizer:v1.14.0
+  target: stgregistry.suse.com/rancher/mirrored-sig-storage-csi-resizer:v1.14.0
   type: image
 - source: registry.k8s.io/sig-storage/csi-resizer:v1.3.0
   target: stgregistry.suse.com/rancher/mirrored-sig-storage-csi-resizer:v1.3.0
@@ -22976,6 +23018,9 @@ sync:
 - source: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
   target: docker.io/rancher/mirrored-sig-storage-livenessprobe:v2.16.0
   type: image
+- source: registry.k8s.io/sig-storage/livenessprobe:v2.17.0
+  target: docker.io/rancher/mirrored-sig-storage-livenessprobe:v2.17.0
+  type: image
 - source: registry.k8s.io/sig-storage/livenessprobe:v2.4.0
   target: docker.io/rancher/mirrored-sig-storage-livenessprobe:v2.4.0
   type: image
@@ -23009,6 +23054,9 @@ sync:
 - source: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
   target: registry.suse.com/rancher/mirrored-sig-storage-livenessprobe:v2.16.0
   type: image
+- source: registry.k8s.io/sig-storage/livenessprobe:v2.17.0
+  target: registry.suse.com/rancher/mirrored-sig-storage-livenessprobe:v2.17.0
+  type: image
 - source: registry.k8s.io/sig-storage/livenessprobe:v2.4.0
   target: registry.suse.com/rancher/mirrored-sig-storage-livenessprobe:v2.4.0
   type: image
@@ -23041,6 +23089,9 @@ sync:
   type: image
 - source: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
   target: stgregistry.suse.com/rancher/mirrored-sig-storage-livenessprobe:v2.16.0
+  type: image
+- source: registry.k8s.io/sig-storage/livenessprobe:v2.17.0
+  target: stgregistry.suse.com/rancher/mirrored-sig-storage-livenessprobe:v2.17.0
   type: image
 - source: registry.k8s.io/sig-storage/livenessprobe:v2.4.0
   target: stgregistry.suse.com/rancher/mirrored-sig-storage-livenessprobe:v2.4.0

--- a/regsync.yaml
+++ b/regsync.yaml
@@ -19881,10 +19881,10 @@ sync:
   target: stgregistry.suse.com/rancher/mirrored-minio-minio:RELEASE.2022-03-24T00-43-44Z
   type: image
 - source: quay.io/openshift/origin-ovirt-csi-driver:4.21.0
-  target: registry.suse.com/rancher/charts/mirrored-ovirt-csi-driver:4.21.0
+  target: registry.suse.com/rancher/mirrored-ovirt-csi-driver:4.21.0
   type: image
 - source: quay.io/openshift/origin-ovirt-csi-driver:4.21.0
-  target: stgregistry.suse.com/rancher/charts/mirrored-ovirt-csi-driver:4.21.0
+  target: stgregistry.suse.com/rancher/mirrored-ovirt-csi-driver:4.21.0
   type: image
 - source: quay.io/prometheus-operator/admission-webhook:v0.72.0
   target: docker.io/rancher/mirrored-prometheus-operator-admission-webhook:v0.72.0


### PR DESCRIPTION
#### Pull Request Checklist ####

- [ ] If an entire artifact is being added, a repo has been created for the artifact in DockerHub under the `rancher` org
- [ ] Additions are licensed with Rancher favored licenses - Apache 2 and MIT - or approved licenses - as according to [CNCF approved licenses](https://github.com/cncf/foundation/blob/main/allowed-third-party-license-policy.md).
- [ ] Additions, when used in Rancher or Rancher's provided charts, have their corresponding origin added in Rancher's images [origins](https://github.com/rancher/rancher/blob/release/v2.7/pkg/image/origins.go) file (must be added for all Rancher versions `>= v2.7`).
- [ ] Any changes to scripting or CI config have been tested to the best of your ability

#### Change Description ####

<!-- Describe what you are doing and why. Link any related issues, pull requests and commit hashes. -->

- Add config for images that need mirroring in csi-driver bundle https://github.com/rancher/rke2-charts/pull/973

#### Final Checks after the PR is merged ####

- [ ] Confirm that you can pull the mirrored artifact and tags from all target locations
