### PR TITLE
Add mirror for ovirt csi driver 4.15

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -2801,6 +2801,7 @@ Artifacts:
   - RELEASE.2022-03-24T00-43-44Z
 - SourceArtifact: quay.io/openshift/origin-ovirt-csi-driver
   Tags:
+  - 4.15.0
   - 4.21.0
   TargetArtifactName: mirrored-ovirt-csi-driver
   TargetRepositories:

--- a/regsync.yaml
+++ b/regsync.yaml
@@ -19880,8 +19880,14 @@ sync:
 - source: quay.io/minio/minio:RELEASE.2022-03-24T00-43-44Z
   target: stgregistry.suse.com/rancher/mirrored-minio-minio:RELEASE.2022-03-24T00-43-44Z
   type: image
+- source: quay.io/openshift/origin-ovirt-csi-driver:4.15.0
+  target: registry.suse.com/rancher/mirrored-ovirt-csi-driver:4.15.0
+  type: image
 - source: quay.io/openshift/origin-ovirt-csi-driver:4.21.0
   target: registry.suse.com/rancher/mirrored-ovirt-csi-driver:4.21.0
+  type: image
+- source: quay.io/openshift/origin-ovirt-csi-driver:4.15.0
+  target: stgregistry.suse.com/rancher/mirrored-ovirt-csi-driver:4.15.0
   type: image
 - source: quay.io/openshift/origin-ovirt-csi-driver:4.21.0
   target: stgregistry.suse.com/rancher/mirrored-ovirt-csi-driver:4.21.0


### PR DESCRIPTION
#### Pull Request Checklist ####

- [ ] If an entire artifact is being added, a repo has been created for the artifact in DockerHub under the `rancher` org
- [ ] Additions are licensed with Rancher favored licenses - Apache 2 and MIT - or approved licenses - as according to [CNCF approved licenses](https://github.com/cncf/foundation/blob/main/allowed-third-party-license-policy.md).
- [ ] Additions, when used in Rancher or Rancher's provided charts, have their corresponding origin added in Rancher's images [origins](https://github.com/rancher/rancher/blob/release/v2.7/pkg/image/origins.go) file (must be added for all Rancher versions `>= v2.7`).
- [ ] Any changes to scripting or CI config have been tested to the best of your ability

#### Change Description ####

<!-- Describe what you are doing and why. Link any related issues, pull requests and commit hashes. -->

#### Final Checks after the PR is merged ####

- [ ] Confirm that you can pull the mirrored artifact and tags from all target locations
