### PR TITLE
remove appco curl from autoupdate and public registry

### DIFF
--- a/autoupdate.yaml
+++ b/autoupdate.yaml
@@ -6,14 +6,6 @@
     VersionFilter: ^0.31.1(.+)$
   Reviewers:
   - rancher/orbs
-- Name: appco-curl
-  Registry:
-    Artifacts:
-    - SourceArtifact: dp.apps.rancher.io/containers/curl
-    Latest: true
-    VersionFilter: ^8.14.1(.+)$
-  Reviewers:
-  - rancher/orbs
 - Name: appco-grafana
   Registry:
     Artifacts:

--- a/config.yaml
+++ b/config.yaml
@@ -134,6 +134,9 @@ Artifacts:
   - 8.14.1-7.3
   - 8.14.1-8.1
   - 8.14.1-8.3
+  TargetRepositories:
+  - registry.suse.com/rancher
+  - stgregistry.suse.com/rancher
 - SourceArtifact: dp.apps.rancher.io/containers/grafana
   Tags:
   - 12.1.1-2.2

--- a/regsync.yaml
+++ b/regsync.yaml
@@ -735,21 +735,6 @@ sync:
   target: stgregistry.suse.com/rancher/appco-alertmanager:0.31.1-15.2
   type: image
 - source: dp.apps.rancher.io/containers/curl:8.14.1-6.1
-  target: docker.io/rancher/appco-curl:8.14.1-6.1
-  type: image
-- source: dp.apps.rancher.io/containers/curl:8.14.1-7.1
-  target: docker.io/rancher/appco-curl:8.14.1-7.1
-  type: image
-- source: dp.apps.rancher.io/containers/curl:8.14.1-7.3
-  target: docker.io/rancher/appco-curl:8.14.1-7.3
-  type: image
-- source: dp.apps.rancher.io/containers/curl:8.14.1-8.1
-  target: docker.io/rancher/appco-curl:8.14.1-8.1
-  type: image
-- source: dp.apps.rancher.io/containers/curl:8.14.1-8.3
-  target: docker.io/rancher/appco-curl:8.14.1-8.3
-  type: image
-- source: dp.apps.rancher.io/containers/curl:8.14.1-6.1
   target: registry.suse.com/rancher/appco-curl:8.14.1-6.1
   type: image
 - source: dp.apps.rancher.io/containers/curl:8.14.1-7.1


### PR DESCRIPTION
`appco-curl` image is not being used anymore and the docker hub repo will be deleted soon