### PR TITLE
Upgrade regsync verion for mirror-artifacts-daily workflow

### DIFF
--- a/.github/workflows/mirror-artifacts-daily.yml
+++ b/.github/workflows/mirror-artifacts-daily.yml
@@ -36,8 +36,8 @@ jobs:
 
       - name: Install regsync
         run: |
-          REGSYNC_CHECKSUM=bbfcf9dc120bd67ad6163eb80667005c47570ff5a90157f0d26efb247906548d
-          curl --silent --fail --location --output regsync https://github.com/regclient/regclient/releases/download/v0.8.3/regsync-linux-amd64
+          REGSYNC_CHECKSUM=486d5fcac076e31837864632446de22519d88101db4a4b4cfaa4ee3350e41606
+          curl --silent --fail --location --output regsync https://github.com/regclient/regclient/releases/download/v0.11.5/regsync-linux-amd64
           echo "${REGSYNC_CHECKSUM}  regsync" | sha256sum -c -
           chmod +x regsync
 


### PR DESCRIPTION
#### Pull Request Checklist ####

- [X] Any changes to scripting or CI config have been tested to the best of your ability

#### Change Description ####

The previous version is too old and does not support some of the syntax used in #1372, which results on too many tags being synced.

#### Final Checks after the PR is merged ####

- [ ] Confirm that you can pull the mirrored artifact and tags from all target locations
