### PR TITLE
Mirror Go images from Application Collection

### DIFF
--- a/.github/workflows/mirror-artifacts-daily.yml
+++ b/.github/workflows/mirror-artifacts-daily.yml
@@ -28,7 +28,11 @@ jobs:
         with:
           secrets: |
             secret/data/github/repo/${{ github.repository }}/dockerhub/rancher/credentials username | DOCKER_USERNAME ;
-            secret/data/github/repo/${{ github.repository }}/dockerhub/rancher/credentials password | DOCKER_PASSWORD
+            secret/data/github/repo/${{ github.repository }}/dockerhub/rancher/credentials password | DOCKER_PASSWORD ;
+            secret/data/github/repo/${{ github.repository }}/application-collection/credentials username | APPCO_USERNAME ;
+            secret/data/github/repo/${{ github.repository }}/application-collection/credentials password | APPCO_PASSWORD ;
+            secret/data/github/repo/${{ github.repository }}/rancher-prime-registry/credentials username | PRIME_USERNAME ;
+            secret/data/github/repo/${{ github.repository }}/rancher-prime-registry/credentials password | PRIME_PASSWORD
 
       - name: Install regsync
         run: |

--- a/regsync-daily.yaml
+++ b/regsync-daily.yaml
@@ -2,6 +2,13 @@ creds:
 - pass: '{{ env "DOCKER_PASSWORD" }}'
   registry: docker.io
   user: '{{ env "DOCKER_USERNAME" }}'
+- pass: '{{ env "APPCO_PASSWORD" }}'
+  registry: dp.apps.rancher.io
+  user: '{{ env "APPCO_USERNAME" }}'
+- pass: '{{ env "PRIME_PASSWORD" }}'
+  registry: registry.suse.com
+  repoAuth: true
+  user: '{{ env "PRIME_USERNAME" }}'
 defaults:
   userAgent: rancher-artifact-mirror
 sync:
@@ -14,3 +21,15 @@ sync:
 - source: neuvector/updater:latest
   target: rancher/mirrored-neuvector-updater:latest
   type: image
+# Go 1.25 and 1.26 from AppCo, used for multi-stage builds and ci-image
+- source: dp.apps.rancher.io/containers/go
+  target: registry.suse.com/rancher/appco-go
+  type: repository
+  tagSets:
+    - semverRange:
+      - '>=1.25.11' # replace with >=1.26 when 1.25 is deprecated
+      allow:
+      - '\d+\.\d+$'
+      - '\d+\.\d+\.\d+$'
+    - allow: # temporary, delete when 1.25 is deprecated
+      - '1.25'


### PR DESCRIPTION
#### Pull Request Checklist ####

- [X] ~If an entire artifact is being added, a repo has been created for the artifact in DockerHub under the `rancher` org~
- [X] ~Additions are licensed with Rancher favored licenses - Apache 2 and MIT - or approved licenses - as according to [CNCF approved licenses](https://github.com/cncf/foundation/blob/main/allowed-third-party-license-policy.md).~
- [X] ~Additions, when used in Rancher or Rancher's provided charts, have their corresponding origin added in Rancher's images [origins](https://github.com/rancher/rancher/blob/release/v2.7/pkg/image/origins.go) file (must be added for all Rancher versions `>= v2.7`).~
- [X] Any changes to scripting or CI config have been tested to the best of your ability:
  - I created a smaller regsync config and tested it locally with the `check` command:
```
❯ ./regsync check -c regsync-golang.yaml
time=2026-06-15T16:59:46.083+02:00 level=INFO msg="Image sync needed" source=dp.apps.rancher.io/containers/go:1.25.11 target=registry.suse.com/rancher/appco-go:1.25.11
time=2026-06-15T16:59:46.321+02:00 level=INFO msg="Image sync needed" source=dp.apps.rancher.io/containers/go:1.26 target=registry.suse.com/rancher/appco-go:1.26
time=2026-06-15T16:59:46.552+02:00 level=INFO msg="Image sync needed" source=dp.apps.rancher.io/containers/go:1.26.0 target=registry.suse.com/rancher/appco-go:1.26.0
time=2026-06-15T16:59:46.766+02:00 level=INFO msg="Image sync needed" source=dp.apps.rancher.io/containers/go:1.26.1 target=registry.suse.com/rancher/appco-go:1.26.1
time=2026-06-15T16:59:46.999+02:00 level=INFO msg="Image sync needed" source=dp.apps.rancher.io/containers/go:1.26.2 target=registry.suse.com/rancher/appco-go:1.26.2
time=2026-06-15T16:59:47.197+02:00 level=INFO msg="Image sync needed" source=dp.apps.rancher.io/containers/go:1.26.3 target=registry.suse.com/rancher/appco-go:1.26.3
time=2026-06-15T16:59:47.412+02:00 level=INFO msg="Image sync needed" source=dp.apps.rancher.io/containers/go:1.26.4 target=registry.suse.com/rancher/appco-go:1.26.4
time=2026-06-15T16:59:47.613+02:00 level=INFO msg="Image sync needed" source=dp.apps.rancher.io/containers/go:1.25 target=registry.suse.com/rancher/appco-go:1.25
```

#### Change Description ####

We need the Go image from Application Collection available in the SUSE Registry.

#### Final Checks after the PR is merged ####

- [ ] Confirm that you can pull the mirrored artifact and tags from all target locations
