### PR TITLE
Add newest grafana/grafana-image-renderer tag

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -619,6 +619,7 @@ Artifacts:
   - v4.0.15
   - v4.0.5
   - v5.1.0
+  - v5.10.1
   - v5.8.3
 - SourceArtifact: idealista/prom2teams
   Tags:

--- a/regsync.yaml
+++ b/regsync.yaml
@@ -3041,6 +3041,9 @@ sync:
 - source: grafana/grafana-image-renderer:v5.1.0
   target: docker.io/rancher/mirrored-grafana-grafana-image-renderer:v5.1.0
   type: image
+- source: grafana/grafana-image-renderer:v5.10.1
+  target: docker.io/rancher/mirrored-grafana-grafana-image-renderer:v5.10.1
+  type: image
 - source: grafana/grafana-image-renderer:v5.8.3
   target: docker.io/rancher/mirrored-grafana-grafana-image-renderer:v5.8.3
   type: image
@@ -3080,6 +3083,9 @@ sync:
 - source: grafana/grafana-image-renderer:v5.1.0
   target: registry.suse.com/rancher/mirrored-grafana-grafana-image-renderer:v5.1.0
   type: image
+- source: grafana/grafana-image-renderer:v5.10.1
+  target: registry.suse.com/rancher/mirrored-grafana-grafana-image-renderer:v5.10.1
+  type: image
 - source: grafana/grafana-image-renderer:v5.8.3
   target: registry.suse.com/rancher/mirrored-grafana-grafana-image-renderer:v5.8.3
   type: image
@@ -3118,6 +3124,9 @@ sync:
   type: image
 - source: grafana/grafana-image-renderer:v5.1.0
   target: stgregistry.suse.com/rancher/mirrored-grafana-grafana-image-renderer:v5.1.0
+  type: image
+- source: grafana/grafana-image-renderer:v5.10.1
+  target: stgregistry.suse.com/rancher/mirrored-grafana-grafana-image-renderer:v5.10.1
   type: image
 - source: grafana/grafana-image-renderer:v5.8.3
   target: stgregistry.suse.com/rancher/mirrored-grafana-grafana-image-renderer:v5.8.3


### PR DESCRIPTION
#### Pull Request Checklist ####

- [x] If an entire artifact is being added, a repo has been created for the artifact in DockerHub under the `rancher` org
- [x] Additions are licensed with Rancher favored licenses - Apache 2 and MIT - or approved licenses - as according to [CNCF approved licenses](https://github.com/cncf/foundation/blob/main/allowed-third-party-license-policy.md).
- [x] Additions, when used in Rancher or Rancher's provided charts, have their corresponding origin added in Rancher's images [origins](https://github.com/rancher/rancher/blob/release/v2.7/pkg/image/origins.go) file (must be added for all Rancher versions `>= v2.7`).
- [x] Any changes to scripting or CI config have been tested to the best of your ability

#### Change Description ####

Add new tag for community image-renderer image.

#### Final Checks after the PR is merged ####

- [ ] Confirm that you can pull the mirrored artifact and tags from all target locations
