### PR TITLE
Added `suse-virtual-cluster-engine` 1.0.3 and 1.1.0

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -112,6 +112,8 @@ Artifacts:
   - 1.0.0
   - 1.0.1
   - 1.0.2
+  - 1.0.3
+  - 1.1.0
   TargetRepositories:
   - registry.suse.com/rancher/charts
   - stgregistry.suse.com/rancher/charts
@@ -138,6 +140,8 @@ Artifacts:
   - 1.0.0-1.1
   - 1.0.1-1.9
   - 1.0.2-2.3
+  - 1.0.3-7.1
+  - 1.1.0-1.1
   TargetRepositories:
   - registry.suse.com/rancher
   - stgregistry.suse.com/rancher
@@ -146,6 +150,8 @@ Artifacts:
   - 1.0.0-1.1
   - 1.0.1-1.9
   - 1.0.2-2.3
+  - 1.0.3-7.1
+  - 1.1.0-1.1
   TargetRepositories:
   - registry.suse.com/rancher
   - stgregistry.suse.com/rancher

--- a/regsync.yaml
+++ b/regsync.yaml
@@ -647,6 +647,12 @@ sync:
 - source: dp.apps.rancher.io/charts/suse-virtual-cluster-engine:1.0.2
   target: registry.suse.com/rancher/charts/appco-suse-virtual-cluster-engine:1.0.2
   type: image
+- source: dp.apps.rancher.io/charts/suse-virtual-cluster-engine:1.0.3
+  target: registry.suse.com/rancher/charts/appco-suse-virtual-cluster-engine:1.0.3
+  type: image
+- source: dp.apps.rancher.io/charts/suse-virtual-cluster-engine:1.1.0
+  target: registry.suse.com/rancher/charts/appco-suse-virtual-cluster-engine:1.1.0
+  type: image
 - source: dp.apps.rancher.io/charts/suse-virtual-cluster-engine:1.0.0
   target: stgregistry.suse.com/rancher/charts/appco-suse-virtual-cluster-engine:1.0.0
   type: image
@@ -655,6 +661,12 @@ sync:
   type: image
 - source: dp.apps.rancher.io/charts/suse-virtual-cluster-engine:1.0.2
   target: stgregistry.suse.com/rancher/charts/appco-suse-virtual-cluster-engine:1.0.2
+  type: image
+- source: dp.apps.rancher.io/charts/suse-virtual-cluster-engine:1.0.3
+  target: stgregistry.suse.com/rancher/charts/appco-suse-virtual-cluster-engine:1.0.3
+  type: image
+- source: dp.apps.rancher.io/charts/suse-virtual-cluster-engine:1.1.0
+  target: stgregistry.suse.com/rancher/charts/appco-suse-virtual-cluster-engine:1.1.0
   type: image
 - source: dp.apps.rancher.io/containers/alertmanager:0.28.1-12.7
   target: docker.io/rancher/appco-alertmanager:0.28.1-12.7
@@ -773,6 +785,12 @@ sync:
 - source: dp.apps.rancher.io/containers/k3k:1.0.2-2.3
   target: registry.suse.com/rancher/appco-k3k:1.0.2-2.3
   type: image
+- source: dp.apps.rancher.io/containers/k3k:1.0.3-7.1
+  target: registry.suse.com/rancher/appco-k3k:1.0.3-7.1
+  type: image
+- source: dp.apps.rancher.io/containers/k3k:1.1.0-1.1
+  target: registry.suse.com/rancher/appco-k3k:1.1.0-1.1
+  type: image
 - source: dp.apps.rancher.io/containers/k3k:1.0.0-1.1
   target: stgregistry.suse.com/rancher/appco-k3k:1.0.0-1.1
   type: image
@@ -781,6 +799,12 @@ sync:
   type: image
 - source: dp.apps.rancher.io/containers/k3k:1.0.2-2.3
   target: stgregistry.suse.com/rancher/appco-k3k:1.0.2-2.3
+  type: image
+- source: dp.apps.rancher.io/containers/k3k:1.0.3-7.1
+  target: stgregistry.suse.com/rancher/appco-k3k:1.0.3-7.1
+  type: image
+- source: dp.apps.rancher.io/containers/k3k:1.1.0-1.1
+  target: stgregistry.suse.com/rancher/appco-k3k:1.1.0-1.1
   type: image
 - source: dp.apps.rancher.io/containers/k3k-kubelet:1.0.0-1.1
   target: registry.suse.com/rancher/appco-k3k-kubelet:1.0.0-1.1
@@ -791,6 +815,12 @@ sync:
 - source: dp.apps.rancher.io/containers/k3k-kubelet:1.0.2-2.3
   target: registry.suse.com/rancher/appco-k3k-kubelet:1.0.2-2.3
   type: image
+- source: dp.apps.rancher.io/containers/k3k-kubelet:1.0.3-7.1
+  target: registry.suse.com/rancher/appco-k3k-kubelet:1.0.3-7.1
+  type: image
+- source: dp.apps.rancher.io/containers/k3k-kubelet:1.1.0-1.1
+  target: registry.suse.com/rancher/appco-k3k-kubelet:1.1.0-1.1
+  type: image
 - source: dp.apps.rancher.io/containers/k3k-kubelet:1.0.0-1.1
   target: stgregistry.suse.com/rancher/appco-k3k-kubelet:1.0.0-1.1
   type: image
@@ -799,6 +829,12 @@ sync:
   type: image
 - source: dp.apps.rancher.io/containers/k3k-kubelet:1.0.2-2.3
   target: stgregistry.suse.com/rancher/appco-k3k-kubelet:1.0.2-2.3
+  type: image
+- source: dp.apps.rancher.io/containers/k3k-kubelet:1.0.3-7.1
+  target: stgregistry.suse.com/rancher/appco-k3k-kubelet:1.0.3-7.1
+  type: image
+- source: dp.apps.rancher.io/containers/k3k-kubelet:1.1.0-1.1
+  target: stgregistry.suse.com/rancher/appco-k3k-kubelet:1.1.0-1.1
   type: image
 - source: dp.apps.rancher.io/containers/k8s-sidecar:1.30.7-11.3
   target: docker.io/rancher/appco-k8s-sidecar:1.30.7-11.3


### PR DESCRIPTION
#### Pull Request Checklist ####

- [ ] If an entire artifact is being added, a repo has been created for the artifact in DockerHub under the `rancher` org
- [ ] Additions are licensed with Rancher favored licenses - Apache 2 and MIT - or approved licenses - as according to [CNCF approved licenses](https://github.com/cncf/foundation/blob/main/allowed-third-party-license-policy.md).
- [ ] Additions, when used in Rancher or Rancher's provided charts, have their corresponding origin added in Rancher's images [origins](https://github.com/rancher/rancher/blob/release/v2.7/pkg/image/origins.go) file (must be added for all Rancher versions `>= v2.7`).
- [ ] Any changes to scripting or CI config have been tested to the best of your ability

#### Change Description ####

<!-- Describe what you are doing and why. Link any related issues, pull requests and commit hashes. -->

#### Final Checks after the PR is merged ####

- [x] Confirm that you can pull the mirrored artifact and tags from all target locations
