### PR TITLE
Add latest classic elemental images

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -3504,15 +3504,19 @@ Artifacts:
   - 1.5.3
   - 1.5.4
   - 1.6.10
+  - 1.6.11
   - 1.6.4
   - 1.6.5
   - 1.6.8
   - 1.6.9
   - 1.7.3
   - 1.7.4
+  - 1.7.5
   - 1.8.1
+  - 1.8.2
   - 1.9.0
   - 1.9.1
+  - 1.9.2
   TargetArtifactName: mirrored-elemental-operator
 - SourceArtifact: registry.suse.com/rancher/seedimage-builder
   Tags:
@@ -3522,15 +3526,19 @@ Artifacts:
   - 1.5.3
   - 1.5.4
   - 1.6.10
+  - 1.6.11
   - 1.6.4
   - 1.6.5
   - 1.6.8
   - 1.6.9
   - 1.7.3
   - 1.7.4
+  - 1.7.5
   - 1.8.1
+  - 1.8.2
   - 1.9.0
   - 1.9.1
+  - 1.9.2
   TargetArtifactName: mirrored-elemental-seedimage-builder
 - SourceArtifact: rpardini/docker-registry-proxy
   Tags:

--- a/regsync.yaml
+++ b/regsync.yaml
@@ -24299,6 +24299,9 @@ sync:
 - source: registry.suse.com/rancher/elemental-operator:1.6.10
   target: docker.io/rancher/mirrored-elemental-operator:1.6.10
   type: image
+- source: registry.suse.com/rancher/elemental-operator:1.6.11
+  target: docker.io/rancher/mirrored-elemental-operator:1.6.11
+  type: image
 - source: registry.suse.com/rancher/elemental-operator:1.6.4
   target: docker.io/rancher/mirrored-elemental-operator:1.6.4
   type: image
@@ -24317,14 +24320,23 @@ sync:
 - source: registry.suse.com/rancher/elemental-operator:1.7.4
   target: docker.io/rancher/mirrored-elemental-operator:1.7.4
   type: image
+- source: registry.suse.com/rancher/elemental-operator:1.7.5
+  target: docker.io/rancher/mirrored-elemental-operator:1.7.5
+  type: image
 - source: registry.suse.com/rancher/elemental-operator:1.8.1
   target: docker.io/rancher/mirrored-elemental-operator:1.8.1
+  type: image
+- source: registry.suse.com/rancher/elemental-operator:1.8.2
+  target: docker.io/rancher/mirrored-elemental-operator:1.8.2
   type: image
 - source: registry.suse.com/rancher/elemental-operator:1.9.0
   target: docker.io/rancher/mirrored-elemental-operator:1.9.0
   type: image
 - source: registry.suse.com/rancher/elemental-operator:1.9.1
   target: docker.io/rancher/mirrored-elemental-operator:1.9.1
+  type: image
+- source: registry.suse.com/rancher/elemental-operator:1.9.2
+  target: docker.io/rancher/mirrored-elemental-operator:1.9.2
   type: image
 - source: registry.suse.com/rancher/elemental-operator:1.4.2
   target: registry.suse.com/rancher/mirrored-elemental-operator:1.4.2
@@ -24340,6 +24352,9 @@ sync:
   type: image
 - source: registry.suse.com/rancher/elemental-operator:1.6.10
   target: registry.suse.com/rancher/mirrored-elemental-operator:1.6.10
+  type: image
+- source: registry.suse.com/rancher/elemental-operator:1.6.11
+  target: registry.suse.com/rancher/mirrored-elemental-operator:1.6.11
   type: image
 - source: registry.suse.com/rancher/elemental-operator:1.6.4
   target: registry.suse.com/rancher/mirrored-elemental-operator:1.6.4
@@ -24359,14 +24374,23 @@ sync:
 - source: registry.suse.com/rancher/elemental-operator:1.7.4
   target: registry.suse.com/rancher/mirrored-elemental-operator:1.7.4
   type: image
+- source: registry.suse.com/rancher/elemental-operator:1.7.5
+  target: registry.suse.com/rancher/mirrored-elemental-operator:1.7.5
+  type: image
 - source: registry.suse.com/rancher/elemental-operator:1.8.1
   target: registry.suse.com/rancher/mirrored-elemental-operator:1.8.1
+  type: image
+- source: registry.suse.com/rancher/elemental-operator:1.8.2
+  target: registry.suse.com/rancher/mirrored-elemental-operator:1.8.2
   type: image
 - source: registry.suse.com/rancher/elemental-operator:1.9.0
   target: registry.suse.com/rancher/mirrored-elemental-operator:1.9.0
   type: image
 - source: registry.suse.com/rancher/elemental-operator:1.9.1
   target: registry.suse.com/rancher/mirrored-elemental-operator:1.9.1
+  type: image
+- source: registry.suse.com/rancher/elemental-operator:1.9.2
+  target: registry.suse.com/rancher/mirrored-elemental-operator:1.9.2
   type: image
 - source: registry.suse.com/rancher/elemental-operator:1.4.2
   target: stgregistry.suse.com/rancher/mirrored-elemental-operator:1.4.2
@@ -24382,6 +24406,9 @@ sync:
   type: image
 - source: registry.suse.com/rancher/elemental-operator:1.6.10
   target: stgregistry.suse.com/rancher/mirrored-elemental-operator:1.6.10
+  type: image
+- source: registry.suse.com/rancher/elemental-operator:1.6.11
+  target: stgregistry.suse.com/rancher/mirrored-elemental-operator:1.6.11
   type: image
 - source: registry.suse.com/rancher/elemental-operator:1.6.4
   target: stgregistry.suse.com/rancher/mirrored-elemental-operator:1.6.4
@@ -24401,14 +24428,23 @@ sync:
 - source: registry.suse.com/rancher/elemental-operator:1.7.4
   target: stgregistry.suse.com/rancher/mirrored-elemental-operator:1.7.4
   type: image
+- source: registry.suse.com/rancher/elemental-operator:1.7.5
+  target: stgregistry.suse.com/rancher/mirrored-elemental-operator:1.7.5
+  type: image
 - source: registry.suse.com/rancher/elemental-operator:1.8.1
   target: stgregistry.suse.com/rancher/mirrored-elemental-operator:1.8.1
+  type: image
+- source: registry.suse.com/rancher/elemental-operator:1.8.2
+  target: stgregistry.suse.com/rancher/mirrored-elemental-operator:1.8.2
   type: image
 - source: registry.suse.com/rancher/elemental-operator:1.9.0
   target: stgregistry.suse.com/rancher/mirrored-elemental-operator:1.9.0
   type: image
 - source: registry.suse.com/rancher/elemental-operator:1.9.1
   target: stgregistry.suse.com/rancher/mirrored-elemental-operator:1.9.1
+  type: image
+- source: registry.suse.com/rancher/elemental-operator:1.9.2
+  target: stgregistry.suse.com/rancher/mirrored-elemental-operator:1.9.2
   type: image
 - source: registry.suse.com/rancher/seedimage-builder:1.3.4
   target: docker.io/rancher/mirrored-elemental-seedimage-builder:1.3.4
@@ -24428,6 +24464,9 @@ sync:
 - source: registry.suse.com/rancher/seedimage-builder:1.6.10
   target: docker.io/rancher/mirrored-elemental-seedimage-builder:1.6.10
   type: image
+- source: registry.suse.com/rancher/seedimage-builder:1.6.11
+  target: docker.io/rancher/mirrored-elemental-seedimage-builder:1.6.11
+  type: image
 - source: registry.suse.com/rancher/seedimage-builder:1.6.4
   target: docker.io/rancher/mirrored-elemental-seedimage-builder:1.6.4
   type: image
@@ -24446,14 +24485,23 @@ sync:
 - source: registry.suse.com/rancher/seedimage-builder:1.7.4
   target: docker.io/rancher/mirrored-elemental-seedimage-builder:1.7.4
   type: image
+- source: registry.suse.com/rancher/seedimage-builder:1.7.5
+  target: docker.io/rancher/mirrored-elemental-seedimage-builder:1.7.5
+  type: image
 - source: registry.suse.com/rancher/seedimage-builder:1.8.1
   target: docker.io/rancher/mirrored-elemental-seedimage-builder:1.8.1
+  type: image
+- source: registry.suse.com/rancher/seedimage-builder:1.8.2
+  target: docker.io/rancher/mirrored-elemental-seedimage-builder:1.8.2
   type: image
 - source: registry.suse.com/rancher/seedimage-builder:1.9.0
   target: docker.io/rancher/mirrored-elemental-seedimage-builder:1.9.0
   type: image
 - source: registry.suse.com/rancher/seedimage-builder:1.9.1
   target: docker.io/rancher/mirrored-elemental-seedimage-builder:1.9.1
+  type: image
+- source: registry.suse.com/rancher/seedimage-builder:1.9.2
+  target: docker.io/rancher/mirrored-elemental-seedimage-builder:1.9.2
   type: image
 - source: registry.suse.com/rancher/seedimage-builder:1.3.4
   target: registry.suse.com/rancher/mirrored-elemental-seedimage-builder:1.3.4
@@ -24473,6 +24521,9 @@ sync:
 - source: registry.suse.com/rancher/seedimage-builder:1.6.10
   target: registry.suse.com/rancher/mirrored-elemental-seedimage-builder:1.6.10
   type: image
+- source: registry.suse.com/rancher/seedimage-builder:1.6.11
+  target: registry.suse.com/rancher/mirrored-elemental-seedimage-builder:1.6.11
+  type: image
 - source: registry.suse.com/rancher/seedimage-builder:1.6.4
   target: registry.suse.com/rancher/mirrored-elemental-seedimage-builder:1.6.4
   type: image
@@ -24491,14 +24542,23 @@ sync:
 - source: registry.suse.com/rancher/seedimage-builder:1.7.4
   target: registry.suse.com/rancher/mirrored-elemental-seedimage-builder:1.7.4
   type: image
+- source: registry.suse.com/rancher/seedimage-builder:1.7.5
+  target: registry.suse.com/rancher/mirrored-elemental-seedimage-builder:1.7.5
+  type: image
 - source: registry.suse.com/rancher/seedimage-builder:1.8.1
   target: registry.suse.com/rancher/mirrored-elemental-seedimage-builder:1.8.1
+  type: image
+- source: registry.suse.com/rancher/seedimage-builder:1.8.2
+  target: registry.suse.com/rancher/mirrored-elemental-seedimage-builder:1.8.2
   type: image
 - source: registry.suse.com/rancher/seedimage-builder:1.9.0
   target: registry.suse.com/rancher/mirrored-elemental-seedimage-builder:1.9.0
   type: image
 - source: registry.suse.com/rancher/seedimage-builder:1.9.1
   target: registry.suse.com/rancher/mirrored-elemental-seedimage-builder:1.9.1
+  type: image
+- source: registry.suse.com/rancher/seedimage-builder:1.9.2
+  target: registry.suse.com/rancher/mirrored-elemental-seedimage-builder:1.9.2
   type: image
 - source: registry.suse.com/rancher/seedimage-builder:1.3.4
   target: stgregistry.suse.com/rancher/mirrored-elemental-seedimage-builder:1.3.4
@@ -24518,6 +24578,9 @@ sync:
 - source: registry.suse.com/rancher/seedimage-builder:1.6.10
   target: stgregistry.suse.com/rancher/mirrored-elemental-seedimage-builder:1.6.10
   type: image
+- source: registry.suse.com/rancher/seedimage-builder:1.6.11
+  target: stgregistry.suse.com/rancher/mirrored-elemental-seedimage-builder:1.6.11
+  type: image
 - source: registry.suse.com/rancher/seedimage-builder:1.6.4
   target: stgregistry.suse.com/rancher/mirrored-elemental-seedimage-builder:1.6.4
   type: image
@@ -24536,14 +24599,23 @@ sync:
 - source: registry.suse.com/rancher/seedimage-builder:1.7.4
   target: stgregistry.suse.com/rancher/mirrored-elemental-seedimage-builder:1.7.4
   type: image
+- source: registry.suse.com/rancher/seedimage-builder:1.7.5
+  target: stgregistry.suse.com/rancher/mirrored-elemental-seedimage-builder:1.7.5
+  type: image
 - source: registry.suse.com/rancher/seedimage-builder:1.8.1
   target: stgregistry.suse.com/rancher/mirrored-elemental-seedimage-builder:1.8.1
+  type: image
+- source: registry.suse.com/rancher/seedimage-builder:1.8.2
+  target: stgregistry.suse.com/rancher/mirrored-elemental-seedimage-builder:1.8.2
   type: image
 - source: registry.suse.com/rancher/seedimage-builder:1.9.0
   target: stgregistry.suse.com/rancher/mirrored-elemental-seedimage-builder:1.9.0
   type: image
 - source: registry.suse.com/rancher/seedimage-builder:1.9.1
   target: stgregistry.suse.com/rancher/mirrored-elemental-seedimage-builder:1.9.1
+  type: image
+- source: registry.suse.com/rancher/seedimage-builder:1.9.2
+  target: stgregistry.suse.com/rancher/mirrored-elemental-seedimage-builder:1.9.2
   type: image
 - source: rpardini/docker-registry-proxy:0.6.1
   target: docker.io/rancher/rpardini-docker-registry-proxy:0.6.1


### PR DESCRIPTION
#### Pull Request Checklist ####

- [x] If an entire artifact is being added, a repo has been created for the artifact in DockerHub under the `rancher` org
- [x] Additions are licensed with Rancher favored licenses - Apache 2 and MIT - or approved licenses - as according to [CNCF approved licenses](https://github.com/cncf/foundation/blob/main/allowed-third-party-license-policy.md).
- [x] Additions, when used in Rancher or Rancher's provided charts, have their corresponding origin added in Rancher's images [origins](https://github.com/rancher/rancher/blob/release/v2.7/pkg/image/origins.go) file (must be added for all Rancher versions `>= v2.7`).
- [x] Any changes to scripting or CI config have been tested to the best of your ability

#### Change Description ####

<!-- Describe what you are doing and why. Link any related issues, pull requests and commit hashes. -->

#### Final Checks after the PR is merged ####

- [ ] Confirm that you can pull the mirrored artifact and tags from all target locations
