### PR TITLE
Add new bci-micro image

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -3430,6 +3430,7 @@ Artifacts:
   - 15.4.14.3
   - 15.6.19.1
   - 15.6.24.2
+  - 16.0-15.11
   TargetArtifactName: mirrored-bci-micro
 - DoNotMirror:
   - 1.3.4

--- a/regsync.yaml
+++ b/regsync.yaml
@@ -23729,6 +23729,9 @@ sync:
 - source: registry.suse.com/bci/bci-micro:15.6.24.2
   target: docker.io/rancher/mirrored-bci-micro:15.6.24.2
   type: image
+- source: registry.suse.com/bci/bci-micro:16.0-15.11
+  target: docker.io/rancher/mirrored-bci-micro:16.0-15.11
+  type: image
 - source: registry.suse.com/bci/bci-micro:15.4.14.3
   target: registry.suse.com/rancher/mirrored-bci-micro:15.4.14.3
   type: image
@@ -23738,6 +23741,9 @@ sync:
 - source: registry.suse.com/bci/bci-micro:15.6.24.2
   target: registry.suse.com/rancher/mirrored-bci-micro:15.6.24.2
   type: image
+- source: registry.suse.com/bci/bci-micro:16.0-15.11
+  target: registry.suse.com/rancher/mirrored-bci-micro:16.0-15.11
+  type: image
 - source: registry.suse.com/bci/bci-micro:15.4.14.3
   target: stgregistry.suse.com/rancher/mirrored-bci-micro:15.4.14.3
   type: image
@@ -23746,6 +23752,9 @@ sync:
   type: image
 - source: registry.suse.com/bci/bci-micro:15.6.24.2
   target: stgregistry.suse.com/rancher/mirrored-bci-micro:15.6.24.2
+  type: image
+- source: registry.suse.com/bci/bci-micro:16.0-15.11
+  target: stgregistry.suse.com/rancher/mirrored-bci-micro:16.0-15.11
   type: image
 - source: registry.suse.com/rancher/elemental-operator:1.4.2
   target: docker.io/rancher/mirrored-elemental-operator:1.4.2


### PR DESCRIPTION
#### Pull Request Checklist ####

- [ ] If an entire artifact is being added, a repo has been created for the artifact in DockerHub under the `rancher` org
- [ ] Additions are licensed with Rancher favored licenses - Apache 2 and MIT - or approved licenses - as according to [CNCF approved licenses](https://github.com/cncf/foundation/blob/main/allowed-third-party-license-policy.md).
- [ ] Additions, when used in Rancher or Rancher's provided charts, have their corresponding origin added in Rancher's images [origins](https://github.com/rancher/rancher/blob/release/v2.7/pkg/image/origins.go) file (must be added for all Rancher versions `>= v2.7`).
- [ ] Any changes to scripting or CI config have been tested to the best of your ability

#### Change Description ####

Added new BCI Micro Tag for audit log use

#### Final Checks after the PR is merged ####

- [ ] Confirm that you can pull the mirrored artifact and tags from all target locations
